### PR TITLE
fix(observability): startup readiness logging and notification skip warnings

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,3 +36,18 @@ Out of scope: third-party services (Railway, Cloudflare, GitHub Actions), depend
 ## Preferred Languages
 
 Reports in **English** are preferred.
+
+---
+
+## Operational Security — Railway CLI
+
+The `railway variables` CLI command exposes **all environment variable values verbatim** in terminal output, including production secrets (`SESSION_SECRET`, `ADMIN_PASSWORD`, `API_KEY`, `RESEND_API_KEY`, `OPENAI_API_KEY`, Google OAuth tokens, and Twilio credentials).
+
+**Do not run `railway variables` in:**
+- Recorded or screen-shared terminal sessions
+- CI logs or GitHub Actions output
+- Any environment where terminal output may be captured or retained
+
+**Use the Railway dashboard instead** (`app.railway.app`) to view or modify production environment variables. Dashboard access is authenticated and does not expose secrets in logs.
+
+This restriction applies to all agents and human operators with Railway access. Any agent that runs `railway variables` and captures its output must treat the session as potentially compromised and stop immediately per the AGENTS.md Autonomous Safety Stop Rule.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -279,3 +279,39 @@ Three final documentation consistency corrections on PR #73 branch. Authorized: 
 
 ### Recommended Next Task
 Phil: update PR description (42/42 → 48/48), resolve all addressed review threads in GitHub UI, obtain approving review from separate authorized account, merge PR #73.
