### PR TITLE
fix(api): address lead hardening review followups

### DIFF
--- a/api/db.js
+++ b/api/db.js
@@ -86,10 +86,49 @@ db.exec(`
     source      TEXT DEFAULT 'web',
     created_at  TEXT NOT NULL DEFAULT (datetime('now'))
   );
+  CREATE TABLE IF NOT EXISTS leads (
+    id                TEXT PRIMARY KEY,
+    property_id       TEXT REFERENCES properties(id) ON DELETE SET NULL,
+    property_slug     TEXT,
+    property_address  TEXT,
+    name              TEXT NOT NULL,
+    email             TEXT,
+    phone             TEXT,
+    lead_type         TEXT NOT NULL,
+    buyer_intent      TEXT,
+    financing_type    TEXT,
+    timeline          TEXT,
+    message           TEXT,
+    sms_consent       INTEGER NOT NULL DEFAULT 0,
+    source            TEXT DEFAULT 'property-lead',
+    utm_source        TEXT,
+    utm_medium        TEXT,
+    utm_campaign      TEXT,
+    status            TEXT NOT NULL DEFAULT 'new',
+    follow_up_status  TEXT NOT NULL DEFAULT 'scheduled',
+    next_follow_up_at TEXT,
+    created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS lead_followups (
+    id            TEXT PRIMARY KEY,
+    lead_id       TEXT NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+    step_code     TEXT NOT NULL,
+    channel       TEXT NOT NULL,
+    template_name TEXT NOT NULL,
+    subject       TEXT NOT NULL,
+    body          TEXT NOT NULL,
+    due_at        TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    sent_at       TEXT
+  );
   CREATE INDEX IF NOT EXISTS idx_properties_county ON properties(county_id);
   CREATE INDEX IF NOT EXISTS idx_properties_status ON properties(status);
   CREATE INDEX IF NOT EXISTS idx_properties_type   ON properties(property_type);
   CREATE INDEX IF NOT EXISTS idx_properties_price  ON properties(price);
+  CREATE INDEX IF NOT EXISTS idx_leads_status ON leads(status);
+  CREATE INDEX IF NOT EXISTS idx_lead_followups_due ON lead_followups(status, due_at);
 `);
 
 // Seed counties

--- a/api/db.js
+++ b/api/db.js
@@ -128,6 +128,7 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_properties_type   ON properties(property_type);
   CREATE INDEX IF NOT EXISTS idx_properties_price  ON properties(price);
   CREATE INDEX IF NOT EXISTS idx_leads_status ON leads(status);
