### PR TITLE
fix(navigation): enable implicit html public links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ All agents treat repository coordination documents as authoritative. In conflict
 - Do not take destructive or irreversible action until the conflict is resolved and documented.
 - Do not rely on conversational context, session memory, or prior agent output that is not committed to the repository.
 
+`docs/CANONICAL_MAP.md` is the required repo/domain/stack disambiguation map for MalickLand production work.
 `docs/agent-handoff.md` is a deployment-state reference only. It does not override AGENTS.md or other governance documents.
 
 ---
@@ -271,6 +272,21 @@ Every agent session that makes changes must append an entry to `WORK_LOG.md`. Th
 
 ---
 
+## Canonical workspace
+
+Active development repo: **`/Users/yhyh7/Projects/wv-property-intelligence`**. Workspace path, branch, merged PRs, and stale clone warnings are in `PROJECT_STATE.md`. Do not treat `~/Documents/GitHub/wv-property-intelligence`, `~/Projects/wv-realestate`, or the separate Next.js `malickland.net` tree as this product.
+
+## MalickLand Domain Guardrails
+
+1. Production website code lives in this repo unless a recorded architecture decision changes that.
+2. Do not edit `malickland-304/malickland.net` for production fixes; it is a separate Next.js experiment/prototype.
+3. Health check URL is `https://malickland.net/api/health`, not `/health`.
+4. Read `docs/CANONICAL_MAP.md` before malickland.net infrastructure or deployment work.
+5. Never run `wrangler deploy` for `listing-system/workers/` without explicit human approval and a recorded route-ownership decision.
+6. `malickland.cloud` is not `malickland.net`; treat OpenClaw/trading work as a separate project.
+
+---
+
 ## Stale Documentation Notice
 
 The following files are historical reference only:
@@ -278,4 +294,4 @@ The following files are historical reference only:
 - `PROJECT.md` — superseded by `PROJECT_STATE.md`
 - `CONTEXT.md` — may contain outdated architectural assumptions; verify against code
 - `SECURITY_VERIFICATION.md` — historical audit from 2026-04-05; does not reflect current state
-- `docs/agent-handoff.md` — deployment state notes only; does not override AGENTS.md
+- `docs/agent-handoff.md` — deployment/guardrail notes only; may lag `main` — see STALE banner; does not override AGENTS.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,11 +67,12 @@ wv-property-intelligence/
 │       └── admin.js            ← adminShell(), listingForm(), loginPageHtml() (SSR)
 ├── app/                        ← Vanilla JS frontend (served as static files)
 │   ├── index.html              ← Public listing search
+│   ├── listings.html           ← Static listings index
+│   ├── 37-advent.html          ← Advent landing page, extensionless at /37-advent
 │   ├── listing.html            ← Single property detail
 │   ├── admin.html              ← Admin login
 │   ├── app.js                  ← Frontend JS for index.html
-│   ├── listing.js              ← Frontend JS for listing.html
-│   └── styles.css
+│   └── listing.js              ← Frontend JS for listing.html
 ├── database/
 │   ├── schema.sql              ← Reference schema (documentation only, not auto-applied)
 │   └── wv_property.db          ← Live DB (gitignored)
@@ -155,6 +156,8 @@ Public read routes use `publicReadRateLimit`. CRUD write routes require `require
 - `GET /robots.txt`
 - `GET /sitemap.xml`
 - `GET /listing/:id`, `/properties/:id` — serve listing.html
+- `GET /advent-drive-land-hampshire-county-wv` — 301 redirect to `/37-advent`
+- Static frontend files are served from `app/` with `.html` extension resolution, so `/37-advent` serves `app/37-advent.html`
 
 ### /api/leads/* (routes/leads.js) — NOT MOUNTED
 Lead capture routes. Requires missing `services/googleSheets.js` and `twilio` package. Unmounting is intentional; mounting would crash the server.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,24 +1,85 @@
 # PROJECT_STATE.md — Malickland 2.0
-> Last verified: 2026-05-27 | Verified by: Claude Code audit
-> This file covers current product completeness and known gaps. For production deployment state, see `docs/agent-handoff.md` (deployment-state reference only — not authoritative per AGENTS.md).
+
+> **Last verified:** 2026-05-31 (canonical repo `fix/public-navigation-links`, `git fetch origin`)
+> **Authority:** Product completeness and repo workspace truth. Use `docs/CANONICAL_MAP.md` for repo/domain/stack disambiguation. Deployment runbooks and guardrails remain in `docs/agent-handoff.md`.
 
 ---
 
-## Production Health (2026-05-27)
+## Canonical workspace (use only this)
+
+| Item | Value |
+|------|--------|
+| **Active repo** | `/Users/yhyh7/Projects/wv-property-intelligence` |
+| **Remote** | `https://github.com/malickland-304/wv-property-intelligence.git` |
+| **Production branch** | `origin/main` @ `2c4b71e` (2026-05-31 fetch) |
+| **In-progress branch** | `fix/public-navigation-links` — local repair branch pending push/PR |
+| **Ahead of `origin/main`** | Public navigation repair plus repository-state documentation refresh |
+
+The fix branch has been rebased onto current `origin/main`; compare future work against `origin/main`, not stale local `main`.
+
+### Do not use as source of truth
+
+| Path | Why |
+|------|-----|
+| `/Users/yhyh7/Documents/GitHub/wv-property-intelligence` | Stale clone (~33 commits behind when last checked) |
+| `/Users/yhyh7/Documents/Documents - Philip's MacBook Pro - 4/GitHub/malickland.net` | Separate dirty **Next.js** site — not this stack |
+| `/Users/yhyh7/Projects/wv-realestate` | Empty / dead |
+
+Local `main` checkout may lag `origin/main`; always `git fetch origin` and compare to `origin/main`, not an old local `main`.
+
+---
+
+## GitHub / PR status (2026-05-31)
+
+| PR | Status |
+|----|--------|
+| **#73** (governance / test-suite overhaul) | ✅ Merged to `main` (governance commits on `origin/main`, e.g. `f8604f0`, `24399fb`) |
+| **#75** (notification observability) | ✅ Merged — `7eb8b1e` on `origin/main` |
+| **Navigation fix** | ⏳ On `fix/public-navigation-links` only — push + PR pending |
+
+---
+
+## Production health
 
 | Item | Status |
 |------|--------|
 | Live URL | https://malickland.net |