+
+---
+
+## 2026-05-28 — Claude Code (Sonnet 4.6) — fix/notification-observability
+
+### Objective
+Add structured observability to notification provider paths — startup readiness logging and per-call skip warnings — so silent notification failures produce visible log output. No runtime behavior changes, no schema changes, no new dependencies.
+
+### Changes Made
+- `api/server.js` — added startup readiness check (Phil's exact design): logs `[Startup] Gmail configured: <bool>` and `[Startup] Resend configured: <bool>` on every startup; emits `[WARN] No outbound notification provider configured` when both are absent
+- `api/google.js` — replaced two silent `return` statements in `sendContactEmail()` with structured `console.warn()` calls: one for missing `GOOGLE_GMAIL_USER` / `NOTIFICATION_EMAIL`, one for OAuth token unavailability
+- `api/services/email.js` — added `console.warn()` when `NOTIFICATION_EMAIL` absent; added `console.warn()` when `RESEND_API_KEY` absent and falling through to Gmail OAuth
+- `api/services/twilioService.js` — no change; existing `console.error` on package-unavailable and send-failure is appropriate for an intentionally feature-flagged service
+- `SECURITY.md` — added operational security section documenting that `railway variables` CLI exposes all secret values verbatim; directs all operators to use Railway dashboard instead
+
+### Verification (Truthfulness Rule)
+- Command: `cd api && npm ci` → Result: PASSED (0 vulnerabilities)
+- Command: `node --check api/server.js api/middleware/auth.js api/routes/admin.js api/routes/api.js api/routes/public.js api/google.js api/services/email.js api/services/twilioService.js` → Result: PASSED (ALL SYNTAX OK)
+- Command: `node tests/verify-security-fixes.test.js` → Result: PASSED (48/48)
+- Command: `bash scripts/preflight.sh` → Result: PASSED (PRE-FLIGHT PASSED)
+- Command: `cd api && npm audit` → Result: PASSED (0 vulnerabilities)
+
+### Security Notes
+- No secrets referenced or printed; no auth, CSRF, or session logic changed
+- All changes are additive log statements only
+- `console.warn` on missing credentials is safe — outputs config state, not secret values
+
+### Remaining Risks
+1. **Contact form uses `google.js/sendContactEmail` directly** (`api/routes/api.js` line 107) — Resend is NOT in this call path. Adding `RESEND_API_KEY` to Railway will make `[Startup] Resend configured: true` log, but the contact form notification will still fail silently because it bypasses `services/email.js` entirely. A follow-on PR is needed to route `POST /api/contacts` through `services/email.js/sendLeadNotification` so Resend is tried first. This is a behavior change and requires separate authorization.
+2. **Gmail OAuth remains unconfigured** — 5 variables required; deferred per Phil's decision 2026-05-28
+3. **`leads.js` unmounted** — `GOOGLE_GMAIL_USER` absence warn in `google.js` will fire if `leads.js` is ever mounted without Gmail credentials
+
+### Recommended Next Task
+1. (Phil) Add `RESEND_API_KEY` to Railway → redeploy → verify `[Startup] Resend configured: true` in Railway logs
+2. (Phil) Verify live contact form submission delivers notification email
+3. (Phil, separate authorization required) Route `POST /api/contacts` through `services/email.js` so Resend is the active path for contact form notifications

--- a/api/google.js
+++ b/api/google.js
@@ -70,10 +70,16 @@ async function getAccessToken() {
 
 async function sendContactEmail(contact, property) {
   const { GOOGLE_GMAIL_USER, NOTIFICATION_EMAIL } = process.env;
-  if (!GOOGLE_GMAIL_USER || !NOTIFICATION_EMAIL) return;
+  if (!GOOGLE_GMAIL_USER || !NOTIFICATION_EMAIL) {
+    console.warn('[Gmail] sendContactEmail skipped: GOOGLE_GMAIL_USER or NOTIFICATION_EMAIL not configured');
+    return;
+  }
 
   const token = await getAccessToken().catch(() => null);
-  if (!token) return;
+  if (!token) {
+    console.warn('[Gmail] sendContactEmail skipped: OAuth token unavailable — check GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN');
+    return;
+  }
 
   try {
     const propertyLine = property

--- a/api/server.js
+++ b/api/server.js
@@ -28,6 +28,18 @@ if (process.env.NODE_ENV === 'production') {
   if (!process.env.SESSION_SECRET)  console.warn('[WARN] SESSION_SECRET not set — using insecure default');
 }
 
+const gmailConfigured =
+  Boolean(process.env.GOOGLE_GMAIL_USER) &&
+  Boolean(process.env.GOOGLE_CLIENT_ID) &&
+  Boolean(process.env.GOOGLE_CLIENT_SECRET) &&
+  Boolean(process.env.GOOGLE_REFRESH_TOKEN);
+const resendConfigured = Boolean(process.env.RESEND_API_KEY);
+console.log(`[Startup] Gmail configured: ${gmailConfigured}`);
+console.log(`[Startup] Resend configured: ${resendConfigured}`);
+if (!gmailConfigured && !resendConfigured) {
+  console.warn("[WARN] No outbound notification provider configured");
+}
+
 app.use(helmet({
   contentSecurityPolicy: {
     directives: {

--- a/api/services/email.js
+++ b/api/services/email.js
@@ -87,7 +87,10 @@ function buildLeadHtml(contact, property) {
 // ── Main export ───────────────────────────────────────────
 async function sendLeadNotification(contact, property) {
   const to = process.env.NOTIFICATION_EMAIL;
-  if (!to) return;
+  if (!to) {
+    console.warn('[email] sendLeadNotification skipped: NOTIFICATION_EMAIL not configured');
+    return;
+  }
 
   const propLabel = property ? ` — ${property.address || property.id}` : '';
   const subject   = `🏡 New Lead: ${contact.name}${propLabel}`;
@@ -105,7 +108,10 @@ async function sendLeadNotification(contact, property) {
     }
   }
 
-  // Path 2: Gmail OAuth (existing google.js flow)
+  // Path 2: Gmail OAuth fallback
+  if (!process.env.RESEND_API_KEY) {
+    console.warn('[email] RESEND_API_KEY not configured — attempting Gmail OAuth fallback');
+  }
   try {
     const { sendContactEmail } = require('../google');
     await sendContactEmail(contact, property);


### PR DESCRIPTION
## What changed

Additive log statements only — no behavior changes, no schema changes, no new dependencies.

**`api/server.js`**
Startup readiness check fires on every boot (Phil's exact design):
```
[Startup] Gmail configured: false
[Startup] Resend configured: true
[WARN] No outbound notification provider configured  ← fires when both absent
```

**`api/google.js`**
Replaced two silent `return` statements in `sendContactEmail()` with `console.warn()`:
- Missing `GOOGLE_GMAIL_USER` or `NOTIFICATION_EMAIL`
- OAuth token unavailable (missing `GOOGLE_CLIENT_*` / `GOOGLE_REFRESH_TOKEN`)

**`api/services/email.js`**
- Warn when `NOTIFICATION_EMAIL` absent
- Warn when `RESEND_API_KEY` absent and falling through to Gmail OAuth fallback

**`SECURITY.md`**
New section: `railway variables` CLI exposes all secret values verbatim. Operators must use Railway dashboard instead.

## Why

Post-merge production audit (2026-05-28) found that all contact form notifications were silently failing — both Gmail OAuth and Resend unconfigured in Railway — with no log output, no error, server appearing healthy. This PR makes that failure class immediately visible in Railway logs on next deploy.

## Known follow-on (not in scope here)

`POST /api/contacts` calls `google.js/sendContactEmail` directly, bypassing `services/email.js` and Resend entirely. Adding `RESEND_API_KEY` will make Resend-configured log `true`, but the contact form will still use Gmail-only until a separate PR routes it through `services/email.js`. Documented in WORK_LOG.md.

## How to validate

```bash
cd api && npm ci
node --check server.js middleware/auth.js routes/admin.js routes/api.js routes/public.js
cd .. && node tests/verify-security-fixes.test.js   # 48/48
bash scripts/preflight.sh                            # PRE-FLIGHT PASSED
```

After Railway deploy: check logs for `[Startup] Gmail configured:` and `[Startup] Resend configured:` lines.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add observability around outbound notification configuration and skips so misconfigured email providers are visible in logs without changing runtime behavior.

New Features:
- Log Gmail and Resend configuration status on server startup and warn when no outbound notification provider is configured.

Bug Fixes:
- Surface previously silent notification send skips by warning when contact emails are not attempted due to missing configuration or OAuth tokens.

Enhancements:
- Add warning logs when notification emails are skipped because NOTIFICATION_EMAIL or RESEND_API_KEY are not set, clarifying fallback behavior.

Documentation:
- Document Railway CLI operational security risks around exposing environment variables and direct operators to use the Railway dashboard instead.

Chores:
- Record the observability changes and remaining notification-path risks in WORK_LOG for operational tracking.