+  CREATE INDEX IF NOT EXISTS idx_lead_followups_lead_due ON lead_followups(lead_id, due_at);
   CREATE INDEX IF NOT EXISTS idx_lead_followups_due ON lead_followups(status, due_at);
 `);
 

--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -10,7 +10,14 @@ const { publicReadRateLimit } = require('../middleware/rate-limits');
 
 const router = express.Router();
 const HOMEPAGE_DISCLOSURE = 'WV Real Estate Agency, LLC | Sheila Judy, Broker | 501 East Main Street, Romney, WV 26757 | (540) 246-1421';
-const COUNTY_TEMPLATE = fs.readFileSync(path.join(PROJECT_ROOT, 'app', 'county.html'), 'utf8');
+let countyTemplate = null;
+
+function getCountyTemplate() {
+  if (countyTemplate == null) {
+    countyTemplate = fs.readFileSync(path.join(PROJECT_ROOT, 'app', 'county.html'), 'utf8');
+  }
+  return countyTemplate;
+}
 
 function replaceHomepageContent(html, search, replacement) {
   if (!html.includes(search)) {
@@ -144,10 +151,10 @@ router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {
 
   const slug = county.name.toLowerCase().replace(/\s+/g, '-') + '-county';
   try {
-    const html = COUNTY_TEMPLATE
+    const html = getCountyTemplate()
       .replaceAll('{{COUNTY_NAME}}', esc(county.name))
       .replaceAll('{{COUNTY_ID}}', String(county.id))
-      .replaceAll('{{COUNTY_SLUG}}', slug)
+      .replaceAll('{{COUNTY_SLUG}}', esc(slug))
       .replaceAll('{{DISCLOSURE}}', esc(HOMEPAGE_DISCLOSURE));
     res.type('html').send(html);
   } catch (err) {

--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -5,11 +5,12 @@ const path    = require('path');
 const fs      = require('fs');
 
 const { db }           = require('../db');
-const { PROJECT_ROOT } = require('../helpers');
+const { PROJECT_ROOT, esc } = require('../helpers');
 const { publicReadRateLimit } = require('../middleware/rate-limits');
 
 const router = express.Router();
 const HOMEPAGE_DISCLOSURE = 'WV Real Estate Agency, LLC | Sheila Judy, Broker | 501 East Main Street, Romney, WV 26757 | (540) 246-1421';
+const COUNTY_TEMPLATE = fs.readFileSync(path.join(PROJECT_ROOT, 'app', 'county.html'), 'utf8');
 
 function replaceHomepageContent(html, search, replacement) {
   if (!html.includes(search)) {
@@ -143,11 +144,11 @@ router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {
 
   const slug = county.name.toLowerCase().replace(/\s+/g, '-') + '-county';
   try {
-    const html = fs.readFileSync(path.join(PROJECT_ROOT, 'app', 'county.html'), 'utf8')
-      .replaceAll('{{COUNTY_NAME}}', county.name)
+    const html = COUNTY_TEMPLATE
+      .replaceAll('{{COUNTY_NAME}}', esc(county.name))
       .replaceAll('{{COUNTY_ID}}', String(county.id))
       .replaceAll('{{COUNTY_SLUG}}', slug)
-      .replaceAll('{{DISCLOSURE}}', HOMEPAGE_DISCLOSURE);
+      .replaceAll('{{DISCLOSURE}}', esc(HOMEPAGE_DISCLOSURE));
     res.type('html').send(html);
   } catch (err) {
     next(err);

--- a/api/services/googleSheets.js
+++ b/api/services/googleSheets.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function isLeadCaptureConfigured() {
-  return false;
+  return Boolean(process.env.GOOGLE_SHEETS_ID || process.env.GOOGLE_SHEET_ID);
 }
 
 async function append37AdventLead() {

--- a/app/county.html
+++ b/app/county.html
@@ -91,6 +91,7 @@
       padding:.7rem 1.4rem; border-radius:8px; font-weight:700; }
     .cta-btn:hover { background:#2d5c42; }
     .empty-state a.alt { color:#1B4332; font-weight:600; text-decoration:underline; margin-left:.5rem; }
+    .card-img img { display:block; width:100%; height:100%; object-fit:cover; }
 
     /* FOOTER */
     footer { background:#1B4332; color:#fff; text-align:center; padding:1.5rem 2rem; font-size:.82rem; margin-top:auto; }
@@ -166,8 +167,22 @@
   const empty = document.getElementById('emptyState');
 
   const escapeHtml = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  const placeholderImage = 'https://placehold.co/400x240/1a3a2a/gold?text=No+Photo';
+  const safeImageUrl = value => {
+    const raw = String(value ?? '').trim();
+    if (!raw || /[\u0000-\u001f"'<>]/.test(raw)) return placeholderImage;
+    if (raw.startsWith('/')) return raw;
+    try {
+      const url = new URL(raw);
+      return ['http:', 'https:'].includes(url.protocol) ? url.href : placeholderImage;
+    } catch (_) {
+      return placeholderImage;
+    }
+  };
   const timeAgo = d => {
-    const date = new Date(d);
+    if (!d) return 'recently';
+    const normalized = typeof d === 'string' ? d.replace(' ', 'T') + 'Z' : d;
+    const date = new Date(normalized);
     if (Number.isNaN(date.getTime())) return 'recently';
     const n = Math.floor((Date.now() - date.getTime()) / 86400000);
     return n <= 0 ? 'today' : n === 1 ? 'yesterday' : n + ' days ago';
@@ -177,12 +192,14 @@
   grid.addEventListener('click', event => {
     const cardEl = event.target.closest('.property-card');
     if (!cardEl || !grid.contains(cardEl)) return;
-    openPropertyPage(cardEl.dataset.slug || '');
+    if (!cardEl.dataset.slug) return;
+    openPropertyPage(cardEl.dataset.slug);
   });
 
   const card = p => `
     <div class="property-card" data-slug="${escapeHtml(p.listing_slug || p.id)}">
-      <div class="card-img" style="background-image:url('${escapeHtml(p.image_url || 'https://placehold.co/400x240/1a3a2a/gold?text=No+Photo')}')">
+      <div class="card-img">
+        <img src="${escapeHtml(safeImageUrl(p.image_url))}" alt="${escapeHtml(p.address || 'Property photo')}" loading="lazy">
         ${p.price_reduced ? '<span class="badge reduced">Price Reduced</span>' : ''}
         <span class="badge type">${escapeHtml(p.property_type)}</span>
       </div>

--- a/app/county.html
+++ b/app/county.html
@@ -166,11 +166,22 @@
   const empty = document.getElementById('emptyState');
 
   const escapeHtml = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
