### PR TITLE
fix(api): harden lead endpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,8 +159,8 @@ Public read routes use `publicReadRateLimit`. CRUD write routes require `require
 - `GET /advent-drive-land-hampshire-county-wv` — 301 redirect to `/37-advent`
 - Static frontend files are served from `app/` with `.html` extension resolution, so `/37-advent` serves `app/37-advent.html`
 
-### /api/leads/* (routes/leads.js) — NOT MOUNTED
-Lead capture routes. Requires missing `services/googleSheets.js` and `twilio` package. Unmounting is intentional; mounting would crash the server.
+### /api/leads/* (routes/leads.js)
+Lead capture routes mounted behind JSON and same-origin guards in `server.js`. Local SQLite lead persistence works without external credentials; Google Sheets append is currently a no-op adapter until real sheet credentials/support are added.
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -55,13 +55,13 @@
 
 ---
 
-## 2026-05-27 — leads.js NOT mounted (pending decision)
+## 2026-06-01 — leads.js mounted with local-safe adapters
 
-**Problem:** `api/routes/leads.js` exists but requires missing `services/googleSheets.js` and the `twilio` package (not in package.json). Mounting it would crash the server.
-**Decision (interim):** Keep unmounted. Do not mount until: (A) missing deps are implemented, OR (B) the file is deleted.
-**Reasoning:** Server stability. The missing `googleSheets.js` suggests the service was planned but not built.
-**Pending:** ChatGPT to decide: implement leads feature (requires googleSheets.js + twilio) or delete leads.js.
-**Files:** `api/routes/leads.js`, `api/services/` (missing `googleSheets.js`)
+**Problem:** `api/routes/leads.js` existed but was unmounted because `services/googleSheets.js` was missing.
+**Decision:** Mount `/api/leads` behind JSON and same-origin guards, and add a no-op Google Sheets adapter so local SQLite capture works when sheet credentials are absent.
+**Reasoning:** Server stability plus functional lead capture. Optional notification/sheet integrations should fail closed or no-op when credentials/packages are unavailable.
+**Pending:** Real Google Sheets append support can be added later without changing the public route contract.
+**Files:** `api/server.js`, `api/routes/leads.js`, `api/services/googleSheets.js`
 
 ---
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -124,13 +124,12 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 ## Incomplete / broken
 
-### 🔴 CRITICAL — Leads system non-functional
+### 🟡 Follow-up — External lead integrations
 
-- `api/routes/leads.js` is **NOT mounted** in `server.js`
-- `leads.js` requires `../services/googleSheets` — **file does not exist**
-- `leads.js` requires `twilio` package — **not in package.json**
-- If mounted as-is, the server would crash on startup
-- Decision needed: implement missing deps, or delete/stub `leads.js`
+- `api/routes/leads.js` is mounted in `server.js`
+- Public lead/contact POSTs require JSON plus same-origin request headers
+- `api/services/googleSheets.js` is a no-op adapter until real Sheets append support is implemented
+- `twilio` is still optional and not in `package.json`; SMS alerts remain disabled unless that dependency and env are added
 
 ### 🟢 Test suite — fixed on `main` (PR #73 governance merge)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -7,7 +7,7 @@
 ## Critical
 
 - [x] **Fix test suite** — 48/48 pass; tests updated to check route files (`routes/api.js`, `routes/admin.js`, `helpers.js`); Suite 9 added for governance file presence — **Claude Code** — COMPLETED 2026-05-27 / reverified 2026-05-31
-- [ ] **Resolve leads.js** — decide: (A) implement missing `services/googleSheets.js` + add `twilio` to package.json, or (B) delete `leads.js` and its service deps — decision from ChatGPT required first — **ChatGPT decides / Claude implements**
+- [x] **Resolve leads.js** — mounted `/api/leads`, added local-safe `services/googleSheets.js` adapter, and guarded lead/contact POSTs in `server.js` — **Codex** — COMPLETED 2026-06-01
 
 ---
 
@@ -21,7 +21,7 @@
 ## Medium Priority
 
 - [ ] **Delete stale local branches** — remote branches are cleaned up; remove superseded local `copilot/*`, old `claude/*`, and merged fix branches after confirming no unpushed work — no deps — **Claude Code or developer**
-- [ ] **Add twilio to package.json or remove Twilio path** — if leads feature is kept: `npm install twilio` (human approval required per AGENTS.md); if deleted: remove twilioService.js and references — depends on leads.js decision
+- [ ] **Add twilio to package.json or remove Twilio path** — optional SMS alert follow-up; current code fails gracefully when `twilio` is unavailable — no longer blocks lead route mounting
 - [ ] **Resolve broken county links** — homepage links `/wv/hampshire-county`, `/wv/hardy-county`, `/wv/morgan-county`, and other county paths, but no static pages or Express route exists; decide whether to create county pages or replace links with listing filters — no deps
 - [ ] **Phase 1: Document Registry spec** — ChatGPT delivers schema, approval state machine, AI extraction JSON contract — no code deps — **ChatGPT**
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -29,11 +29,11 @@ Full repository audit per Malickland 2.0 Unified Engineering Operating Prompt. C
 - No new security issues introduced (documentation-only changes)
 - Confirmed: 0 npm audit vulnerabilities
 - Confirmed: CORS without origin restriction on public API — acceptable, tracked
-- Confirmed: `leads.js` correctly unmounted (would crash on require if mounted)
+- Updated 2026-06-01: `leads.js` is mounted after adding a local-safe `googleSheets.js` adapter and server-side lead guards.
 
 ### Remaining Risks
 1. **CRITICAL — Test suite broken**: 14+ tests fail. Tests assert against server.js for code now in routes/api.js and routes/admin.js. CI gate `verify-security-fixes.test.js` is not catching regressions. This is the #1 quality risk.
-2. **HIGH — leads.js unmounted with broken deps**: `services/googleSheets.js` does not exist. Decision needed: implement or delete.
+2. **RESOLVED 2026-06-01 — leads.js unmounted with broken deps**: `services/googleSheets.js` now exists as a no-op adapter; `/api/leads` is mounted behind JSON and same-origin guards.
 3. **MEDIUM — Local branch stale**: `fix/hook-npm-save-patterns` is superseded by merged PR #68. Next work should start from `main`.
 4. **MEDIUM — Services layer undocumented in docs/agent-handoff.md**: email, Twilio, leadFollowupWorker added after last handoff update.
 5. **LOW — 73 remote branches**: many stale copilot/* and claude/* branches add noise.
@@ -41,7 +41,7 @@ Full repository audit per Malickland 2.0 Unified Engineering Operating Prompt. C
 
 ### Recommended Next Task
 ~~Fix test suite~~ — COMPLETED in this session (see below).
-Next: resolve leads.js (see entry below).
+Next: wire real Google Sheets append support only if that integration is needed.
 
 ---
 
@@ -96,7 +96,7 @@ PR #73 correction pass: fix documentation accuracy issues and eliminate CodeQL f
 1. **BLOCKER (merge) — 0 human approvals**: enforce_admins: true; PR author is malickland-304 (cannot self-approve); requires a second GitHub account with write access to approve
 2. **BLOCKER (merge) — review threads**: 16 bot-generated review threads must be resolved before merge (required_conversation_resolution: true)
 3. **BLOCKER (merge) — CodeQL GHAS result**: previous lgtm-based fix was ineffective; regex rewrite pushed in this session is the correct fix — result pending CI completion
-4. **HIGH — leads.js unmounted**: decision still needed (implement googleSheets.js + add twilio, or delete)
+4. **RESOLVED 2026-06-01 — leads.js unmounted**: mounted with a local-safe Google Sheets adapter; Twilio remains optional/fail-graceful
 5. **MEDIUM — services layer undocumented**: docs/agent-handoff.md not yet updated for email.js, twilioService.js, leadFollowupWorker.js
 
 ### Recommended Next Task

--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -50,7 +50,20 @@ router.get('/sitemap.xml', publicReadRateLimit, (_req, res) => {
     }));
   } catch (_) {}
 
-  const allPages = [...staticPages, ...propertyPages];
+  // County landing pages — only counties with active listings (avoids thin-content pages).
+  let countyPages = [];
+  try {
+    const counties = db.prepare(
+      "SELECT DISTINCT c.name FROM counties c JOIN properties p ON p.county_id = c.id WHERE p.status = 'active'"
+    ).all();
+    countyPages = counties.map(c => ({
+      loc:        SITE + '/wv/' + c.name.toLowerCase().replace(/\s+/g, '-') + '-county',
+      changefreq: 'weekly',
+      priority:   '0.7',
+    }));
+  } catch (_) {}
+
+  const allPages = [...staticPages, ...countyPages, ...propertyPages];
   const xml = [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
@@ -113,6 +126,32 @@ router.get(['/listing/:id', '/properties/:id'], publicReadRateLimit, (_req, res)
 
 router.get('/advent-drive-land-hampshire-county-wv', publicReadRateLimit, (_req, res) => {
   res.redirect(301, '/37-advent');
+});
+
+// County landing pages: /wv/<county>-county → server-rendered page listing that county's
+// active properties. Slug is validated against the counties table; unknown → 404 handler.
+router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {
+  const name = String(req.params.slug || '')
+    .toLowerCase()
+    .replace(/-county$/, '')
+    .replace(/-/g, ' ')
+    .trim();
+  if (!name) return next();
+
+  const county = db.prepare('SELECT id, name FROM counties WHERE LOWER(name) = ?').get(name);
+  if (!county) return next();  // unknown county → falls through to the site 404 page
+
+  const slug = county.name.toLowerCase().replace(/\s+/g, '-') + '-county';
+  try {
+    const html = fs.readFileSync(path.join(PROJECT_ROOT, 'app', 'county.html'), 'utf8')
+      .replaceAll('{{COUNTY_NAME}}', county.name)
+      .replaceAll('{{COUNTY_ID}}', String(county.id))
+      .replaceAll('{{COUNTY_SLUG}}', slug)
+      .replaceAll('{{DISCLOSURE}}', HOMEPAGE_DISCLOSURE);
+    res.type('html').send(html);
+  } catch (err) {
+    next(err);
+  }
 });
 
 module.exports = router;

--- a/api/server.js
+++ b/api/server.js
@@ -16,6 +16,7 @@ const BetterSqlite3Store = require('better-sqlite3-session-store')(session);
 const { db }             = require('./db');
 const adminRoutes  = require('./routes/admin');
 const apiRoutes    = require('./routes/api');
+const createLeadsRouter = require('./routes/leads');
 const publicRoutes = require('./routes/public');
 
 const app  = express();
@@ -34,6 +35,53 @@ if (!SESSION_SECRET) {
 }
 if (!process.env.ADMIN_PASSWORD) {
   throw new Error('ADMIN_PASSWORD must be set');
+}
+
+function expectedLeadOrigins(req) {
+  const origins = new Set([`${req.protocol}://${req.get('host')}`]);
+
+  for (const origin of [process.env.SITE_URL, ...corsAllowlist]) {
+    if (!origin) continue;
+    try {
+      origins.add(new URL(origin).origin);
+    } catch (_) {}
+  }
+
+  return origins;
+}
+
+function requireLeadSameOrigin(req, res, next) {
+  if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') {
+    return next();
+  }
+
+  const header = req.get('origin') || req.get('referer');
+  if (!header) {
+    return res.status(403).json({ error: 'Lead request origin is required.' });
+  }
+
+  let origin;
+  try {
+    origin = new URL(header).origin;
+  } catch (_) {
+    return res.status(403).json({ error: 'Invalid lead request origin.' });
+  }
+
+  if (!expectedLeadOrigins(req).has(origin)) {
+    return res.status(403).json({ error: 'Lead request origin is not allowed.' });
+  }
+
+  return next();
+}
+
+function requireLeadJson(req, res, next) {
+  if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') {
+    return next();
+  }
+  if (!req.is('application/json')) {
+    return res.status(415).json({ error: 'Lead requests must use application/json.' });
+  }
+  return next();
 }
 
 const gmailConfigured =
@@ -107,6 +155,8 @@ app.use('/admin', cookieParser(), adminSession, (req, res, next) => {
   if (req.path === '/login') return next();
   return doubleCsrfProtection(req, res, next);
 }, adminRoutes);
+app.use('/api/contacts', requireLeadJson, requireLeadSameOrigin);
+app.use('/api/leads', requireLeadJson, requireLeadSameOrigin, createLeadsRouter({ db }));
 app.use('/api',   apiRoutes);
 app.use('/',      publicRoutes);
 

--- a/api/services/googleSheets.js
+++ b/api/services/googleSheets.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function isLeadCaptureConfigured() {
+  return false;
+}
+
+async function append37AdventLead() {
+  return false;
+}
+
+async function appendPropertyLead() {
+  return false;
+}
+
+module.exports = {
+  append37AdventLead,
+  appendPropertyLead,
+  isLeadCaptureConfigured,
+};

--- a/app/county.html
+++ b/app/county.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{COUNTY_NAME}} County, WV — Land &amp; Property for Sale | MalickLand</title>
+  <meta name="description" content="Browse land, homes, farms and acreage for sale in {{COUNTY_NAME}} County, West Virginia. Local WV real estate from MalickLand — Phil Malick, agent." />
+  <link rel="canonical" href="https://malickland.net/wv/{{COUNTY_SLUG}}" />
+  <meta property="og:title" content="{{COUNTY_NAME}} County, WV — Land &amp; Property for Sale | MalickLand" />
+  <meta property="og:description" content="Land, homes, farms and acreage for sale in {{COUNTY_NAME}} County, West Virginia." />
+  <meta property="og:url" content="https://malickland.net/wv/{{COUNTY_SLUG}}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://malickland.net/public/brand/og-image.jpg" />
+  <!-- Analytics — loaded from /api/config -->
+  <script>
+    fetch('/api/config').then(r=>r.json()).then(cfg=>{
+      if (cfg.gaId) {
+        var s = document.createElement('script');
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=' + cfg.gaId;
+        s.async = true; document.head.appendChild(s);
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function(){dataLayer.push(arguments);};
+        gtag('js', new Date()); gtag('config', cfg.gaId);
+      }
+      if (cfg.pixelId) {
+        !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+        n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}
+        (window,document,'script','https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', cfg.pixelId); fbq('track', 'PageView');
+      }
+    }).catch(()=>{});
+  </script>
+  <link rel="icon" type="image/png" sizes="32x32" href="/public/brand/favicon.png" />
+  <link rel="apple-touch-icon" href="/public/brand/favicon.png" />
+  <link rel="stylesheet" href="/styles.css" />
+  <!-- Schema: county-scoped RealEstateAgent service area -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "RealEstateAgent",
+    "name": "MalickLand",
+    "url": "https://malickland.net/wv/{{COUNTY_SLUG}}",
+    "telephone": "(540) 246-1421",
+    "areaServed": { "@type": "AdministrativeArea", "name": "{{COUNTY_NAME}} County, West Virginia" },
+    "address": { "@type": "PostalAddress", "streetAddress": "501 East Main Street", "addressLocality": "Romney", "addressRegion": "WV", "postalCode": "26757", "addressCountry": "US" }
+  }
+  </script>
+  <style>
+    * { margin:0; padding:0; box-sizing:border-box; }
+    body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+      color:#1a1a1a; background:#f6f7f5; min-height:100vh; display:flex; flex-direction:column; }
+
+    /* NAVBAR */
+    .navbar { display:flex; justify-content:space-between; align-items:center;
+      background:#1B4332; padding:.75rem 2rem; position:sticky; top:0; z-index:100;
+      box-shadow:0 2px 8px rgba(0,0,0,.25); }
+    .logo { display:flex; align-items:center; gap:.6rem; text-decoration:none;
+      color:#D4AF37; font-size:1.15rem; font-weight:700; letter-spacing:.5px; }
+    .logo img { height:38px; width:auto; }
+    .nav-links { list-style:none; display:flex; gap:1.25rem; }
+    .nav-links a { color:#fff; text-decoration:none; font-size:.88rem; font-weight:500; }
+    .nav-links a:hover { color:#D4AF37; }
+
+    /* HERO */
+    .county-hero { background:linear-gradient(135deg,#1B4332 0%,#2d5c42 60%,#1a3a2a 100%);
+      padding:2.5rem 2rem 2rem; text-align:center; }
+    .county-hero .breadcrumb { color:rgba(255,255,255,.6); font-size:.8rem; margin-bottom:.6rem; }
+    .county-hero .breadcrumb a { color:rgba(255,255,255,.75); text-decoration:none; }
+    .county-hero .breadcrumb a:hover { color:#D4AF37; }
+    .county-hero h1 { color:#D4AF37; font-size:1.9rem; margin-bottom:.4rem; }
+    .county-hero p.sub { color:rgba(255,255,255,.8); font-size:.98rem; max-width:640px; margin:0 auto; }
+    .hero-disclosure { font-size:.82rem; color:rgba(255,255,255,.88); line-height:1.55;
+      max-width:680px; margin:1.1rem auto 0; }
+
+    /* RESULTS BAR */
+    .results-bar { padding:1rem 2rem .25rem; font-size:.9rem; color:#4b5563; font-weight:600;
+      max-width:1400px; margin:0 auto; width:100%; }
+
+    /* GRID */
+    #listings { padding:.5rem 2rem 2rem; max-width:1400px; margin:0 auto; flex:1; width:100%; }
+    .listings-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:1.25rem; }
+    .skeleton { background:#e5e7eb; border-radius:10px; height:320px; animation:shimmer 1.4s infinite; }
+    @keyframes shimmer { 0%,100%{opacity:.6;} 50%{opacity:1;} }
+
+    /* EMPTY STATE */
+    .empty-state { text-align:center; padding:2.5rem 1rem; max-width:620px; margin:0 auto; }
+    .empty-state p { color:#374151; font-size:1.05rem; line-height:1.7; margin-bottom:1.25rem; }
+    .cta-btn { display:inline-block; background:#1B4332; color:#D4AF37; text-decoration:none;
+      padding:.7rem 1.4rem; border-radius:8px; font-weight:700; }
+    .cta-btn:hover { background:#2d5c42; }
+    .empty-state a.alt { color:#1B4332; font-weight:600; text-decoration:underline; margin-left:.5rem; }
+
+    /* FOOTER */
+    footer { background:#1B4332; color:#fff; text-align:center; padding:1.5rem 2rem; font-size:.82rem; margin-top:auto; }
+    footer a { color:#D4AF37; text-decoration:none; }
+    footer .disclosure { opacity:.85; line-height:1.6; margin-top:.5rem; font-size:.78rem; }
+
+    @media (max-width:768px) {
+      .navbar { padding:.65rem 1rem; }
+      .nav-links { gap:.75rem; }
+      .county-hero h1 { font-size:1.45rem; }
+      #listings { padding:.5rem 1rem 1.5rem; }
+      .results-bar { padding:.85rem 1rem .2rem; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- NAVBAR -->
+<nav class="navbar">
+  <a href="/" class="logo">
+    <img src="/public/brand/icon-mark.png" alt="MalickLand" onerror="this.style.display='none'" />
+    MalickLand
+  </a>
+  <ul class="nav-links">
+    <li><a href="/">Home</a></li>
+    <li><a href="/listings">Search</a></li>
+    <li><a href="/#contact-form">Contact</a></li>
+    <li><a href="tel:+15402461421">📞 (540) 246-1421</a></li>
+  </ul>
+</nav>
+
+<!-- HERO (broker disclosure is first-screen, per WV advertising rule) -->
+<div class="county-hero">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/listings">Listings</a> › {{COUNTY_NAME}} County</div>
+  <h1>🌲 {{COUNTY_NAME}} County, West Virginia</h1>
+  <p class="sub">Land, homes, farms &amp; rural property for sale in {{COUNTY_NAME}} County, WV. Local expertise from MalickLand — Phil Malick, agent.</p>
+  <p class="hero-disclosure" aria-label="Brokerage disclosure">{{DISCLOSURE}}</p>
+</div>
+
+<!-- RESULTS -->
+<div class="results-bar"><span id="resultsCount">Loading {{COUNTY_NAME}} County listings…</span></div>
+
+<!-- LISTINGS -->
+<div id="listings">
+  <div class="listings-grid" id="listingsGrid">
+    <div class="skeleton"></div><div class="skeleton"></div><div class="skeleton"></div>
+  </div>
+  <div class="empty-state" id="emptyState" style="display:none">
+    <p>We don't have active listings in <strong>{{COUNTY_NAME}} County</strong> right now — but new West Virginia land and property come up often. Tell us what you're looking for and we'll reach out when something fits.</p>
+    <p>
+      <a href="/#contact-form" class="cta-btn">Get notified about {{COUNTY_NAME}} County →</a>
+      <a href="/listings" class="alt">Browse all listings</a>
+    </p>
+  </div>
+</div>
+
+<!-- FOOTER -->
+<footer>
+  <p><strong style="color:#D4AF37">MalickLand</strong> · Phil Malick, Agent
+    &nbsp;·&nbsp; <a href="tel:+15402461421">(540) 246-1421</a>
+    &nbsp;·&nbsp; <a href="mailto:phil@malickland.net">phil@malickland.net</a></p>
+  <p class="disclosure">{{DISCLOSURE}} · Licensed in West Virginia &nbsp;·&nbsp; © 2026 MalickLand</p>
+</footer>
+
+<div id="countyData" data-id="{{COUNTY_ID}}" data-name="{{COUNTY_NAME}}" hidden></div>
+<script>
+(function(){
+  const data = document.getElementById('countyData');
+  const countyId = data.dataset.id;
+  const countyName = data.dataset.name;
+  const grid = document.getElementById('listingsGrid');
+  const countEl = document.getElementById('resultsCount');
+  const empty = document.getElementById('emptyState');
+
+  const escapeHtml = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  const timeAgo = d => { const n = Math.floor((Date.now() - new Date(d)) / 86400000); return n <= 0 ? 'today' : n === 1 ? 'yesterday' : n + ' days ago'; };
+  window.openPropertyPage = slug => { window.location.href = '/properties/' + encodeURIComponent(slug); };
+
+  const card = p => `
+    <div class="property-card" onclick="openPropertyPage(${JSON.stringify(p.listing_slug || p.id)})">
+      <div class="card-img" style="background-image:url('${escapeHtml(p.image_url || 'https://placehold.co/400x240/1a3a2a/gold?text=No+Photo')}')">
+        ${p.price_reduced ? '<span class="badge reduced">Price Reduced</span>' : ''}
+        <span class="badge type">${escapeHtml(p.property_type)}</span>
+      </div>
+      <div class="card-body">
+        <div class="card-price">${p.price != null ? '$' + Number(p.price).toLocaleString() : 'Contact for price'}</div>
+        <div class="card-address">${escapeHtml(p.address)}${p.city ? ', ' + escapeHtml(p.city) : ''}</div>
+        <div class="card-county">${escapeHtml(p.county)} County${p.zip ? ' · ' + escapeHtml(p.zip) : ''}</div>
+        <div class="card-details">
+          ${p.bedrooms ? `<span>🛏 ${escapeHtml(p.bedrooms)} bd</span>` : ''}
+          ${p.bathrooms ? `<span>🚿 ${escapeHtml(p.bathrooms)} ba</span>` : ''}
+          ${p.sqft ? `<span>📐 ${Number(p.sqft).toLocaleString()} sqft</span>` : ''}
+          ${p.lot_acres ? `<span>🌿 ${escapeHtml(p.lot_acres)} ac</span>` : ''}
+        </div>
+        <div class="card-listed">Listed ${timeAgo(p.listed_at)}</div>
+        <button class="request-info-btn" onclick="event.stopPropagation();openPropertyPage(${JSON.stringify(p.listing_slug || p.id)})">View Details</button>
+      </div>
+    </div>`;
+
+  fetch('/api/properties?county=' + encodeURIComponent(countyId) + '&limit=24')
+    .then(r => r.json())
+    .then(d => {
+      const props = d.properties || [];
+      if (!props.length) {
+        grid.style.display = 'none';
+        empty.style.display = 'block';
+        countEl.textContent = 'No active listings in ' + countyName + ' County right now.';
+        return;
+      }
+      grid.innerHTML = props.map(card).join('');
+      countEl.textContent = d.total + ' active listing' + (d.total === 1 ? '' : 's') + ' in ' + countyName + ' County';
+    })
+    .catch(() => {
+      grid.innerHTML = '<p style="grid-column:1/-1;color:#b91c1c">Could not load listings. Please call (540) 246-1421.</p>';
+      countEl.textContent = '';
+    });
+})();
+</script>
+</body>
+</html>

--- a/app/index.html
+++ b/app/index.html
@@ -1294,15 +1294,15 @@
   <div style="max-width:1200px;margin:0 auto">
     <p style="text-align:center;font-size:.8rem;color:#6b7280;margin-bottom:.85rem;text-transform:uppercase;letter-spacing:.5px;font-weight:600">Browse by County</p>
     <div style="display:flex;flex-wrap:wrap;gap:.5rem;justify-content:center">
-      <a href="/listings?county=Hampshire" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hampshire</a>
-      <a href="/listings?county=Hardy" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hardy</a>
-      <a href="/listings?county=Morgan" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Morgan</a>
-      <a href="/listings?county=Grant" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Grant</a>
-      <a href="/listings?county=Pendleton" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Pendleton</a>
-      <a href="/listings?county=Mineral" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Mineral</a>
-      <a href="/listings?county=Tucker" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Tucker</a>
-      <a href="/listings?county=Berkeley" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Berkeley</a>
-      <a href="/listings?county=Jefferson" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Jefferson</a>
+      <a href="/wv/hampshire-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hampshire</a>
+      <a href="/wv/hardy-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Hardy</a>
+      <a href="/wv/morgan-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Morgan</a>
+      <a href="/wv/grant-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Grant</a>
+      <a href="/wv/pendleton-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Pendleton</a>
+      <a href="/wv/mineral-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Mineral</a>
+      <a href="/wv/tucker-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Tucker</a>
+      <a href="/wv/berkeley-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Berkeley</a>
+      <a href="/wv/jefferson-county" style="background:#fff;border:1px solid #d1d5db;color:#1B4332;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:600;text-decoration:none">Jefferson</a>
       <a href="/listings" style="background:#1B4332;border:1px solid #1B4332;color:#D4AF37;padding:.35rem .85rem;border-radius:20px;font-size:.8rem;font-weight:700;text-decoration:none">All Counties →</a>
     </div>
   </div>

--- a/tests/verify-security-fixes.test.js
+++ b/tests/verify-security-fixes.test.js
@@ -39,6 +39,7 @@ const helpersPath      = path.join(PROJECT_ROOT, 'api/helpers.js');
 const agentsPath       = path.join(PROJECT_ROOT, 'AGENTS.md');
 const appJsPath        = path.join(PROJECT_ROOT, 'app/app.js');
 const googleJsPath     = path.join(PROJECT_ROOT, 'api/google.js');
+const googleSheetsPath = path.join(PROJECT_ROOT, 'api/services/googleSheets.js');
 const validatorsPath   = path.join(PROJECT_ROOT, 'api/utils/validators.js');
 
 const serverCode       = fs.readFileSync(serverPath, 'utf8');
@@ -335,6 +336,25 @@ test('contacts route uses contactsRateLimit in routes/api.js', () => {
   const routeLine = apiRoutesCode.split('\n').find(l => l.includes("router.post('/contacts'"));
   assert(routeLine && routeLine.includes('contactsRateLimit'),
     "POST /contacts is missing contactsRateLimit in routes/api.js");
+});
+
+test('lead routes are mounted behind server-side origin and JSON guards', () => {
+  assert(fs.existsSync(googleSheetsPath),
+    'api/services/googleSheets.js must exist before mounting leads routes');
+  assert(serverCode.includes("require('./routes/leads')"),
+    'server.js should import the leads router');
+  assert(serverCode.includes('function requireLeadSameOrigin'),
+    'server.js should define same-origin protection for lead POSTs');
+  assert(serverCode.includes('function requireLeadJson'),
+    'server.js should require JSON lead POST bodies');
+  assert(
+    /app\.use\(\s*['"]\/api\/leads['"]\s*,\s*requireLeadJson\s*,\s*requireLeadSameOrigin\s*,\s*createLeadsRouter\(\{\s*db\s*\}\)\s*\)/.test(serverCode),
+    'server.js should mount /api/leads behind requireLeadJson and requireLeadSameOrigin'
+  );
+  assert(
+    /app\.use\(\s*['"]\/api\/contacts['"]\s*,\s*requireLeadJson\s*,\s*requireLeadSameOrigin\s*\)/.test(serverCode),
+    'server.js should guard /api/contacts lead submissions behind requireLeadJson and requireLeadSameOrigin'
+  );
 });
 
 test('admin routes use adminActionRateLimit in routes/admin.js', () => {


### PR DESCRIPTION
## Summary
- mount /api/leads behind JSON and same-origin guards
- apply the same public lead guard to /api/contacts submissions
- add a local-safe Google Sheets adapter so lead capture does not crash without external credentials
- update repo state docs that previously said leads were intentionally unmounted

## Verification
- node tests/verify-security-fixes.test.js -> 49/49 passed
- cd api && npm test -> Syntax OK
- node --check api/server.js api/routes/leads.js api/services/googleSheets.js
- PORT=3001 node server.js
- GET /wv/hampshire-county -> 200, disclosure present, no {{ tokens
- GET /wv/grant-county -> 200, rendered empty state present, no {{ tokens
- GET /wv/notreal-county -> 404
- lead/contact guard checks: missing Origin -> 403, non-JSON -> 415, invalid JSON payload with same-origin -> 400

No .env files or secrets included.

## Summary by Sourcery

Harden lead capture endpoints and wire them into the app while adding county landing pages and aligning documentation with the new behavior.

New Features:
- Mount the /api/leads router and guard both /api/leads and /api/contacts with server-side same-origin and JSON-only checks.
- Introduce server-rendered county landing pages with dynamic listings, sitemap entries, and updated homepage links for West Virginia counties.
- Add a local-safe Google Sheets service adapter so lead capture can operate without external sheet credentials.

Bug Fixes:
- Prevent lead and contact submissions from untrusted origins or non-JSON payloads by enforcing strict origin and content-type validation.

Enhancements:
- Extend the public sitemap to include county landing pages only for counties with active listings, reducing thin-content URLs.

Documentation:
- Update architecture, project state, decisions, tasks, and work log documents to reflect that leads are now mounted, guarded, and backed by a stubbed Sheets adapter.