### PR TITLE
docs: add Cursor workspace guardrails

### DIFF
--- a/.cursor/rules/malickland-canonical-workspace.mdc
+++ b/.cursor/rules/malickland-canonical-workspace.mdc
@@ -1,0 +1,42 @@
+---
+description: MalickLand production workspace and handoff guardrails
+globs:
+  - "**/*"
+alwaysApply: true
+---
+
+# MalickLand Production Workspace
+
+This Cursor workspace is the canonical production website repo for `malickland.net`:
+
+- Local path: `/Users/yhyh7/Projects/wv-property-intelligence`
+- Remote: `https://github.com/malickland-304/wv-property-intelligence.git`
+- Production branch: `main`
+- Stack: Express 5, SQLite, vanilla HTML in `app/`, Railway deploy
+- Health URL: `https://malickland.net/api/health`
+
+Before any work:
+
+1. Run `git fetch origin --prune`.
+2. Run `git status --short --branch`.
+3. If you are not intentionally on a feature branch, switch to `main` and pull: `git checkout main && git pull --ff-only origin main`.
+4. Read `AGENTS.md`, `docs/CANONICAL_MAP.md`, `PROJECT_STATE.md`, and `TASKS.md`.
+
+Do not use these for production website work:
+
+- `/Users/yhyh7/Projects/openclaw-system`
+- `/Users/yhyh7/Documents/GitHub/wv-property-intelligence`
+- `/Users/yhyh7/Documents/GitHub/wv-property-intelligence-repair`
+- `/Users/yhyh7/Documents/Documents - Philip's MacBook Pro - 4/GitHub/malickland.net`
+- `malickland-304/malickland.net`
+- `listing-system/workers/`
+
+If a prompt mentions MalickLand website work while Cursor is rooted anywhere else, stop and tell Phil to reopen Cursor at `/Users/yhyh7/Projects/wv-property-intelligence`.
+
+When handing work to Codex, report:
+
+- Branch name
+- `git status --short --branch`
+- Files touched
+- Commit or PR URL, if pushed
+- Validation actually run

--- a/CODEX_COLLABORATION.md
+++ b/CODEX_COLLABORATION.md
@@ -1,0 +1,41 @@
+# Codex Collaboration Guide
+
+This file gives Codex (or any external assistant that cannot attach to the Cursor account) everything it needs to review and continue work that Cursor does in this repo.
+
+## Repo
+
+- **Local path:** `/Users/yhyh7/Projects/wv-property-intelligence`
+- **Work happens here.** Cursor performs edits in this repo so Codex can inspect committed or uncommitted changes locally.
+
+## How Codex gets context (no Cursor login required)
+
+Codex cannot log into or attach to the Cursor account. Instead, hand it context through the repo:
+
+1. **Paste Cursor output** directly into the Codex chat when needed.
+2. **Share files** Cursor creates in the repo (or as attachments).
+3. **Use the same GitHub repo/branch** so Codex can inspect Cursor's committed or uncommitted changes locally.
+4. **Tracked plans/rules:** Cursor writes plans, rules, and decisions to tracked files (`.cursor/rules/`, `docs/`, or the root `*.md` docs) so Codex can read and use them.
+
+## Handoff protocol (every time Cursor finishes a chunk of work)
+
+Tell Codex:
+
+- **Branch** Cursor worked on (e.g. output of `git branch --show-current`).
+- **Files touched** (e.g. output of `git status` / `git diff --name-only`).
+- **What changed and why** (point Codex at the relevant `*.md` doc or commit message).
+
+### Quick commands to copy/paste to Codex
+
+```bash
+git branch --show-current        # current branch
+git status                       # uncommitted changes
+git diff --name-only             # changed file paths
+git log --oneline -10            # recent commits
+```
+
+## Where to look for plans and state
+
+- `PROJECT_STATE.md`, `TASKS.md`, `WORK_LOG.md` — current state, task list, history
+- `ARCHITECTURE.md`, `DECISIONS.md` — design and decisions
+- `.cursor/rules/` — Cursor rules (if present)
+- `docs/` — additional documentation

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE.md — Malickland 2.0
 
