### PR TITLE
fix(web): gzip compression + repoint 9 broken county nav links

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "better-sqlite3": "12.8.0",
         "better-sqlite3-session-store": "^0.1.0",
+        "compression": "^1.8.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "csrf-csrf": "^3.2.2",
@@ -730,6 +731,80 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "better-sqlite3": "12.8.0",
     "better-sqlite3-session-store": "^0.1.0",
+    "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "csrf-csrf": "^3.2.2",

--- a/api/server.js
+++ b/api/server.js
@@ -6,6 +6,7 @@ const express  = require('express');
 const cors     = require('cors');
 const helmet   = require('helmet');
 const morgan   = require('morgan');
+const compression  = require('compression');
 const session      = require('express-session');
 const cookieParser = require('cookie-parser');
 const path         = require('path');
@@ -61,6 +62,10 @@ app.use(helmet({
     },
   },
 }));
+
+// Compress all responses (gzip) — shrinks the ~71KB homepage to ~12-15KB on the wire.
+app.use(compression());
+
 app.use(cors((req, cb) => {
   const origin = req.headers.origin;
   if (!origin) {

--- a/app/index.html
+++ b/app/index.html
@@ -1294,15 +1294,15 @@
   <div style="max-width:1200px;margin:0 auto">
     <p style="text-align:center;font-size:.8rem;color:#6b7280;margin-bottom:.85rem;text-transform:uppercase;letter-spacing:.5px;font-weight:600">Browse by County</p>
     <div style="display:flex;flex-wrap:wrap;gap:.5rem;justify-content:center">
-      <a href="/wv/hampshire-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hampshire</a>
-      <a href="/wv/hardy-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hardy</a>
-      <a href="/wv/morgan-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Morgan</a>
-      <a href="/wv/grant-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Grant</a>
-      <a href="/wv/pendleton-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Pendleton</a>
-      <a href="/wv/mineral-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Mineral</a>
-      <a href="/wv/tucker-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Tucker</a>
-      <a href="/wv/berkeley-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Berkeley</a>
-      <a href="/wv/jefferson-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Jefferson</a>
+      <a href="/listings?county=Hampshire" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hampshire</a>
+      <a href="/listings?county=Hardy" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hardy</a>
+      <a href="/listings?county=Morgan" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Morgan</a>
+      <a href="/listings?county=Grant" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Grant</a>
+      <a href="/listings?county=Pendleton" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Pendleton</a>
+      <a href="/listings?county=Mineral" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Mineral</a>
+      <a href="/listings?county=Tucker" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Tucker</a>
+      <a href="/listings?county=Berkeley" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Berkeley</a>
+      <a href="/listings?county=Jefferson" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Jefferson</a>
       <a href="/listings" style="background:#1B4332;border:1px solid #1B4332;color:#D4AF37;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:700;text-decoration:none">All Counties →</a>
     </div>
   </div>


### PR DESCRIPTION
## What
Two production fixes found during a live audit of malickland.net:

1. **Gzip compression** — the Express app had no `compression` middleware, so the homepage shipped ~71 KB uncompressed even when gzip was requested. Added `compression()` after helmet → **~71 KB → ~16 KB gzipped** on the wire (`Content-Encoding: gzip`, `Vary: Accept-Encoding`).
2. **Broken county navigation** — the homepage linked to 9 `/wv/<county>-county` pages that **all return 404** (no route, no pages). Repointed those 9 links to `/listings?county=<Name>` (resolves 200, forward-compatible with the existing county filter). Dedicated county landing pages are a tracked follow-up.

## Files
- `api/server.js` — `require('compression')` + `app.use(compression())`
- `api/package.json` / `package-lock.json` — add `compression@^1.8.1` (Docker `npm ci --omit=dev` needs it in deps)
- `app/index.html` — 9 county chip links repointed

## Verification (local)
- App boots; `GET /` → `Content-Encoding: gzip`, 16,533 B (was 71,758 B)
- `/listings?county=Hampshire` → 200; old `/wv/hampshire-county` → 404 (no longer linked)
- Brokerage disclosure intact (no WV-compliance regression)
- **48/48** security/correctness tests pass

## Summary by Sourcery

Enable gzip compression for the web server and correct broken county navigation links on the homepage.

Bug Fixes:
- Fix nine broken county navigation links by routing them to the listings page filtered by county.

Enhancements:
- Enable gzip response compression across the Express API to reduce homepage payload size.

Build:
- Add the compression package as a runtime dependency in the API service.