-| Railway deploy | ✅ HEAD `a312aa6` (PR #68 merged) |
-| npm audit | ✅ 0 vulnerabilities |
-| Smoke test (7/7) | ✅ PASSED 2026-05-27 |
-| CI gates | ✅ CodeQL, Semgrep, preflight.yml |
+| Railway deploy | Not verified in this 2026-05-31 local refresh; verify Railway before claiming production state |
+| Health endpoint | **`GET /api/health`** — not `/health` (mounted in `api/routes/api.js`) |
+| npm audit | ✅ 0 vulnerabilities (verified on fix branch 2026-05-31) |
+| Security test suite | ✅ **48/48** on `fix/public-navigation-links` (`node tests/verify-security-fixes.test.js`) |
+| Preflight + route smoke | ✅ Passed on fix branch per session validation (2026-05-31) |
+| CI gates | ✅ CodeQL, Semgrep, `preflight.yml` |
 | Branch protection | ✅ hardened |
-| Local repo branch | ⚠️ `fix/hook-npm-save-patterns` — stale, superseded by PR #68; switch to `main` before new work |
 
 ---
 
-## Technology Stack
+## Stack truth (not Next.js / not Supabase)
+
+| Layer | Choice |
+|-------|--------|
+| **This repo** | Node.js 20 / **Express 5** monolith, **SQLite** (`better-sqlite3`), **vanilla HTML** in `app/` (no frontend build) |
+| **Deploy** | **Railway** + Docker (`api/Dockerfile`), `main` auto-deploys |
+| **Not this product** | The separate **malickland.net Next.js** tree under Documents — different codebase; do not conflate env or deploy |
+| **Not used** | **Supabase**, PostgreSQL, Vercel app router, etc. |
+
+---
+
+## Navigation fix (branch `fix/public-navigation-links`)
+
+| Change | Location |
+|--------|----------|
+| Implicit `.html` for static pages | `api/server.js` — `express.static(..., { extensions: ['html'] })` so `/37-advent` serves `app/37-advent.html` |
+| Legacy URL redirect | `api/routes/public.js` — `301` `/advent-drive-land-hampshire-county-wv` → `/37-advent` |
+| Site links | `app/index.html` → `/37-advent`; page file `app/37-advent.html` |
+
+**Validation (2026-05-31, fix branch):** `npm ci`, `node --check` (server + routes), **48/48** security tests, `scripts/preflight.sh`, route smoke — all passed.
+
+Not yet on production until branch is pushed, PR merged to `main`, and Railway deploys.
+
+---
+
+## Technology stack
 
 | Layer | Choice |
 |-------|--------|
@@ -35,10 +96,11 @@
 
 ---
 
-## Implemented Functionality
+## Implemented functionality
 
 - ✅ Public listing search (`/`, `/api/properties`)
 - ✅ Individual property pages (`/listing/:slug`, `/properties/:slug`)
+- ✅ 37 Advent landing (`/37-advent`, redirect from legacy slug on fix branch)
 - ✅ Admin panel: listing CRUD, photo uploads (with sharp compression), due-diligence notes
 - ✅ AI marketing content generation (GPT-4o, per-listing)
 - ✅ Google Drive photo backup
@@ -51,68 +113,70 @@
 
 ---
 
-## Incomplete / Broken
+## Incomplete / broken
 
 ### 🔴 CRITICAL — Leads system non-functional
+
 - `api/routes/leads.js` is **NOT mounted** in `server.js`
 - `leads.js` requires `../services/googleSheets` — **file does not exist**
 - `leads.js` requires `twilio` package — **not in package.json**
 - If mounted as-is, the server would crash on startup
 - Decision needed: implement missing deps, or delete/stub `leads.js`
 
-### 🟢 Test suite fixed (PR #73, not yet merged to main)
-- `tests/verify-security-fixes.test.js` was rewritten on branch `chore/governance-overhaul-2026-05-27`
-- Tests updated to check actual code locations: `routes/api.js`, `routes/admin.js`, `helpers.js`
-- Suite passes 42/42 on the PR branch; fix pending merge to `main` via PR #73
-- On `main` before PR #73 merges: test suite still reflects pre-fix state
+### 🟢 Test suite — fixed on `main` (PR #73 governance merge)
+
+- `tests/verify-security-fixes.test.js` checks `routes/api.js`, `routes/admin.js`, `helpers.js`
+- **48/48** passing on `fix/public-navigation-links` (2026-05-31)
+- Do not report pre-merge or wrong-file test state
 
 ### 🟡 MEDIUM — Services layer undocumented
-- `api/services/email.js` (Resend/Gmail), `twilioService.js`, `leadFollowupWorker.js` exist but are undocumented in `AGENTS.md` env vars and `docs/agent-handoff.md`
-- New env vars: `RESEND_API_KEY`, `FROM_EMAIL`, `NOTIFICATION_EMAIL`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`, `LEAD_ALERT_TO_NUMBER`
 
-### 🟡 MEDIUM — 73 stale remote branches
-- Many `copilot/*` and old `claude/*` branches — safe to delete
-- Adds noise to branch listings
+- `api/services/email.js` (Resend/Gmail), `twilioService.js`, `leadFollowupWorker.js` exist but are thinly documented in env-var lists
+- Env vars: `RESEND_API_KEY`, `FROM_EMAIL`, `NOTIFICATION_EMAIL`, `TWILIO_*`, `LEAD_ALERT_TO_NUMBER` — see `AGENTS.md`
+
+### 🟡 MEDIUM — Stale remote branches
+
+- Many `copilot/*` and old `claude/*` branches — safe to delete after review
 
 ### 🟢 LOW — OpenHands runtime not activated
-- All governance controls in place
-- Blocked on: provision fine-grained GitHub token + start executor
-- First task: Issue #66 (already fixed on main — pick a new first task)
+
+- Governance controls in place on `main`
+- Blocked on: fine-grained GitHub token + executor start
 
 ---
 
-## Known Bugs
+## Known bugs
 
 | Bug | Severity | Notes |
 |-----|----------|-------|
-| leads.js missing deps | High | Not mounted, would crash if mounted |
-| Test suite wrong-file bug | Fixed (PR #73) | Tests updated to check routes/; fix pending merge to main |
+| leads.js missing deps | High | Not mounted; would crash if mounted |
+| Local `main` behind `origin/main` | Ops | Run `git checkout main && git pull origin main` before branching from stale laptop `main` |
 
 ---
 
-## Security Notes
+## Security notes
 
-- No critical security issues in production code
-- CORS: `cors()` without origin restriction — acceptable for public listing API; review if private data ever exposed
-- `twilio` dynamically required in twilioService.js — fail-graceful (returns null), but package not installed
+- No critical security issues identified in recent validation pass
+- CORS: `cors()` without origin restriction — acceptable for public listing API; review if private data exposed
+- `twilio` dynamically required in `twilioService.js` — fail-graceful; package not installed
 
 ---
 
-## Architecture Notes
+## Architecture notes
 
-- Routes: `server.js` → `routes/admin.js` (624 LOC), `routes/api.js` (227 LOC), `routes/public.js` (94 LOC)
-- `routes/leads.js` (202 LOC) exists but unmounted
+- Routes: `server.js` → `routes/admin.js`, `routes/api.js` (`/api/health`), `routes/public.js`
+- `routes/leads.js` exists but unmounted
 - Services: `email.js`, `twilioService.js`, `leadFollowupWorker.js`, `leadNotifications.js`
 - Utils: `validators.js`, `propertyMarketing.js`, `sqliteSessionStore.js`
-- DB: `db.js` (291 LOC) — SQLite with migrations, county seed, leads/followup tables present
-- CSRF polyfill: `req.csrfToken = () => generateToken(req, res)` patched in server.js before admin routes
+- DB: `db.js` — SQLite with migrations
+- CSRF: `req.csrfToken = () => generateToken(req, res)` polyfill before admin routes
 
 ---
 
-## Product Roadmap (approved, per AGENTS.md / docs/agent-handoff.md)
+## Product roadmap (approved, per AGENTS.md)
 
 - **Phase 0** (current): OpenHands executor validation
-- **Phase 1**: Document Registry skeleton (SQLite tables: documents, document_versions, audit_events, integration_events) — spec from ChatGPT required first
-- **Phase 2**: AI Review Queue (extracted_claims, approval workflow)
-- **Phase 3**: Drive event automation (push notifications)
-- **Phase 4**: Gmail intake (Pub/Sub, mailbox watch)
+- **Phase 1**: Document Registry skeleton (SQLite tables) — spec required first
+- **Phase 2**: AI Review Queue
+- **Phase 3**: Drive event automation
+- **Phase 4**: Gmail intake (Pub/Sub)

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -12,7 +12,7 @@
 | **Active repo** | `/Users/yhyh7/Projects/wv-property-intelligence` |
 | **Remote** | `https://github.com/malickland-304/wv-property-intelligence.git` |
 | **Production branch** | `origin/main` @ `2c4b71e` (2026-05-31 fetch) |
-| **In-progress branch** | `fix/public-navigation-links` — local repair branch pending push/PR |
+| **In-progress branch** | `fix/public-navigation-links` — pushed as PR #76 |
 | **Ahead of `origin/main`** | Public navigation repair plus repository-state documentation refresh |
 
 The fix branch has been rebased onto current `origin/main`; compare future work against `origin/main`, not stale local `main`.
@@ -35,7 +35,7 @@ Local `main` checkout may lag `origin/main`; always `git fetch origin` and compa
 |----|--------|
 | **#73** (governance / test-suite overhaul) | ✅ Merged to `main` (governance commits on `origin/main`, e.g. `f8604f0`, `24399fb`) |
 | **#75** (notification observability) | ✅ Merged — `7eb8b1e` on `origin/main` |
-| **Navigation fix** | ⏳ On `fix/public-navigation-links` only — push + PR pending |
+| **Navigation fix** | ⏳ PR #76 open; waiting for GitHub checks, review/approval, merge, Railway deploy, and production smoke |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ wv-property-intelligence/
 │       └── admin.js        ← Server-rendered admin HTML shell
 ├── app/                    ← Frontend (vanilla JS, no build step)
 │   ├── index.html          ← Public listing search page
+│   ├── listings.html       ← Static listings index
+│   ├── 37-advent.html      ← Advent landing page, served at /37-advent
 │   ├── listing.html        ← Single property detail page
 │   ├── admin.html          ← Admin login page
 │   ├── app.js              ← Listing grid, filters, modal, contact form
-│   ├── listing.js          ← Property detail + inquiry form
-│   └── styles.css          ← All styles (shared across pages)
+│   └── listing.js          ← Property detail + inquiry form
 ├── database/
 │   ├── wv_property.db      ← SQLite database (runtime, gitignored)
 │   └── schema.sql          ← Reference schema (SQLite, documentation only)

--- a/TASKS.md
+++ b/TASKS.md
@@ -6,23 +6,24 @@
 
 ## Critical
 
-- [x] **Fix test suite** — 42/42 pass; tests updated to check route files (`routes/api.js`, `routes/admin.js`, `helpers.js`); Suite 9 added for governance file presence — **Claude Code** — COMPLETED 2026-05-27
+- [x] **Fix test suite** — 48/48 pass; tests updated to check route files (`routes/api.js`, `routes/admin.js`, `helpers.js`); Suite 9 added for governance file presence — **Claude Code** — COMPLETED 2026-05-27 / reverified 2026-05-31
 - [ ] **Resolve leads.js** — decide: (A) implement missing `services/googleSheets.js` + add `twilio` to package.json, or (B) delete `leads.js` and its service deps — decision from ChatGPT required first — **ChatGPT decides / Claude implements**
 
 ---
 
 ## High Priority
 
-- [ ] **Update docs/agent-handoff.md + AGENTS.md env vars** — document services layer env vars: `RESEND_API_KEY`, `FROM_EMAIL`, `NOTIFICATION_EMAIL`, `TWILIO_*`, `LEAD_ALERT_TO_NUMBER`; update architecture notes — no deps — Claude Code
-- [ ] **Switch local repo to main** — `git checkout main && git pull origin main` before starting any new work; local is on stale `fix/hook-npm-save-patterns` — pre-condition for all new work — **developer action**
+- [ ] **Open PR for public navigation repair** — push `fix/public-navigation-links`, open PR to `main`, and wait for GitHub checks; local branch is rebased onto current `origin/main` and locally verified — no deps — **Claude Code or developer**
+- [ ] **Update docs/agent-handoff.md service notes** — keep deployment-state reference aligned with current service env vars and merged PR state; do not let it override AGENTS.md — no deps — Claude Code
 - [ ] **OpenHands executor activation** — provision fine-grained GitHub token; start executor; run first supervised task — waiting on developer action; Issue #66 is now fixed on main, so pick Issue #65 or new task — **developer action**
 
 ---
 
 ## Medium Priority
 
-- [ ] **Delete stale remote branches** — remove merged `copilot/*`, old `claude/*` branches; keep only active feature branches — no deps — **Claude Code or developer**
+- [ ] **Delete stale local branches** — remove superseded local `copilot/*`, old `claude/*`, and merged fix branches after confirming no unpushed work — no deps — **Claude Code or developer**
 - [ ] **Add twilio to package.json or remove Twilio path** — if leads feature is kept: `npm install twilio` (human approval required per AGENTS.md); if deleted: remove twilioService.js and references — depends on leads.js decision
+- [ ] **Resolve broken county links** — homepage links `/wv/hampshire-county`, `/wv/hardy-county`, `/wv/morgan-county`, and other county paths, but no static pages or Express route exists; decide whether to create county pages or replace links with listing filters — no deps
 - [ ] **Phase 1: Document Registry spec** — ChatGPT delivers schema, approval state machine, AI extraction JSON contract — no code deps — **ChatGPT**
 - [ ] **Narrow CodeQL suppression** (Issue #65) — replace broad `js/missing-token-validation` query exclusion with per-file suppression — low risk, no deps — **Claude Code**
 
@@ -45,6 +46,9 @@
 - [x] AI control plane bootstrap (AGENTS.md, OpenHands hooks, issue templates) — PR #64 merged 2026-05-27
 - [x] Handoff doc update post-PR #64 — PR #67 merged
 - [x] Block `npm install --save` / `npm i -S` in pre-tool hook — PR #68 merged 2026-05-27 (copilot fix for Issue #66)
+- [x] Governance test suite repair — PR #73 merged 2026-05-28
+- [x] Startup notification observability — PR #75 merged 2026-05-28
+- [x] Canonical production map created — `docs/CANONICAL_MAP.md` added 2026-05-31
 - [x] GitHub branch protection hardened — required checks, review approval, stale dismissal, admin enforcement
 - [x] `production` GitHub environment locked — reviewer gate, main-only deploys
 - [x] `brace-expansion` patched, `cookie` transitive vuln contained

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,7 +13,7 @@
 
 ## High Priority
 
-- [ ] **Open PR for public navigation repair** — push `fix/public-navigation-links`, open PR to `main`, and wait for GitHub checks; local branch is rebased onto current `origin/main` and locally verified — no deps — **Claude Code or developer**
+- [ ] **Merge and deploy public navigation repair** — PR #76 is open; wait for GitHub checks, review/approval, merge to `main`, Railway deploy, and production smoke for `/listings`, `/37-advent`, legacy Advent SEO redirect, and `/api/health` — no deps — **Phil / Claude Code**
 - [ ] **Update docs/agent-handoff.md service notes** — keep deployment-state reference aligned with current service env vars and merged PR state; do not let it override AGENTS.md — no deps — Claude Code
 - [ ] **OpenHands executor activation** — provision fine-grained GitHub token; start executor; run first supervised task — waiting on developer action; Issue #66 is now fixed on main, so pick Issue #65 or new task — **developer action**
 
@@ -49,6 +49,7 @@
 - [x] Governance test suite repair — PR #73 merged 2026-05-28
 - [x] Startup notification observability — PR #75 merged 2026-05-28
 - [x] Canonical production map created — `docs/CANONICAL_MAP.md` added 2026-05-31
+- [x] Public navigation repair PR opened — PR #76 opened 2026-05-31
 - [x] GitHub branch protection hardened — required checks, review approval, stale dismissal, admin enforcement
 - [x] `production` GitHub environment locked — reviewer gate, main-only deploys
 - [x] `brace-expansion` patched, `cookie` transitive vuln contained

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -315,3 +315,44 @@ Add structured observability to notification provider paths — startup readines
 1. (Phil) Add `RESEND_API_KEY` to Railway → redeploy → verify `[Startup] Resend configured: true` in Railway logs
 2. (Phil) Verify live contact form submission delivers notification email
 3. (Phil, separate authorization required) Route `POST /api/contacts` through `services/email.js` so Resend is the active path for contact form notifications
+
+---
+
+## 2026-05-31 — Codex — fix/public-navigation-links
+
+### Objective
+Repair repo truth after multiple overlapping agent sessions: identify the canonical production checkout, stop agents from using stale clones or the separate Next.js experiment for production fixes, rebase the public navigation repair onto current `origin/main`, and prepare the branch for PR.
+
+### Changes Made
+- `api/server.js` — existing branch change retained: static HTML files are served with extension resolution so `/listings` and `/37-advent` can resolve without `.html`.
+- `api/routes/public.js` — existing branch change retained: legacy Advent SEO URL redirects to `/37-advent`.
+- `docs/CANONICAL_MAP.md` — added canonical repo/domain/stack map and guardrails from local git state plus read-only live probes.
+- `AGENTS.md` — added required reference to `docs/CANONICAL_MAP.md` and MalickLand domain guardrails.
+- `PROJECT_STATE.md` — refreshed current repo, branch, PR, validation, and stale-checkout status.
+- `ARCHITECTURE.md` and `README.md` — corrected frontend file tree and documented `/37-advent` extensionless static serving.
+- `TASKS.md` — updated completed PR/test status and added follow-up for broken `/wv/*-county` links.
+- `docs/agent-handoff.md` — demoted to deployment-state reference and removed stale PR #64-era source-of-truth language.
+
+### Verification (Truthfulness Rule)
+- Command: `git fetch origin --prune` → Result: PASSED.
+- Command: `git rebase origin/main` → Result: PASSED.
+- Command: `cd api && npm ci` → Result: PASSED (0 vulnerabilities).
+- Command: `node --check server.js && node --check middleware/auth.js && node --check routes/admin.js && node --check routes/api.js && node --check routes/public.js` → Result: PASSED.
+- Command: `node tests/verify-security-fixes.test.js` → Result: PASSED (48/48).
+- Command: `PREFLIGHT_PORT=43137 bash scripts/preflight.sh` → Result: PASSED after rerun; an earlier parallel run failed before `npm ci` completed and was not a code failure.
+- Command: local route smoke on port 43138 for `/37-advent` and `/advent-drive-land-hampshire-county-wv` → Result: PASSED (`/37-advent` 200, legacy URL 301 then 200).
+- Command: `curl -fsS https://malickland.net/api/health` → Result: PASSED (200 JSON health response).
+- Command: live read-only probes for `/listings`, `/37-advent`, and `/listings.html` → Result: VERIFIED current production still has extensionless 404s before this branch is merged.
+
+### Security Notes
+- No secrets read or printed.
+- No production mutation, deploy, merge, database mutation, or destructive filesystem cleanup performed.
+- Cloudflare Worker deploy remains explicitly blocked without human approval and route-ownership decision.
+
+### Remaining Risks
+1. Branch still needs push, PR, GitHub CI, merge, Railway deploy, and production verification.
+2. Homepage county links under `/wv/*-county` still point to missing routes/pages; tracked separately in `TASKS.md`.
+3. Old local branches and stale duplicate checkouts still exist; do not delete until unpushed work is reviewed.
+
+### Recommended Next Task
+Push `fix/public-navigation-links`, open a PR to `main`, wait for GitHub checks, merge after approval, then verify production `/listings`, `/37-advent`, `/advent-drive-land-hampshire-county-wv`, and `/api/health`.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -350,9 +350,9 @@ Repair repo truth after multiple overlapping agent sessions: identify the canoni
 - Cloudflare Worker deploy remains explicitly blocked without human approval and route-ownership decision.
 
 ### Remaining Risks
-1. Branch still needs push, PR, GitHub CI, merge, Railway deploy, and production verification.
+1. PR #76 still needs GitHub CI, review/approval, merge, Railway deploy, and production verification.
 2. Homepage county links under `/wv/*-county` still point to missing routes/pages; tracked separately in `TASKS.md`.
 3. Old local branches and stale duplicate checkouts still exist; do not delete until unpushed work is reviewed.
 
 ### Recommended Next Task
-Push `fix/public-navigation-links`, open a PR to `main`, wait for GitHub checks, merge after approval, then verify production `/listings`, `/37-advent`, `/advent-drive-land-hampshire-county-wv`, and `/api/health`.
+Wait for PR #76 GitHub checks, merge after approval, then verify production `/listings`, `/37-advent`, `/advent-drive-land-hampshire-county-wv`, and `/api/health`.

--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -112,28 +112,7 @@ router.get(['/listing/:id', '/properties/:id'], publicReadRateLimit, (_req, res)
 });
 
 router.get('/advent-drive-land-hampshire-county-wv', publicReadRateLimit, (_req, res) => {
-  res.send(`<!DOCTYPE html>
-<html>
-<head>
-  <title>Land for Sale Hampshire County WV | Advent Dr</title>
-  <meta name="description" content="Land for sale in Hampshire County WV on Advent Drive. Hunting, recreation, or build opportunity near VA/DC.">
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "RealEstateListing",
-    "name": "Land for Sale – Advent Drive, Hampshire County WV",
-    "description": "Land for sale in Hampshire County West Virginia on Advent Drive.",
-    "url": "https://malickland.net/advent-drive-land-hampshire-county-wv"
-  }
-  </script>
-</head>
-<body>
-  <h1>Land for Sale – Advent Drive, Hampshire County WV</h1>
-  <p>This property offers privacy, usable acreage, and strong long-term value.</p>
-  <p><strong>Contact now to walk the property.</strong></p>
-  <a href="https://malickland.net">Back to MalickLand</a>
-</body>
-</html>`);
+  res.redirect(301, '/37-advent');
 });
 
 module.exports = router;

--- a/api/server.js
+++ b/api/server.js
@@ -105,7 +105,7 @@ app.use('/admin', cookieParser(), adminSession, (req, res, next) => {
 app.use('/api',   apiRoutes);
 app.use('/',      publicRoutes);
 
-app.use(express.static(path.join(PROJECT_ROOT, 'app')));
+app.use(express.static(path.join(PROJECT_ROOT, 'app'), { extensions: ['html'] }));
 
 app.use((req, res) => {
   if (req.path.startsWith('/api')) return res.status(404).json({ error: 'Not found' });

--- a/docs/CANONICAL_MAP.md
+++ b/docs/CANONICAL_MAP.md
@@ -1,0 +1,62 @@
+# CANONICAL_MAP.md — MalickLand Production Map
+
+> Last verified: 2026-05-31 by Codex using local git state plus read-only DNS/curl probes.
+> Use this file to prevent repo, domain, and stack confusion before touching MalickLand production work.
+
+## Canonical Truth
+
+| Layer | Current truth | Evidence |
+|-------|---------------|----------|
+| Live domain | `https://malickland.net` | DNS resolves to `66.33.22.228`; responses are served by Railway |
+| Production stack | Express 5 monolith: `api/` JSON + `app/` static HTML | `railway.toml`, `api/Dockerfile`, `api/server.js`, live `/api/health` |
+| Production repo | `malickland-304/wv-property-intelligence` | `origin` in `/Users/yhyh7/Projects/wv-property-intelligence` |
+| Production branch | `origin/main` | `git fetch origin`; last observed `origin/main` was `2c4b71e` on 2026-05-31 |
+| Canonical local checkout | `/Users/yhyh7/Projects/wv-property-intelligence` | Active repair branch `fix/public-navigation-links` |
+| Health URL | `https://malickland.net/api/health` | Live probe returned `{"status":"ok", ...}` on 2026-05-31 |
+| Not production | `malickland-304/malickland.net` | Separate dirty Next.js checkout under Documents; live site is not serving Next.js routes |
+| Not deployed | `listing-system/workers/` | Cloudflare Worker config is experimental/template-level and must not be deployed to apex without an architecture decision |
+| Separate project | `malickland.cloud` | OpenClaw/trading infrastructure; not the MalickLand real estate website |
+
+## Active Repair
+
+Branch: `fix/public-navigation-links`
+
+Purpose:
+- Serve `app/*.html` pages without requiring the `.html` suffix.
+- Make `/listings` resolve to `app/listings.html`.
+- Make `/37-advent` resolve to `app/37-advent.html`.
+- Redirect `/advent-drive-land-hampshire-county-wv` to `/37-advent`.
+
+Production symptoms observed before merge:
+- `/api/health` returns 200.
+- `/listings` returns 404 while `/listings.html` returns 200.
+- `/37-advent` returns 404 while `/37-advent.html` returns 200.
+
+Local validation on the repair branch passed:
+- `cd api && npm ci`
+- `node --check server.js middleware/auth.js routes/admin.js routes/api.js routes/public.js`
+- `node tests/verify-security-fixes.test.js` — 48/48
+- `PREFLIGHT_PORT=43137 bash scripts/preflight.sh`
+- Local route smoke: `/37-advent` 200 and legacy Advent SEO URL 301 -> `/37-advent`.
+
+## Do Not Use As Source Of Truth
+
+| Path or repo | Reason |
+|--------------|--------|
+| `/Users/yhyh7/Documents/GitHub/wv-property-intelligence` | Stale clone from earlier consolidation work |
+| `/Users/yhyh7/Documents/Documents - Philip's MacBook Pro - 4/GitHub/malickland.net` | Separate Next.js experiment/prototype, not current production |
+| `/Users/yhyh7/Projects/wv-realestate` | Empty/dead checkout at last verification |
+| `listing-system/workers/` | Experimental Worker path that would conflict with Railway apex routes if deployed blindly |
+
+## Guardrails
+
+1. For production website fixes, start in `/Users/yhyh7/Projects/wv-property-intelligence`.
+2. Compare against `origin/main`; do not trust stale local `main` or old handoff text.
+3. Health is `/api/health`, not `/health`.
+4. Do not edit the Next.js `malickland.net` repo for production fixes unless a documented architecture decision changes the production stack.
+5. Do not run `wrangler deploy` for `listing-system/workers/` without explicit human approval and a recorded route-ownership decision.
+6. Before claiming production deployment, verify Railway and run read-only live smoke checks.
+
+## Known Follow-Up
+
+The homepage links `/wv/hampshire-county`, `/wv/hardy-county`, and other county routes, but no matching static pages or Express route currently exists. Track this separately from the public navigation repair.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -1,18 +1,23 @@
-# Agent Handoff — Source of Truth
+# Agent Handoff — Deployment reference
 
 > **All agents must read this file before acting on this repo.**
 
 ---
 
-> **This file reflects canonical production state, not necessarily any agent's local checkout.**
-> Always verify local repo state with `git fetch origin && git status` before acting.
+> **⚠️ STALE RISK — Product/repo workspace truth lives in [`PROJECT_STATE.md`](../PROJECT_STATE.md).**
+> This file may lag GitHub `main` (HEAD, merged PRs, branch paths). Before acting: use canonical repo `/Users/yhyh7/Projects/wv-property-intelligence`, `git fetch origin`, compare `git rev-parse origin/main`. Do **not** use stale clones under `~/Documents/GitHub/` or the separate Next.js `malickland.net` tree.
+
+---
+
+> **This file reflects deployment/guardrail notes, not necessarily any agent's local checkout.**
+> Always verify with `git fetch origin && git status` before acting.
 
 ## Current Production State
 
 | Item | Status |
 |------|--------|
-| HEAD (main) | `2d4fffc` (merge of PR #64 — AI control plane bootstrap) |
-| Railway deployment | ✅ confirmed live (`2d4fffc`) — verify in Railway Dashboard → Deployments; smoke PASSED 2026-05-27 |
+| HEAD (main) | See `PROJECT_STATE.md` — verify with `git rev-parse origin/main` (was `2c4b71e` at 2026-05-31 doc pass) |
+| Railway deployment | ✅ Tracks `main` — confirm HEAD in Railway Dashboard → Deployments |
 | Authenticated smoke | ✅ PASSED (7/7) — 2026-05-27 |
 | npm audit | 0 vulnerabilities (main) |
 | Dependabot | clean |
@@ -65,24 +70,24 @@ Governance layer is live on `main`. Includes:
 4. ✅ `production` GitHub environment locked (reviewer gate, main-only)
 5. ⏳ OpenHands fine-grained GitHub token — `contents: write`, `pull-requests: write`, `issues: write`; all other permissions set to `none`
 6. ⏳ OpenHands executor started (`docker run ...` or `openhands start`)
-7. ⏳ First supervised run — Issue #66 as dry-run task
+7. ⏳ First supervised run — choose a current open issue; Issue #66 is already fixed
 
 **Runtime activation** is the only remaining blocker. All governance controls are in place.
 
-### Issue #66 — npm install --save not yet blocked (low priority, safe to defer)
+### Issue #66 — CLOSED
 
-`.openhands/hooks/pre-tool-use.sh` blocks `npm install <pkg>`, `npm install` (bare), `npm i <pkg>`, `npm i` (bare) — but NOT `npm install --save <pkg>` or `npm i -S <pkg>`. Safe for initial supervised dry run. Fix tracked in Issue #66.
+Issue #66 was fixed by merged PRs #68/#69. The OpenHands npm install blocker now covers the previously missed save-flag forms.
 
 **Other deferred:**
 - `leads.js` — not mounted in `server.js`; decide: mount or delete
-- `PROJECT.md` — severely stale, needs update
-- Stale remote branches (`copilot/*`, some `claude/*`) — safe to delete
+- `PROJECT.md` — may be stale, needs review before use
+- Stale local branches (`copilot/*`, some `claude/*`, superseded fix branches) — safe to delete only after confirming no unpushed work
 
 ---
 
 ## Guardrails
 
-- **This file reflects canonical production state, not any agent's local checkout.** Verify: `git fetch origin && git status && git rev-parse HEAD`
+- **This file is a deployment-state reference, not the canonical authority document and not proof of any agent's local checkout.** Verify: `git fetch origin && git status && git rev-parse HEAD`
 - Read this file before acting
 - **Do not commit directly to `main`** unless explicitly approved by the user
 - **Do not mutate production data** during smoke tests


### PR DESCRIPTION
## Summary
- Enables extensionless static HTML resolution so /listings and /37-advent serve their existing app/*.html files.
- Redirects the legacy Advent SEO URL to /37-advent.
- Adds docs/CANONICAL_MAP.md and guardrails so agents use wv-property-intelligence as production truth instead of stale clones or the separate Next.js experiment.
- Tracks the remaining /wv/* county-link gap as a separate follow-up.

## Validation
- cd api && npm ci: passed, 0 vulnerabilities
- node --check server.js middleware/auth.js routes/admin.js routes/api.js routes/public.js: passed
- node tests/verify-security-fixes.test.js: passed, 48/48
- PREFLIGHT_PORT=43137 bash scripts/preflight.sh: passed
- Local route smoke: /37-advent 200; /advent-drive-land-hampshire-county-wv 301 -> /37-advent -> 200
- Live read-only check before merge: /api/health 200; /listings and /37-advent still 404 on production until this PR is deployed

No issue number: repair came from repo-state reconciliation after overlapping agent sessions.

## Summary by Sourcery

Enable extensionless public HTML routes and document the canonical production workspace and navigation fix status.

New Features:
- Serve static HTML pages at extensionless URLs such as `/listings` and `/37-advent`.
- Redirect the legacy Advent SEO URL `/advent-drive-land-hampshire-county-wv` to the new `/37-advent` landing page.

Enhancements:
- Document the canonical MalickLand production repo, stack, and workspace guardrails in new and updated docs, including `CANONICAL_MAP.md`, `PROJECT_STATE.md`, `AGENTS.md`, and `docs/agent-handoff.md`.
- Refresh architecture, README, and task tracking to reflect the extensionless navigation behavior, current test/governance status, and remaining county link follow-ups.