### PR TITLE
fix(hooks): block npm install --save and -S variants

### DIFF
--- a/.openhands/hooks/pre-tool-use.sh
+++ b/.openhands/hooks/pre-tool-use.sh
@@ -51,6 +51,10 @@ FORBIDDEN=(
   "npm install$"
   "npm i[[:space:]][^-]"
   "npm i$"
+  "npm install[[:space:]].*--save"
+  "npm install[[:space:]].*-S[[:space:]]"
+  "npm i[[:space:]].*--save"
+  "npm i[[:space:]].*-S[[:space:]]"
   # Secret exposure — never log or echo production credentials
   "printenv"
   "echo[[:space:]].*SESSION_SECRET"


### PR DESCRIPTION
Closes #66

## Summary by Sourcery

Bug Fixes:
- Prevent npm install commands using --save or -S flags from bypassing the pre-tool-use forbidden command checks.