-  const timeAgo = d => { const n = Math.floor((Date.now() - new Date(d)) / 86400000); return n <= 0 ? 'today' : n === 1 ? 'yesterday' : n + ' days ago'; };
-  window.openPropertyPage = slug => { window.location.href = '/properties/' + encodeURIComponent(slug); };
+  const timeAgo = d => {
+    const date = new Date(d);
+    if (Number.isNaN(date.getTime())) return 'recently';
+    const n = Math.floor((Date.now() - date.getTime()) / 86400000);
+    return n <= 0 ? 'today' : n === 1 ? 'yesterday' : n + ' days ago';
+  };
+  const openPropertyPage = slug => { window.location.href = '/properties/' + encodeURIComponent(slug); };
+
+  grid.addEventListener('click', event => {
+    const cardEl = event.target.closest('.property-card');
+    if (!cardEl || !grid.contains(cardEl)) return;
+    openPropertyPage(cardEl.dataset.slug || '');
+  });
 
   const card = p => `
-    <div class="property-card" onclick="openPropertyPage(${JSON.stringify(p.listing_slug || p.id)})">
+    <div class="property-card" data-slug="${escapeHtml(p.listing_slug || p.id)}">
       <div class="card-img" style="background-image:url('${escapeHtml(p.image_url || 'https://placehold.co/400x240/1a3a2a/gold?text=No+Photo')}')">
         ${p.price_reduced ? '<span class="badge reduced">Price Reduced</span>' : ''}
         <span class="badge type">${escapeHtml(p.property_type)}</span>
@@ -186,7 +197,7 @@
           ${p.lot_acres ? `<span>🌿 ${escapeHtml(p.lot_acres)} ac</span>` : ''}
         </div>
         <div class="card-listed">Listed ${timeAgo(p.listed_at)}</div>
-        <button class="request-info-btn" onclick="event.stopPropagation();openPropertyPage(${JSON.stringify(p.listing_slug || p.id)})">View Details</button>
+        <button class="request-info-btn" type="button">View Details</button>
       </div>
     </div>`;
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -129,4 +129,5 @@ CREATE INDEX IF NOT EXISTS idx_properties_status ON properties(status);
 CREATE INDEX IF NOT EXISTS idx_properties_type   ON properties(property_type);
 CREATE INDEX IF NOT EXISTS idx_properties_price  ON properties(price);
 CREATE INDEX IF NOT EXISTS idx_leads_status ON leads(status);
