### PR TITLE
docs: record GitHub cleanup audit

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -30,12 +30,18 @@ Local `main` checkout may lag `origin/main`; always `git fetch origin` and compa
 
 ## GitHub / PR status (2026-05-31)
 
+Open GitHub issues: **0**. Open pull requests: **0** after cleanup on 2026-05-31.
+
 | PR | Status |
 |----|--------|
+| **#60** (old consolidation PR) | Closed 2026-05-31 as stale/unsafe to merge; branch deleted |
+| **#70** (npm hook blocker) | Closed 2026-05-31 as superseded by current `main`; branch deleted |
+| **#71** (CodeQL suppression narrowing) | Closed 2026-05-31 as not viable; linked Issue #65 is closed and PR failed CodeQL; branch deleted |
 | **#73** (governance / test-suite overhaul) | ✅ Merged to `main` (governance commits on `origin/main`, e.g. `f8604f0`, `24399fb`) |
 | **#75** (notification observability) | ✅ Merged — `7eb8b1e` on `origin/main` |
 | **#76** (public navigation links fix) | ✅ Merged — `dc8cc53` on `origin/main` (2026-05-31); production smoke passed |
 | **#77** (Cursor workspace guardrails) | ✅ Merged — `b34e2fb` on `origin/main` (2026-05-31) |
+| **#78** (post-PR76 docs refresh) | ✅ Merged — `0908cd4` on `origin/main` (2026-05-31) |
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -15,7 +15,7 @@
 
 - [ ] **Resolve branch protection policy mismatch** — GitHub currently requires status checks, but PR review protection, required conversation resolution, and admin enforcement are not enabled; decide whether to tighten settings or document the intentional policy — no deps — **Phil / Codex**
 - [ ] **Update docs/agent-handoff.md service notes** — keep deployment-state reference aligned with current service env vars and merged PR state; do not let it override AGENTS.md — no deps — Claude Code
-- [ ] **OpenHands executor activation** — provision fine-grained GitHub token; start executor; run first supervised task — waiting on developer action; Issue #66 is now fixed on main, so pick Issue #65 or new task — **developer action**
+- [ ] **OpenHands executor activation** — provision fine-grained GitHub token; start executor; run first supervised task — waiting on developer action; Issue #66 is fixed and Issue #65 is closed, so create or pick a current task — **developer action**
 
 ---
 
@@ -25,7 +25,6 @@
 - [ ] **Add twilio to package.json or remove Twilio path** — if leads feature is kept: `npm install twilio` (human approval required per AGENTS.md); if deleted: remove twilioService.js and references — depends on leads.js decision
 - [ ] **Resolve broken county links** — homepage links `/wv/hampshire-county`, `/wv/hardy-county`, `/wv/morgan-county`, and other county paths, but no static pages or Express route exists; decide whether to create county pages or replace links with listing filters — no deps
 - [ ] **Phase 1: Document Registry spec** — ChatGPT delivers schema, approval state machine, AI extraction JSON contract — no code deps — **ChatGPT**