-> **Last verified:** 2026-05-31 (canonical repo `fix/public-navigation-links`, `git fetch origin`)
+> **Last verified:** 2026-05-31 (canonical branch `main` @ `dc8cc53`, `git pull` fast-forward; PR #76 merged)
 > **Authority:** Product completeness and repo workspace truth. Use `docs/CANONICAL_MAP.md` for repo/domain/stack disambiguation. Deployment runbooks and guardrails remain in `docs/agent-handoff.md`.
 
 ---
@@ -11,11 +11,10 @@
 |------|--------|
 | **Active repo** | `/Users/yhyh7/Projects/wv-property-intelligence` |
 | **Remote** | `https://github.com/malickland-304/wv-property-intelligence.git` |
-| **Production branch** | `origin/main` @ `2c4b71e` (2026-05-31 fetch) |
-| **In-progress branch** | `fix/public-navigation-links` — pushed as PR #76 |
-| **Ahead of `origin/main`** | Public navigation repair plus repository-state documentation refresh |
+| **Production branch** | `origin/main` @ `dc8cc53` (PR #76 merged 2026-05-31) |
+| **Last merged PR** | #76 public navigation repair — merged into `main`; branch `fix/public-navigation-links` deleted remotely |
 
-The fix branch has been rebased onto current `origin/main`; compare future work against `origin/main`, not stale local `main`.
+PR #76 is merged into `main`; compare future work against `origin/main`, not a stale local `main`.
 
 ### Do not use as source of truth
 
@@ -35,7 +34,7 @@ Local `main` checkout may lag `origin/main`; always `git fetch origin` and compa
 |----|--------|
 | **#73** (governance / test-suite overhaul) | ✅ Merged to `main` (governance commits on `origin/main`, e.g. `f8604f0`, `24399fb`) |
 | **#75** (notification observability) | ✅ Merged — `7eb8b1e` on `origin/main` |
-| **Navigation fix** | ⏳ PR #76 open; waiting for GitHub checks, review/approval, merge, Railway deploy, and production smoke |
+| **#76** (public navigation links fix) | ✅ Merged — `dc8cc53` on `origin/main` (2026-05-31); Railway deploy + production smoke still to verify |
 
 ---
 
@@ -65,7 +64,7 @@ Local `main` checkout may lag `origin/main`; always `git fetch origin` and compa
 
 ---
 
-## Navigation fix (branch `fix/public-navigation-links`)
+## Navigation fix (PR #76, merged into `main` @ `dc8cc53`)
 
 | Change | Location |
 |--------|----------|
@@ -73,9 +72,9 @@ Local `main` checkout may lag `origin/main`; always `git fetch origin` and compa
 | Legacy URL redirect | `api/routes/public.js` — `301` `/advent-drive-land-hampshire-county-wv` → `/37-advent` |
 | Site links | `app/index.html` → `/37-advent`; page file `app/37-advent.html` |
 
-**Validation (2026-05-31, fix branch):** `npm ci`, `node --check` (server + routes), **48/48** security tests, `scripts/preflight.sh`, route smoke — all passed.
+**Validation (2026-05-31, pre-merge on `fix/public-navigation-links`):** `npm ci`, `node --check` (server + routes), **48/48** security tests, `scripts/preflight.sh`, route smoke — all passed.
 
-Not yet on production until branch is pushed, PR merged to `main`, and Railway deploys.
+Merged into `main` @ `dc8cc53` via PR #76; verify Railway deploy and run read-only production smoke before claiming it is live.
 
 ---
 
@@ -100,7 +99,7 @@ Not yet on production until branch is pushed, PR merged to `main`, and Railway d
 
 - ✅ Public listing search (`/`, `/api/properties`)
 - ✅ Individual property pages (`/listing/:slug`, `/properties/:slug`)
-- ✅ 37 Advent landing (`/37-advent`, redirect from legacy slug on fix branch)
+- ✅ 37 Advent landing (`/37-advent`, redirect from legacy slug — merged to `main` via PR #76)
 - ✅ Admin panel: listing CRUD, photo uploads (with sharp compression), due-diligence notes
 - ✅ AI marketing content generation (GPT-4o, per-listing)
 - ✅ Google Drive photo backup


### PR DESCRIPTION
## Summary
- Adds a repo-local Cursor rule requiring MalickLand website work to run from /Users/yhyh7/Projects/wv-property-intelligence.
- Explicitly blocks production-site assumptions from stale local clones, openclaw-system, the separate Next.js malickland.net repo, and listing-system workers.
- Tracks the Codex/Cursor handoff protocol in CODEX_COLLABORATION.md.

## Validation
- Verified branch is based on current origin/main before commit.
- Documentation-only change; no runtime code touched.

## Notes
- Also added a local-only Cursor rule under /Users/yhyh7/Projects/openclaw-system/.cursor/rules/not-malickland-production.mdc because Cursor had launched there for MalickLand work. That directory is not a git repo, so the rule is local-only.

## Summary by Sourcery

Document Codex–Cursor collaboration workflows and add Cursor workspace guardrails for the MalickLand website repo.

Documentation:
- Add Codex collaboration guide describing repo location, handoff protocol, and locations of project state and planning documents.

Chores:
- Add Cursor rule to enforce MalickLand work occurs in the canonical wv-property-intelligence workspace and avoid stale or non-production clones.