+CREATE INDEX IF NOT EXISTS idx_lead_followups_lead_due ON lead_followups(lead_id, due_at);
 CREATE INDEX IF NOT EXISTS idx_lead_followups_due ON lead_followups(status, due_at);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -79,6 +79,45 @@ CREATE TABLE IF NOT EXISTS contacts (
   created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS leads (
+  id                TEXT PRIMARY KEY,
+  property_id       TEXT REFERENCES properties(id) ON DELETE SET NULL,
+  property_slug     TEXT,
+  property_address  TEXT,
+  name              TEXT NOT NULL,
+  email             TEXT,
+  phone             TEXT,
+  lead_type         TEXT NOT NULL,
+  buyer_intent      TEXT,
+  financing_type    TEXT,
+  timeline          TEXT,
+  message           TEXT,
+  sms_consent       INTEGER NOT NULL DEFAULT 0,
+  source            TEXT DEFAULT 'property-lead',
+  utm_source        TEXT,
+  utm_medium        TEXT,
+  utm_campaign      TEXT,
+  status            TEXT NOT NULL DEFAULT 'new',
+  follow_up_status  TEXT NOT NULL DEFAULT 'scheduled',
+  next_follow_up_at TEXT,
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS lead_followups (
+  id            TEXT PRIMARY KEY,
+  lead_id       TEXT NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+  step_code     TEXT NOT NULL,
+  channel       TEXT NOT NULL,
+  template_name TEXT NOT NULL,
+  subject       TEXT NOT NULL,
+  body          TEXT NOT NULL,
+  due_at        TEXT NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'pending',
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  sent_at       TEXT
+);
+
 CREATE TABLE IF NOT EXISTS sessions (
   sid    TEXT NOT NULL PRIMARY KEY,
   sess   JSON NOT NULL,
@@ -89,3 +128,5 @@ CREATE INDEX IF NOT EXISTS idx_properties_county ON properties(county_id);
 CREATE INDEX IF NOT EXISTS idx_properties_status ON properties(status);
 CREATE INDEX IF NOT EXISTS idx_properties_type   ON properties(property_type);
 CREATE INDEX IF NOT EXISTS idx_properties_price  ON properties(price);
+CREATE INDEX IF NOT EXISTS idx_leads_status ON leads(status);
+CREATE INDEX IF NOT EXISTS idx_lead_followups_due ON lead_followups(status, due_at);

--- a/tests/verify-security-fixes.test.js
+++ b/tests/verify-security-fixes.test.js
@@ -35,6 +35,8 @@ const serverPath       = path.join(PROJECT_ROOT, 'api/server.js');
 const apiRoutesPath    = path.join(PROJECT_ROOT, 'api/routes/api.js');
 const adminRoutesPath  = path.join(PROJECT_ROOT, 'api/routes/admin.js');
 const publicRoutesPath = path.join(PROJECT_ROOT, 'api/routes/public.js');
+const dbPath           = path.join(PROJECT_ROOT, 'api/db.js');
+const schemaPath       = path.join(PROJECT_ROOT, 'database/schema.sql');
 const helpersPath      = path.join(PROJECT_ROOT, 'api/helpers.js');
 const agentsPath       = path.join(PROJECT_ROOT, 'AGENTS.md');
 const appJsPath        = path.join(PROJECT_ROOT, 'app/app.js');
@@ -46,6 +48,8 @@ const serverCode       = fs.readFileSync(serverPath, 'utf8');
 const apiRoutesCode    = fs.readFileSync(apiRoutesPath, 'utf8');
 const adminRoutesCode  = fs.readFileSync(adminRoutesPath, 'utf8');
 const publicRoutesCode = fs.readFileSync(publicRoutesPath, 'utf8');
+const dbCode           = fs.readFileSync(dbPath, 'utf8');
+const schemaCode       = fs.readFileSync(schemaPath, 'utf8');
 const helpersCode      = fs.readFileSync(helpersPath, 'utf8');
 const agentsCode       = fs.existsSync(agentsPath) ? fs.readFileSync(agentsPath, 'utf8') : '';
 const appJsCode        = fs.existsSync(appJsPath) ? fs.readFileSync(appJsPath, 'utf8') : '';
@@ -355,6 +359,15 @@ test('lead routes are mounted behind server-side origin and JSON guards', () => 
     /app\.use\(\s*['"]\/api\/contacts['"]\s*,\s*requireLeadJson\s*,\s*requireLeadSameOrigin\s*\)/.test(serverCode),
     'server.js should guard /api/contacts lead submissions behind requireLeadJson and requireLeadSameOrigin'
   );
+});
+
+test('mounted lead routes have runtime and reference schema tables', () => {
+  for (const code of [dbCode, schemaCode]) {
+    assert(/CREATE TABLE IF NOT EXISTS leads/i.test(code),
+      'leads table must exist in runtime and reference schemas');
+    assert(/CREATE TABLE IF NOT EXISTS lead_followups/i.test(code),
+      'lead_followups table must exist in runtime and reference schemas');
+  }
 });
 
 test('admin routes use adminActionRateLimit in routes/admin.js', () => {

--- a/tests/verify-security-fixes.test.js
+++ b/tests/verify-security-fixes.test.js
@@ -367,6 +367,8 @@ test('mounted lead routes have runtime and reference schema tables', () => {
       'leads table must exist in runtime and reference schemas');
     assert(/CREATE TABLE IF NOT EXISTS lead_followups/i.test(code),
       'lead_followups table must exist in runtime and reference schemas');
+    assert(/CREATE INDEX IF NOT EXISTS idx_lead_followups_lead_due/i.test(code),
+      'lead_followups lead_id due_at index must exist in runtime and reference schemas');
   }
 });
 


### PR DESCRIPTION
## Summary
- add `leads` and `lead_followups` tables to runtime DB initialization and `database/schema.sql`
- cache the county page template and escape server-side county/disclosure substitutions
- remove inline county-card click handlers in favor of delegated `data-slug` navigation
- guard invalid listing dates from rendering `NaN days ago`
- make the Google Sheets adapter report configured state from sheet env presence

## Verification
- `node tests/verify-security-fixes.test.js` -> 50/50 passed
- `cd api && npm test` -> Syntax OK
- `node --check api/server.js api/routes/public.js api/routes/leads.js api/services/googleSheets.js api/db.js`
- temp DB runtime smoke: valid `POST /api/leads/37-advent` -> 201; DB counts `leads=1`, `lead_followups=3`, `contacts=1`
- temp DB HTTP smoke: `GET /wv/hampshire-county` -> 200, disclosure present, no `{{` tokens; `GET /wv/notreal-county` -> 404
- rendered browser smoke: Grant County empty state present, no `{{` tokens

No `.env` files or secrets included.

## Summary by Sourcery

Add lead tracking tables to both runtime and reference schemas, harden county page rendering and navigation, and align configuration and tests around lead capture and security fixes.

New Features:
- Introduce leads and lead_followups tables, including indexes, to support storing lead data and follow-up steps.
- Detect Google Sheets lead capture configuration from environment variables.

Bug Fixes:
- Prevent invalid listing dates from rendering as NaN days ago on county property cards.
- Ensure county page templates escape dynamic county and disclosure content and avoid leaking template tokens in rendered HTML.
- Replace inline property-card click handlers with delegated click handling based on data attributes for safer navigation.

Tests:
- Extend security verification tests to assert the presence of leads and lead_followups tables in both runtime and schema SQL definitions.