### PR TITLE
docs: clarify handoff deployment verification and token permissions

### DIFF
--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -12,7 +12,7 @@
 | Item | Status |
 |------|--------|
 | HEAD (main) | `2d4fffc` (merge of PR #64 — AI control plane bootstrap) |
-| Railway deployment | ✅ confirmed live — smoke PASSED 2026-05-27 |
+| Railway deployment | ✅ confirmed live (`2d4fffc`) — verify in Railway Dashboard → Deployments; smoke PASSED 2026-05-27 |
 | Authenticated smoke | ✅ PASSED (7/7) — 2026-05-27 |
 | npm audit | 0 vulnerabilities (main) |
 | Dependabot | clean |
@@ -63,7 +63,7 @@ Governance layer is live on `main`. Includes:
 2. ✅ Production smoke — PASSED (7/7)
 3. ✅ GitHub branch protection hardened
 4. ✅ `production` GitHub environment locked (reviewer gate, main-only)
-5. ⏳ OpenHands fine-grained GitHub token — provisioned with contents/PR/issues write; no secrets/deploy/admin
+5. ⏳ OpenHands fine-grained GitHub token — `contents: write`, `pull-requests: write`, `issues: write`; all other permissions set to `none`
 6. ⏳ OpenHands executor started (`docker run ...` or `openhands start`)
 7. ⏳ First supervised run — Issue #66 as dry-run task
 

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -12,11 +12,13 @@
 | Item | Status |
 |------|--------|
 | HEAD (main) | `2d4fffc` (merge of PR #64 — AI control plane bootstrap) |
-| Railway deployment | verify status — two merges since last confirmed deploy (`ed2b977`, `2d4fffc`) |
-| Authenticated smoke | PENDING — owner must run `ADMIN_PASSWORD=<pw> ./scripts/smoke-admin.sh` against prod |
+| Railway deployment | ✅ confirmed live — smoke PASSED 2026-05-27 |
+| Authenticated smoke | ✅ PASSED (7/7) — 2026-05-27 |
 | npm audit | 0 vulnerabilities (main) |
 | Dependabot | clean |
-| Production test artifacts | none |
+| GitHub branch protection | ✅ hardened — required checks, review approval, stale dismissal, conversation resolution, admin enforcement |
+| GitHub `production` environment | ✅ locked — reviewer gate, admin bypass disabled, `main`-only deploys |
+| OpenHands executor | ⏳ NOT LIVE — awaiting token provisioning and runtime start |
 | `API_KEY` in Railway | confirmed present |
 
 ---
@@ -38,7 +40,7 @@
 
 csurf removed. csrf-csrf@^3.2.2 in production. See Recent Completed Work.
 
-**Pending owner action:** run `ADMIN_PASSWORD=<pw> ./scripts/smoke-admin.sh` against prod after Railway deploy completes. Must see `PASSED (7/7)`.
+**Smoke result:** ✅ PASSED (7/7) — 2026-05-27. Production is clean.
 
 ### Tech Debt — CodeQL query exclusion (open, low priority)
 
@@ -56,12 +58,16 @@ Governance layer is live on `main`. Includes:
 - `.github/pull_request_template.md` — QC checklist
 - `.github/ISSUE_TEMPLATE/` — AI task templates
 
-**OpenHands is still NOT LIVE.** Owner must complete before first supervised run:
+**OpenHands is NOT YET LIVE.** Pre-flight checklist status (2026-05-27):
 1. ✅ PR #64 merged
-2. ⏳ Production smoke — `ADMIN_PASSWORD=<pw> ./scripts/smoke-admin.sh` → must see `PASSED (7/7)`
-3. ⏳ GitHub branch protection on `main` (see AGENTS.md Required Manual GitHub Settings)
-4. ⏳ Create `production` GitHub environment (required reviewer: owner)
-5. ⏳ Lock OpenHands token: contents/PR/issues write only; no secrets/deploy/admin
+2. ✅ Production smoke — PASSED (7/7)
+3. ✅ GitHub branch protection hardened
+4. ✅ `production` GitHub environment locked (reviewer gate, main-only)
+5. ⏳ OpenHands fine-grained GitHub token — provisioned with contents/PR/issues write; no secrets/deploy/admin
+6. ⏳ OpenHands executor started (`docker run ...` or `openhands start`)
+7. ⏳ First supervised run — Issue #66 as dry-run task
+
+**Runtime activation** is the only remaining blocker. All governance controls are in place.
 
 ### Issue #66 — npm install --save not yet blocked (low priority, safe to defer)
 

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -11,9 +11,9 @@
 
 | Item | Status |
 |------|--------|
-| HEAD (main) | `ed2b977` (`feat(security): replace deprecated csurf with csrf-csrf`) |
-| Railway deployment | DEPLOYING — auto-triggered by merge of `ed2b977`; run smoke after deploy |
-| Authenticated smoke | PENDING — must run `ADMIN_PASSWORD=<pw> ./scripts/smoke-admin.sh` after deploy |
+| HEAD (main) | `2d4fffc` (merge of PR #64 — AI control plane bootstrap) |
+| Railway deployment | verify status — two merges since last confirmed deploy (`ed2b977`, `2d4fffc`) |
+| Authenticated smoke | PENDING — owner must run `ADMIN_PASSWORD=<pw> ./scripts/smoke-admin.sh` against prod |
 | npm audit | 0 vulnerabilities (main) |
 | Dependabot | clean |
 | Production test artifacts | none |
@@ -24,7 +24,7 @@
 ## Recent Completed Work
 
 - **csurf → csrf-csrf migration** (PR #63, merged 2026-05-27): double-submit cookie CSRF, session-bound, req.csrfToken() polyfill, 0 vulnerabilities
-- AI agent control plane bootstrap (PR #64, open): AGENTS.md, .openhands/hooks.json, issue templates, PR template, npm ci policy
+- **AI control plane bootstrap** (PR #64, merged 2026-05-27): AGENTS.md, .openhands/hooks.json (real OpenHands schema), issue templates, PR template, npm ci policy, GitHub settings docs, fail-closed audit
 - Authenticated admin smoke test added (`scripts/smoke-admin.sh`)
 - macOS smoke portability fix; smoke body-handling subshell fix
 - Smoke converted to non-mutating protected POST; `EBADCSRFTOKEN` → 403
@@ -44,10 +44,28 @@ csurf removed. csrf-csrf@^3.2.2 in production. See Recent Completed Work.
 
 `.github/codeql/codeql-config.yml` globally excludes `js/missing-token-validation` as a false-positive workaround (csrf-csrf is not in CodeQL's recognized CSRF library list). This is safe while csrf-csrf is in use but broader than ideal. Future work: replace with a narrower per-file suppression or contribute csrf-csrf recognition upstream.
 
-### AI Control Plane Bootstrap (PR #64 — open, awaiting merge)
+### AI Control Plane Bootstrap — MERGED (PR #64, 2026-05-27)
 
-Branch: `chore/ai-control-plane-bootstrap`
-AGENTS.md, hooks.json, issue templates, PR template, npm ci policy. Review before merging.
+Governance layer is live on `main`. Includes:
+- `AGENTS.md` — agent roles, supervised-only restrictions, dependency hygiene, required GitHub settings
+- `.openhands/hooks.json` — documented OpenHands schema (array/matcher format)
+- `.openhands/hooks/pre-tool-use.sh` — stdin JSON parsing, exit 2 deny, secret-safe output
+- `.openhands/hooks/on-stop.sh` — structured stop report
+- `.openhands/setup.sh` — fail-closed npm audit, npm ci enforcement
+- `.openhands/instructions.md` — agent operating rules
+- `.github/pull_request_template.md` — QC checklist
+- `.github/ISSUE_TEMPLATE/` — AI task templates
+
+**OpenHands is still NOT LIVE.** Owner must complete before first supervised run:
+1. ✅ PR #64 merged
+2. ⏳ Production smoke — `ADMIN_PASSWORD=<pw> ./scripts/smoke-admin.sh` → must see `PASSED (7/7)`
+3. ⏳ GitHub branch protection on `main` (see AGENTS.md Required Manual GitHub Settings)
+4. ⏳ Create `production` GitHub environment (required reviewer: owner)
+5. ⏳ Lock OpenHands token: contents/PR/issues write only; no secrets/deploy/admin
+
+### Issue #66 — npm install --save not yet blocked (low priority, safe to defer)
+
+`.openhands/hooks/pre-tool-use.sh` blocks `npm install <pkg>`, `npm install` (bare), `npm i <pkg>`, `npm i` (bare) — but NOT `npm install --save <pkg>` or `npm i -S <pkg>`. Safe for initial supervised dry run. Fix tracked in Issue #66.
 
 **Other deferred:**
 - `leads.js` — not mounted in `server.js`; decide: mount or delete


### PR DESCRIPTION
## What changed and why

`docs/agent-handoff.md` was updated to address review feedback on ambiguity in production/deployment status and OpenHands token permission wording.

Changes:
- Clarified Railway deployment status with a concrete verification method (`Railway Dashboard → Deployments`) and explicit deployed SHA context (`2d4fffc`).
- Replaced ambiguous token scope wording with exact GitHub fine-grained permission keys:
  - `contents: write`
  - `pull-requests: write`
  - `issues: write`
  - all other permissions set to `none`
- Kept the rest of the handoff content unchanged outside those targeted fixes.

## Scope

**Files changed:**
- `docs/agent-handoff.md`

**What is NOT changed:**
- No application/runtime code
- No CI/workflow logic
- No deployment configuration changes
- No secret or environment variable changes

## How to validate

```bash
cd api && npm ci
node --check server.js
cd ..
bash scripts/preflight.sh
# If CSRF-sensitive: ADMIN_PASSWORD=<pw> ./scripts/smoke-admin.sh
```

Additional validation run for this update:
- `cd api && npm test`
- `bash scripts/preflight.sh`

## QC Checklist (required before merge)

- [x] No direct push to `main` — this is a PR
- [x] Branch is up to date with `main`
- [ ] All required CI checks are green (CodeQL, preflight, verify, CodeScan)
- [x] `npm audit` shows 0 critical/high vulnerabilities
- [x] No hardcoded secrets, passwords, or tokens introduced
- [x] No Railway environment variables modified
- [x] No production database mutations in tests
- [x] Scope is limited to what's described above
- [x] `docs/agent-handoff.md` updated if this changes production state or architecture

## Agent notes (if AI-implemented)

Implemented by Copilot Coding Agent. This was a docs-only, review-feedback follow-up focused strictly on wording/clarity corrections in the existing handoff document.