### PR TITLE
docs: record final GitHub audit state

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -71,3 +71,15 @@
 **Decision:** ChatGPT = orchestrator/PM; Claude Code = implementation; Codex = audit-only (no mutations); Gemini = architecture challenger (no code in active PRs); OpenHands = supervised worker.
 **Reasoning:** Prevents conflicting implementations, ensures human review, preserves security posture.
 **Files:** `AGENTS.md`
+
+---
+
+## 2026-05-31 — GitHub hygiene cleanup and branch-protection policy
+
+**Problem:** GitHub had no open issues/PRs after cleanup, but repository metadata still contained stale remote branches, branch-protection drift, and misleading environment documentation.
+**Decision:** Under Phil's direct instruction for a one-time GitHub cleanup, Codex may execute GitHub metadata hygiene for this task only: close stale PRs, delete stale non-`main` remote branches, and update branch protection. This is not a standing change to the Codex audit-only role.
+**Branch protection:** Preserve required status checks (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`) and enable required conversation resolution. Keep required PR reviews and admin enforcement off to avoid solo-maintainer merge bottlenecks.
+**Human gate:** Production deployments, production secrets, schema-breaking changes, and publication decisions still require Phil's explicit approval. Disabling required PR reviews does not grant any agent deploy authority.
+**Reasoning:** Automated checks plus conversation resolution provide the useful GitHub safety gates without recreating the manual-review bottleneck that previously blocked repository throughput.
+**Alternatives:** Required PR reviews/admin enforcement — rejected for now because the repo is operated by a solo maintainer and those settings can block emergency fixes or docs-only cleanup.
+**Files:** `TASKS.md`, `PROJECT_STATE.md`, `docs/agent-handoff.md`, `WORK_LOG.md`

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -56,7 +56,10 @@ Open GitHub issues: **0**. Open pull requests: **0** after cleanup on 2026-05-31
 | Security test suite | ✅ **48/48** on `fix/public-navigation-links` (`node tests/verify-security-fixes.test.js`) |
 | Preflight + route smoke | ✅ Passed on fix branch per session validation (2026-05-31) |
 | CI gates | ✅ CodeQL, Semgrep, `preflight.yml` |
-| Branch protection | Required status checks enabled (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`); PR review protection, conversation resolution, and admin enforcement were not enabled in the 2026-05-31 GitHub API check |
+| Branch protection | Required status checks enabled (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`); required conversation resolution enabled; PR review protection and admin enforcement intentionally off for low-friction solo operation |
+| GitHub security queues | ✅ Open code-scanning alerts: 0; Dependabot alerts: 0; secret-scanning alerts: 0 (2026-05-31 API audit) |
+| Remote branches | ✅ Only protected `main` remains on `origin` after stale branch cleanup (2026-05-31) |
+| GitHub environments | Railway deployment statuses use `alert-laughter / production`; `production` and `copilot` environments exist but are not deployment-gating for Railway |
 
 ---
 
@@ -139,10 +142,6 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 - `api/services/email.js` (Resend/Gmail), `twilioService.js`, `leadFollowupWorker.js` exist but are thinly documented in env-var lists
 - Env vars: `RESEND_API_KEY`, `FROM_EMAIL`, `NOTIFICATION_EMAIL`, `TWILIO_*`, `LEAD_ALERT_TO_NUMBER` — see `AGENTS.md`
-
-### 🟡 MEDIUM — Stale remote branches
-
-- Many `copilot/*` and old `claude/*` branches — safe to delete after review
 
 ### 🟢 LOW — OpenHands runtime not activated
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -56,7 +56,7 @@ Open GitHub issues: **0**. Open pull requests: **0** after cleanup on 2026-05-31
 | Security test suite | ✅ **48/48** on `fix/public-navigation-links` (`node tests/verify-security-fixes.test.js`) |
 | Preflight + route smoke | ✅ Passed on fix branch per session validation (2026-05-31) |
 | CI gates | ✅ CodeQL, Semgrep, `preflight.yml` |
-| Branch protection | Required status checks enabled (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`); required conversation resolution enabled; PR review protection and admin enforcement intentionally off for low-friction solo operation |
+| Branch protection | Required status checks enabled (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`); required conversation resolution enabled; PR review protection and admin enforcement intentionally off per `DECISIONS.md` 2026-05-31 |
 | GitHub security queues | ✅ Open code-scanning alerts: 0; Dependabot alerts: 0; secret-scanning alerts: 0 (2026-05-31 API audit) |
 | Remote branches | ✅ Only protected `main` remains on `origin` after stale branch cleanup (2026-05-31) |
 | GitHub environments | Railway deployment statuses use `alert-laughter / production`; `production` and `copilot` environments exist but are not deployment-gating for Railway |

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,7 +13,6 @@
 
 ## High Priority
 
-- [ ] **Resolve branch protection policy mismatch** — GitHub currently requires status checks, but PR review protection, required conversation resolution, and admin enforcement are not enabled; decide whether to tighten settings or document the intentional policy — no deps — **Phil / Codex**
 - [ ] **Update docs/agent-handoff.md service notes** — keep deployment-state reference aligned with current service env vars and merged PR state; do not let it override AGENTS.md — no deps — Claude Code
 - [ ] **OpenHands executor activation** — provision fine-grained GitHub token; start executor; run first supervised task — waiting on developer action; Issue #66 is fixed and Issue #65 is closed, so create or pick a current task — **developer action**
 
@@ -21,7 +20,7 @@
 
 ## Medium Priority
 
-- [ ] **Delete stale local branches** — remove superseded local `copilot/*`, old `claude/*`, and merged fix branches after confirming no unpushed work — no deps — **Claude Code or developer**
+- [ ] **Delete stale local branches** — remote branches are cleaned up; remove superseded local `copilot/*`, old `claude/*`, and merged fix branches after confirming no unpushed work — no deps — **Claude Code or developer**
 - [ ] **Add twilio to package.json or remove Twilio path** — if leads feature is kept: `npm install twilio` (human approval required per AGENTS.md); if deleted: remove twilioService.js and references — depends on leads.js decision
 - [ ] **Resolve broken county links** — homepage links `/wv/hampshire-county`, `/wv/hardy-county`, `/wv/morgan-county`, and other county paths, but no static pages or Express route exists; decide whether to create county pages or replace links with listing filters — no deps
 - [ ] **Phase 1: Document Registry spec** — ChatGPT delivers schema, approval state machine, AI extraction JSON contract — no code deps — **ChatGPT**
@@ -54,7 +53,10 @@
 - [x] Public navigation repair merged — PR #76 merged to `main` (`dc8cc53`) 2026-05-31
 - [x] Public navigation repair deployed and smoke-tested — production `/api/health`, `/listings`, `/37-advent`, and legacy Advent redirect verified 2026-05-31
 - [x] GitHub required status checks configured — `CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`
-- [x] `production` GitHub environment locked — reviewer gate, main-only deploys
+- [x] GitHub branch protection finalized — required checks + conversation resolution enabled; manual PR review/admin gates intentionally off for low-friction solo operation — 2026-05-31
+- [x] GitHub remote branch cleanup — 73 stale non-`main` remote branches deleted; only protected `main` remains — 2026-05-31
+- [x] GitHub security queues audited — open CodeQL/code-scanning alerts, Dependabot alerts, and secret-scanning alerts all zero — 2026-05-31
+- [x] GitHub environments audited — Railway deployments report to `alert-laughter / production`; unused `production`/`copilot` environments documented as non-gating — 2026-05-31
 - [x] `brace-expansion` patched, `cookie` transitive vuln contained
 - [x] Create PROJECT_STATE.md, TASKS.md, DECISIONS.md, QA_CHECKLIST.md — 2026-05-27 (Claude Code)
 - [x] Create ARCHITECTURE.md, WORK_LOG.md — 2026-05-27 (Claude Code)

--- a/TASKS.md
+++ b/TASKS.md
@@ -53,7 +53,7 @@
 - [x] Public navigation repair merged — PR #76 merged to `main` (`dc8cc53`) 2026-05-31
 - [x] Public navigation repair deployed and smoke-tested — production `/api/health`, `/listings`, `/37-advent`, and legacy Advent redirect verified 2026-05-31
 - [x] GitHub required status checks configured — `CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`
-- [x] GitHub branch protection finalized — required checks + conversation resolution enabled; manual PR review/admin gates intentionally off for low-friction solo operation — 2026-05-31
+- [x] GitHub branch protection finalized — required checks + conversation resolution enabled; manual PR review/admin gates intentionally off per `DECISIONS.md` 2026-05-31 — 2026-05-31
 - [x] GitHub remote branch cleanup — 73 stale non-`main` remote branches deleted; only protected `main` remains — 2026-05-31
 - [x] GitHub security queues audited — open CodeQL/code-scanning alerts, Dependabot alerts, and secret-scanning alerts all zero — 2026-05-31
 - [x] GitHub environments audited — Railway deployments report to `alert-laughter / production`; unused `production`/`copilot` environments documented as non-gating — 2026-05-31

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -424,3 +424,40 @@ Audit all open GitHub issues and pull requests, finish stale/superseded PRs with
 
 ### Recommended Next Task
 Open and merge this docs cleanup PR, then address remaining non-GitHub-open-item work: branch-protection policy, `leads.js`, and `/wv/*-county` links.
+
+---
+
+## 2026-05-31 — Codex — Final GitHub surface cleanup
+
+### Objective
+Resolve remaining GitHub repository-level cleanup after issues and PRs were closed: branch protection, stale remote branches, security queues, Actions health, and environment truth.
+
+### Changes Made
+- GitHub branch protection — enabled required conversation resolution on `main` while preserving required checks (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`), `strict=false`, no PR review gate, and no admin enforcement.
+- GitHub remote branches — deleted 73 stale non-`main` remote branches with no open PRs attached; only protected `main` remains on `origin`.
+- GitHub security queues — verified open code-scanning alerts, Dependabot alerts, and secret-scanning alerts are all zero.
+- GitHub Actions — verified recent `main` runs are green; cancelled Copilot dynamic review runs were non-required and from merged PR branches.
+- GitHub environments — verified Railway deployment statuses use `alert-laughter / production`; `production` and `copilot` environments exist but do not gate Railway deploys.
+- `PROJECT_STATE.md`, `TASKS.md`, and `docs/agent-handoff.md` — updated to match the final GitHub state.
+
+### Verification (Truthfulness Rule applies)
+- Command: `gh issue list --state open --limit 100` → Result: PASSED (`[]`).
+- Command: `gh pr list --state open --limit 100` → Result: PASSED (`[]`).
+- Command: `gh api repos/malickland-304/wv-property-intelligence/branches/main/protection` → Result: PASSED; required conversation resolution enabled, required checks preserved.
+- Command: `gh api .../code-scanning/alerts -f state=open` → Result: PASSED (0).
+- Command: `gh api .../dependabot/alerts -f state=open` → Result: PASSED (0).
+- Command: `gh api .../secret-scanning/alerts -f state=open` → Result: PASSED (0).
+- Command: `gh api repos/malickland-304/wv-property-intelligence/branches --paginate` → Result: PASSED; only `main` remains.
+
+### Security Notes
+- No secrets read or printed.
+- No production deployment or database mutation performed.
+- Manual PR review and admin enforcement remain intentionally disabled to avoid solo-maintainer merge bottlenecks while automated checks and conversation resolution remain enforced.
+
+### Remaining Risks
+1. Local stale branches and worktrees remain on this machine; GitHub remote branches are clean.
+2. Railway deployment gating is not controlled by GitHub environments; deployment statuses are reported to `alert-laughter / production`.
+3. Product backlog items (`leads.js`, `/wv/*-county`, document registry) remain non-GitHub-open-item work.
+
+### Recommended Next Task
+Open and merge this final docs PR, then move from GitHub hygiene to product/runtime backlog: `leads.js`, `/wv/*-county`, and OpenHands runtime activation.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -444,9 +444,9 @@ Resolve remaining GitHub repository-level cleanup after issues and PRs were clos
 - Command: `gh issue list --state open --limit 100` → Result: PASSED (`[]`).
 - Command: `gh pr list --state open --limit 100` → Result: PASSED (`[]`).
 - Command: `gh api repos/malickland-304/wv-property-intelligence/branches/main/protection` → Result: PASSED; required conversation resolution enabled, required checks preserved.
-- Command: `gh api .../code-scanning/alerts -f state=open` → Result: PASSED (0).
-- Command: `gh api .../dependabot/alerts -f state=open` → Result: PASSED (0).
-- Command: `gh api .../secret-scanning/alerts -f state=open` → Result: PASSED (0).
+- Command: `gh api repos/malickland-304/wv-property-intelligence/code-scanning/alerts -f state=open` → Result: PASSED (0).
+- Command: `gh api repos/malickland-304/wv-property-intelligence/dependabot/alerts -f state=open` → Result: PASSED (0).
+- Command: `gh api repos/malickland-304/wv-property-intelligence/secret-scanning/alerts -f state=open` → Result: PASSED (0).
 - Command: `gh api repos/malickland-304/wv-property-intelligence/branches --paginate` → Result: PASSED; only `main` remains.
 
 ### Security Notes

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -427,12 +427,13 @@ Open and merge this docs cleanup PR, then address remaining non-GitHub-open-item
 
 ---
 
-## 2026-05-31 — Codex — Final GitHub surface cleanup
+## 2026-05-31 — Codex — Phil-authorized GitHub surface cleanup
 
 ### Objective
-Resolve remaining GitHub repository-level cleanup after issues and PRs were closed: branch protection, stale remote branches, security queues, Actions health, and environment truth.
+Resolve remaining GitHub repository-level cleanup after issues and PRs were closed: branch protection, stale remote branches, security queues, Actions health, and environment truth. This was performed under Phil's explicit instruction to resolve GitHub hygiene today and is recorded as a one-time exception in `DECISIONS.md`.
 
 ### Changes Made
+- `DECISIONS.md` — recorded Phil's one-time authorization for Codex to execute GitHub metadata hygiene and the branch-protection policy; this does not change Codex's normal audit-only role.
 - GitHub branch protection — enabled required conversation resolution on `main` while preserving required checks (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`), `strict=false`, no PR review gate, and no admin enforcement.
 - GitHub remote branches — deleted 73 stale non-`main` remote branches with no open PRs attached; only protected `main` remains on `origin`.
 - GitHub security queues — verified open code-scanning alerts, Dependabot alerts, and secret-scanning alerts are all zero.
@@ -452,7 +453,8 @@ Resolve remaining GitHub repository-level cleanup after issues and PRs were clos
 ### Security Notes
 - No secrets read or printed.
 - No production deployment or database mutation performed.
-- Manual PR review and admin enforcement remain intentionally disabled to avoid solo-maintainer merge bottlenecks while automated checks and conversation resolution remain enforced.
+- Manual PR review and admin enforcement remain intentionally disabled per `DECISIONS.md` 2026-05-31 while automated checks and conversation resolution remain enforced.
+- Production deployments, production secrets, schema-breaking changes, and publication decisions still require Phil's explicit approval.
 
 ### Remaining Risks
 1. Local stale branches and worktrees remain on this machine; GitHub remote branches are clean.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -16,13 +16,13 @@
 
 | Item | Status |
 |------|--------|
-| HEAD (main) | See `PROJECT_STATE.md` — verify with `git rev-parse origin/main` (was `2c4b71e` at 2026-05-31 doc pass) |
+| HEAD (main) | See `PROJECT_STATE.md` — verify with `git rev-parse origin/main` before work |
 | Railway deployment | ✅ Tracks `main` — confirm HEAD in Railway Dashboard → Deployments |
 | Authenticated smoke | ✅ PASSED (7/7) — 2026-05-27 |
 | npm audit | 0 vulnerabilities (main) |
-| Dependabot | clean |
-| GitHub branch protection | ✅ hardened — required checks, review approval, stale dismissal, conversation resolution, admin enforcement |
-| GitHub `production` environment | ✅ locked — reviewer gate, admin bypass disabled, `main`-only deploys |
+| GitHub security queues | ✅ clean — open code-scanning, Dependabot, and secret-scanning alerts all zero on 2026-05-31 |
+| GitHub branch protection | ✅ required checks + conversation resolution; PR review/admin gates intentionally off for low-friction solo operation |
+| GitHub deployment environments | Railway reports deployments to `alert-laughter / production`; `production` and `copilot` environments exist but do not gate Railway deploys |
 | OpenHands executor | ⏳ NOT LIVE — awaiting token provisioning and runtime start |
 | `API_KEY` in Railway | confirmed present |
 
@@ -67,12 +67,12 @@ Governance layer is live on `main`. Includes:
 1. ✅ PR #64 merged
 2. ✅ Production smoke — PASSED (7/7)
 3. ✅ GitHub required status checks configured (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`)
-4. ✅ `production` GitHub environment locked (reviewer gate, main-only)
+4. ✅ GitHub branch protection finalized (required checks + conversation resolution)
 5. ⏳ OpenHands fine-grained GitHub token — `contents: write`, `pull-requests: write`, `issues: write`; all other permissions set to `none`
 6. ⏳ OpenHands executor started (`docker run ...` or `openhands start`)
 7. ⏳ First supervised run — create or choose a current task; GitHub currently has no open issues and Issue #66 is already fixed
 
-**Runtime activation** is the only remaining blocker. Required automated checks are in place; PR review protection, required conversation resolution, and admin enforcement were not enabled in the 2026-05-31 GitHub API check.
+**Runtime activation** is the only remaining blocker. Required automated checks and conversation resolution are in place; PR review protection and admin enforcement are intentionally off for solo-maintainer throughput.
 
 ### Issue #66 — CLOSED
 
@@ -83,6 +83,7 @@ Issue #66 was fixed by merged PRs #68/#69. The OpenHands npm install blocker now
 - `PROJECT.md` — may be stale, needs review before use
 - Stale local branches (`copilot/*`, some `claude/*`, superseded fix branches) — safe to delete only after confirming no unpushed work
 - Closed stale GitHub PRs #60, #70, and #71 on 2026-05-31; do not revive them without re-cutting fresh branches from current `main`
+- Deleted stale remote branches on 2026-05-31; only protected `main` remains on `origin`
 
 ---
 

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -21,7 +21,7 @@
 | Authenticated smoke | ✅ PASSED (7/7) — 2026-05-27 |
 | npm audit | 0 vulnerabilities (main) |
 | GitHub security queues | ✅ clean — open code-scanning, Dependabot, and secret-scanning alerts all zero on 2026-05-31 |
-| GitHub branch protection | ✅ required checks + conversation resolution; PR review/admin gates intentionally off for low-friction solo operation |
+| GitHub branch protection | ✅ required checks + conversation resolution; PR review/admin gates intentionally off per `DECISIONS.md` 2026-05-31 |
 | GitHub deployment environments | Railway reports deployments to `alert-laughter / production`; `production` and `copilot` environments exist but do not gate Railway deploys |
 | OpenHands executor | ⏳ NOT LIVE — awaiting token provisioning and runtime start |
 | `API_KEY` in Railway | confirmed present |
@@ -72,7 +72,7 @@ Governance layer is live on `main`. Includes:
 6. ⏳ OpenHands executor started (`docker run ...` or `openhands start`)
 7. ⏳ First supervised run — create or choose a current task; GitHub currently has no open issues and Issue #66 is already fixed
 
-**Runtime activation** is the only remaining blocker. Required automated checks and conversation resolution are in place; PR review protection and admin enforcement are intentionally off for solo-maintainer throughput.
+**Runtime activation** is the only remaining blocker. Required automated checks and conversation resolution are in place; PR review protection and admin enforcement are intentionally off per the 2026-05-31 `DECISIONS.md` branch-protection policy.
 
 ### Issue #66 — CLOSED
 


### PR DESCRIPTION
## Summary
- record final GitHub audit state after branch protection and remote branch cleanup
- mark branch-protection mismatch resolved: required checks + conversation resolution enabled, PR review/admin gates intentionally off
- document zero open security queues and only protected main remaining on origin
- correct deployment environment wording: Railway reports to alert-laughter / production; GitHub production/copilot environments do not gate Railway deploys

## Validation
- git diff --check
- gh issue list --state open => []
- gh pr list --state open => [] before this docs PR
- code-scanning open alerts => 0
- dependabot open alerts => 0
- secret-scanning open alerts => 0
- gh branches => only main

## Summary by Sourcery

Document the final GitHub repository state, including branch protection, remote branches, security queues, and deployment environments, and align operational docs with that state.

Documentation:
- Add a work-log entry capturing the final GitHub cleanup actions and verification commands.
- Update agent handoff documentation to describe the finalized branch protection policy, clean security queues, remote branch cleanup, and non-gating deployment environments.
- Revise project state documentation to reflect zero security alerts, single protected main branch, and accurate description of GitHub environments.
- Update task tracking to remove resolved branch protection mismatch work and record completion of GitHub cleanup items.