-- [ ] **Narrow CodeQL suppression** (Issue #65) — replace broad `js/missing-token-validation` query exclusion with per-file suppression — low risk, no deps — **Claude Code**
 
 ---
 
@@ -46,6 +45,8 @@
 - [x] AI control plane bootstrap (AGENTS.md, OpenHands hooks, issue templates) — PR #64 merged 2026-05-27
 - [x] Handoff doc update post-PR #64 — PR #67 merged
 - [x] Block `npm install --save` / `npm i -S` in pre-tool hook — PR #68 merged 2026-05-27 (copilot fix for Issue #66)
+- [x] GitHub stale PR cleanup — PRs #60, #70, and #71 closed with evidence comments; linked Issues #65/#66 already closed — 2026-05-31
+- [x] CodeQL suppression narrowing attempt closed — PR #71 failed CodeQL; broad false-positive exclusion remains documented until a fresh green approach exists
 - [x] Governance test suite repair — PR #73 merged 2026-05-28
 - [x] Startup notification observability — PR #75 merged 2026-05-28
 - [x] Canonical production map created — `docs/CANONICAL_MAP.md` added 2026-05-31

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -390,3 +390,37 @@ Repair post-merge coordination state after PR #76 and PR #77 landed, and reduce 
 
 ### Recommended Next Task
 Push this docs refresh branch and open a PR, then decide the branch-protection policy before changing GitHub settings.
+
+---
+
+## 2026-05-31 — Codex — GitHub issue and PR cleanup
+
+### Objective
+Audit all open GitHub issues and pull requests, finish stale/superseded PRs with evidence, and leave the GitHub issue/PR surface clean.
+
+### Changes Made
+- GitHub PR #60 — commented and closed as stale/unsafe to merge; remote branch `codex/malickland-2-consolidation` deleted.
+- GitHub PR #70 — commented and closed as superseded by current `main`; remote branch `copilot/malickland-304-block-npm-install-save` deleted.
+- GitHub PR #71 — commented and closed as not viable because the linked Issue #65 is closed and the PR failed CodeQL; remote branch `copilot/malickland-304replace-codeql-exclusion` deleted.
+- `PROJECT_STATE.md` — recorded zero open issues / zero open PRs and the cleanup result for PRs #60, #70, and #71.
+- `TASKS.md` — removed stale open work that pointed agents at closed Issue #65 and recorded the stale PR cleanup as complete.
+- `docs/agent-handoff.md` — corrected OpenHands first-task guidance and branch-protection wording to match current GitHub state.
+
+### Verification (Truthfulness Rule applies)
+- Command: `gh issue list --state open --limit 100 --json number,title,url` → Result: PASSED (`[]`).
+- Command: `gh pr list --state open --limit 100 --json number,title,url` → Result: PASSED (`[]`).
+- Command: `gh pr view 60/70/71 --json state,closed,closedAt` → Result: PASSED (all closed at `2026-05-31T18:24:46Z`).
+- Command: `git fetch origin --prune` → Result: PASSED; deleted stale remote PR branches were pruned.
+
+### Security Notes
+- No secrets read or printed.
+- PR #71 was not merged because it failed CodeQL after removing the global `js/missing-token-validation` false-positive exclusion.
+- No branch protection, production deployment, or environment settings changed.
+
+### Remaining Risks
+1. Local stale branches still exist and should only be deleted after confirming they have no unpushed work.
+2. CodeQL suppression remains broad by design until a fresh narrowing approach passes CodeQL.
+3. Branch protection policy mismatch remains a separate decision item.
+
+### Recommended Next Task
+Open and merge this docs cleanup PR, then address remaining non-GitHub-open-item work: branch-protection policy, `leads.js`, and `/wv/*-county` links.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -66,13 +66,13 @@ Governance layer is live on `main`. Includes:
 **OpenHands is NOT YET LIVE.** Pre-flight checklist status (2026-05-27):
 1. ✅ PR #64 merged
 2. ✅ Production smoke — PASSED (7/7)
-3. ✅ GitHub branch protection hardened
+3. ✅ GitHub required status checks configured (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`)
 4. ✅ `production` GitHub environment locked (reviewer gate, main-only)
 5. ⏳ OpenHands fine-grained GitHub token — `contents: write`, `pull-requests: write`, `issues: write`; all other permissions set to `none`
 6. ⏳ OpenHands executor started (`docker run ...` or `openhands start`)
-7. ⏳ First supervised run — choose a current open issue; Issue #66 is already fixed
+7. ⏳ First supervised run — create or choose a current task; GitHub currently has no open issues and Issue #66 is already fixed
 
-**Runtime activation** is the only remaining blocker. All governance controls are in place.
+**Runtime activation** is the only remaining blocker. Required automated checks are in place; PR review protection, required conversation resolution, and admin enforcement were not enabled in the 2026-05-31 GitHub API check.
 
 ### Issue #66 — CLOSED
 
@@ -82,6 +82,7 @@ Issue #66 was fixed by merged PRs #68/#69. The OpenHands npm install blocker now
 - `leads.js` — not mounted in `server.js`; decide: mount or delete
 - `PROJECT.md` — may be stale, needs review before use
 - Stale local branches (`copilot/*`, some `claude/*`, superseded fix branches) — safe to delete only after confirming no unpushed work
+- Closed stale GitHub PRs #60, #70, and #71 on 2026-05-31; do not revive them without re-cutting fresh branches from current `main`
 
 ---
 


### PR DESCRIPTION
## Summary
- record that GitHub now has zero open issues and zero open PRs
- document closure of stale PRs #60, #70, and #71 with their rationale
- remove stale task guidance pointing agents at closed Issue #65
- correct OpenHands handoff text to match current GitHub and branch-protection state

## Validation
- gh issue list --state open => []
- gh pr list --state open => [] before this docs PR
- gh pr view 60/70/71 confirmed closed
- git diff --check

## Summary by Sourcery

Document the cleanup of GitHub issues and pull requests and align operational docs with the current repository and governance state.

Documentation:
- Record the 2026-05-31 GitHub issue/PR cleanup, including closure rationale for PRs #60, #70, and #71, in WORK_LOG.md and PROJECT_STATE.md.
- Update agent handoff documentation to reflect current required status checks, lack of additional branch protection, and the absence of open GitHub issues.
- Adjust TASKS.md to remove stale work tied to closed Issue #65 and to log the stale PR cleanup and CodeQL suppression narrowing attempt as completed.