### PR TITLE
feat(ai): route listing generator through Vercel AI Gateway

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -39,8 +39,19 @@ NOTIFICATION_EMAIL=phil@malickland.net
 GOOGLE_DRIVE_FOLDER_ID=
 
 # ── AI listing content (optional) ───────────────────────────────────────────────
-# Powers /admin/ai/:id — generates a full marketing package per listing via GPT-4o.
+# Powers /admin/ai/:id — turns a listing into a full marketing package.
 # Cost: ~$0.01–0.03 per generation.
+#
+# Preferred — route through the Vercel AI Gateway for model failover, spend
+# tracking, observability, and one place to cap cost. Get a key from the Vercel
+# dashboard → AI Gateway. When set, this takes precedence over OPENAI_API_KEY.
+AI_GATEWAY_API_KEY=
+# Optional model overrides. Browse slugs: https://ai-gateway.vercel.sh/v1/models
+# Defaults: AI_GATEWAY_MODEL=openai/gpt-5.4  AI_GATEWAY_FALLBACK_MODEL=anthropic/claude-haiku-4.5
+AI_GATEWAY_MODEL=
+AI_GATEWAY_FALLBACK_MODEL=
+#
+# Direct OpenAI — used only when AI_GATEWAY_API_KEY is empty.
 # Get key: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 # Optional model override (defaults to gpt-4o, auto-falls back to gpt-4o-mini on access errors)

--- a/api/ai-generator.js
+++ b/api/ai-generator.js
@@ -14,7 +14,8 @@
  *   - Landing page content
  *   - SMS blast
  *
- * Requires: OPENAI_API_KEY in environment
+ * Requires: AI_GATEWAY_API_KEY (preferred — routes via Vercel AI Gateway) or
+ * OPENAI_API_KEY (direct) in environment
  *
  * Usage:
  *   const { generateListingContent } = require('./ai-generator');
@@ -28,26 +29,78 @@ const path   = require('path');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 
-// ── OpenAI call (no SDK — keeps dependencies minimal) ────────────────────────
+// ── AI provider calls — Vercel AI Gateway or direct OpenAI, no SDK ────────────────────────
 
-function requestOpenAI(messages, model, apiKey) {
-  const body = JSON.stringify({
-    model,
-    messages,
-    temperature: 0.7,
-    max_tokens: 2500,
-    response_format: { type: 'json_object' }
-  });
+const ENDPOINTS = {
+  gateway: { hostname: 'ai-gateway.vercel.sh', path: '/v1/chat/completions' },
+  openai:  { hostname: 'api.openai.com',       path: '/v1/chat/completions' }
+};
+
+const DEFAULT_GATEWAY_MODEL          = 'openai/gpt-5.4';
+const DEFAULT_GATEWAY_FALLBACK_MODEL = 'anthropic/claude-haiku-4.5';
+const DEFAULT_OPENAI_MODEL           = 'gpt-4o';
+
+/**
+ * Pick provider, endpoint, key, and models from the environment.
+ * Pure (no I/O) so it is unit-testable. Returns null when nothing is configured.
+ * The gateway takes precedence over a direct OpenAI key when both are present.
+ */
+function resolveAiProvider(env = process.env) {
+  const gatewayKey = env.AI_GATEWAY_API_KEY?.trim();
+  if (gatewayKey) {
+    const primaryModel  = env.AI_GATEWAY_MODEL?.trim()          || DEFAULT_GATEWAY_MODEL;
+    const fallbackModel = env.AI_GATEWAY_FALLBACK_MODEL?.trim() || DEFAULT_GATEWAY_FALLBACK_MODEL;
+    return {
+      mode: 'gateway',
+      ...ENDPOINTS.gateway,
+      apiKey: gatewayKey,
+      primaryModel,
+      fallbackModel: fallbackModel === primaryModel ? null : fallbackModel
+    };
+  }
+
+  const openaiKey = env.OPENAI_API_KEY?.trim();
+  if (openaiKey) {
+    const primaryModel = env.OPENAI_MODEL?.trim() || DEFAULT_OPENAI_MODEL;
+    return {
+      mode: 'openai',
+      ...ENDPOINTS.openai,
+      apiKey: openaiKey,
+      primaryModel,
+      // Preserve the original auto-fallback to gpt-4o-mini for the default model.
+      fallbackModel: primaryModel === DEFAULT_OPENAI_MODEL ? 'gpt-4o-mini' : null
+    };
+  }
+
+  return null;
+}
+
+/** True when any AI provider is configured (gateway or direct OpenAI). */
+function aiConfigured(env = process.env) {
+  return Boolean(env.AI_GATEWAY_API_KEY?.trim() || env.OPENAI_API_KEY?.trim());
+}
+
+// response_format:{type:'json_object'} is an OpenAI-family feature. Send it for
+// OpenAI models (direct, or gateway openai/*); for other gateway providers
+// (e.g. anthropic/*) rely on the prompt's "return ONLY valid JSON" instruction.
+function supportsJsonObjectFormat(model) {
+  return !model.includes('/') || model.startsWith('openai/');
+}
+
+function requestChat(messages, model, endpoint) {
+  const payload = { model, messages, temperature: 0.7, max_tokens: 2500 };
+  if (supportsJsonObjectFormat(model)) payload.response_format = { type: 'json_object' };
+  const body = JSON.stringify(payload);
 
   return new Promise((resolve, reject) => {
     const req = https.request(
       {
-        hostname: 'api.openai.com',
-        path: '/v1/chat/completions',
+        hostname: endpoint.hostname,
+        path: endpoint.path,
         method: 'POST',
         headers: {
-          'Content-Type':  'application/json',
-          'Authorization': 'Bearer ' + apiKey,
+          'Content-Type':   'application/json',
+          'Authorization':  'Bearer ' + endpoint.apiKey,
           'Content-Length': Buffer.byteLength(body)
         }
       },
@@ -59,22 +112,22 @@ function requestOpenAI(messages, model, apiKey) {
             const parsed = data ? JSON.parse(data) : {};
             if (res.statusCode >= 400 || parsed.error) {
               const message = parsed?.error?.message || `HTTP ${res.statusCode}`;
-              const err = new Error(`OpenAI API error (${res.statusCode}): ${message}`);
+              const err = new Error(`AI API error (${res.statusCode}): ${message}`);
               err.statusCode = res.statusCode;
               err.openaiCode = parsed?.error?.code || null;
               err.openaiType = parsed?.error?.type || null;
               return reject(err);
             }
             const content = parsed.choices?.[0]?.message?.content;
-            if (!content) return reject(new Error('Empty response from OpenAI'));
+            if (!content) return reject(new Error('Empty response from AI provider'));
             resolve(JSON.parse(content));
           } catch (e) {
-            reject(new Error('Failed to parse OpenAI response: ' + e.message));
+            reject(new Error('Failed to parse AI response: ' + e.message));
           }
         });
       }
     );
-    req.setTimeout(30000, () => req.destroy(new Error('OpenAI request timed out')));
+    req.setTimeout(30000, () => req.destroy(new Error('AI request timed out')));
     req.on('error', reject);
     req.write(body);
     req.end();
@@ -86,18 +139,31 @@ function isModelAccessError(err) {
     ((err?.statusCode === 403 || err?.statusCode === 404) && err?.openaiType === 'invalid_request_error');
 }
 
-async function callOpenAI(messages, model) {
-  const apiKey = process.env.OPENAI_API_KEY?.trim();
-  if (!apiKey) throw new Error('OPENAI_API_KEY is not set');
+// Through the gateway, also fail over on transient provider errors (5xx / 429 /
+// timeout) so an outage at the primary provider falls back to the secondary.
+function isRetryableError(err) {
+  const sc = err?.statusCode;
+  return isModelAccessError(err) || sc === 429 ||
+    (typeof sc === 'number' && sc >= 500 && sc <= 599) ||
+    /timed out/i.test(err?.message || '');
+}
 
-  const configuredModel = process.env.OPENAI_MODEL?.trim() || model || 'gpt-4o';
+async function callAI(messages) {
+  const provider = resolveAiProvider();
+  if (!provider) {
+    throw new Error('No AI provider configured — set AI_GATEWAY_API_KEY (preferred) or OPENAI_API_KEY');
+  }
+
+  const endpoint = { hostname: provider.hostname, path: provider.path, apiKey: provider.apiKey };
 
   try {
-    return await requestOpenAI(messages, configuredModel, apiKey);
+    return await requestChat(messages, provider.primaryModel, endpoint);
   } catch (err) {
-    if (configuredModel === 'gpt-4o' && isModelAccessError(err)) {
-      console.warn('[AI] Falling back to gpt-4o-mini due to model access error');
-      return requestOpenAI(messages, 'gpt-4o-mini', apiKey);
+    const shouldFallback = provider.fallbackModel &&
+      (provider.mode === 'gateway' ? isRetryableError(err) : isModelAccessError(err));
+    if (shouldFallback) {
+      console.warn(`[AI] Primary model ${provider.primaryModel} failed (${err.message}); falling back to ${provider.fallbackModel}`);
+      return requestChat(messages, provider.fallbackModel, endpoint);
     }
     throw err;
   }
@@ -220,9 +286,9 @@ async function generateListingContent(property, db = null) {
   let content;
 
   try {
-    content = await callOpenAI(messages);
+    content = await callAI(messages);
   } catch (err) {
-    console.error('[AI] OpenAI call failed:', err.message);
+    console.error('[AI] generation call failed:', err.message);
     throw err;
   }
 
@@ -275,4 +341,11 @@ async function getOrGenerateContent(property, db, force = false) {
   return generateListingContent(property, db);
 }
 
-module.exports = { generateListingContent, getOrGenerateContent, buildPrompt };
+module.exports = {
+  generateListingContent,
+  getOrGenerateContent,
+  buildPrompt,
+  resolveAiProvider,
+  supportsJsonObjectFormat,
+  aiConfigured
+};

--- a/api/ai-generator.js
+++ b/api/ai-generator.js
@@ -84,6 +84,7 @@ function aiConfigured(env = process.env) {
 // OpenAI models (direct, or gateway openai/*); for other gateway providers
 // (e.g. anthropic/*) rely on the prompt's "return ONLY valid JSON" instruction.
 function supportsJsonObjectFormat(model) {
+  if (!model || typeof model !== 'string') return false;
   return !model.includes('/') || model.startsWith('openai/');
 }
 
@@ -108,21 +109,31 @@ function requestChat(messages, model, endpoint) {
         let data = '';
         res.on('data', chunk => data += chunk);
         res.on('end', () => {
+          const status = res.statusCode;
+          let parsed = null;
+          try { parsed = data ? JSON.parse(data) : {}; } catch { /* non-JSON body (e.g. a 5xx HTML proxy page) */ }
+
+          // Attach statusCode even when the body is not JSON, so isRetryableError()
+          // can fail over on a 5xx/429 gateway error page.
+          if (status >= 400 || parsed?.error) {
+            const message = parsed?.error?.message || (data ? data.slice(0, 200) : `HTTP ${status}`);
+            const err = new Error(`AI API error (${status}): ${message}`);
+            err.statusCode = status;
+            err.openaiCode = parsed?.error?.code || null;
+            err.openaiType = parsed?.error?.type || null;
+            return reject(err);
+          }
+          if (!parsed) {
+            const err = new Error(`AI API error (${status}): non-JSON response`);
+            err.statusCode = status;
+            return reject(err);
+          }
+          const content = parsed.choices?.[0]?.message?.content;
+          if (!content) return reject(new Error('Empty response from AI provider'));
           try {
-            const parsed = data ? JSON.parse(data) : {};
-            if (res.statusCode >= 400 || parsed.error) {
-              const message = parsed?.error?.message || `HTTP ${res.statusCode}`;
-              const err = new Error(`AI API error (${res.statusCode}): ${message}`);
-              err.statusCode = res.statusCode;
-              err.openaiCode = parsed?.error?.code || null;
-              err.openaiType = parsed?.error?.type || null;
-              return reject(err);
-            }
-            const content = parsed.choices?.[0]?.message?.content;
-            if (!content) return reject(new Error('Empty response from AI provider'));
             resolve(JSON.parse(content));
           } catch (e) {
-            reject(new Error('Failed to parse AI response: ' + e.message));
+            reject(new Error('Failed to parse AI response content: ' + e.message));
           }
         });
       }

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -12,7 +12,7 @@ const { adminLoginRateLimit, uploadRateLimit, adminActionRateLimit } = require('
 const { adminShell, listingForm, loginPageHtml, loginErrorHtml } = require('../views/admin');
 const { esc, slugify, initListingFolder, isSafePathComponent, normalizeAcreage, safeListingPath } = require('../helpers');
 const { uploadPhotoToDrive } = require('../google');
-const { generateListingContent } = require('../ai-generator');
+const { generateListingContent, aiConfigured } = require('../ai-generator');
 
 let sharp;
 try { sharp = require('sharp'); } catch (_) { sharp = null; }
@@ -480,7 +480,7 @@ router.get('/ai/:id', requireAuth, adminActionRateLimit, (req, res) => {
   `).get(req.params.id);
   if (!p) return res.redirect('/admin');
 
-  const aiOk = !!process.env.OPENAI_API_KEY;
+  const aiOk = aiConfigured();
   let content = null;
   if (p.ai_content) {
     try { content = JSON.parse(p.ai_content); } catch {}
@@ -528,12 +528,12 @@ router.get('/ai/:id', requireAuth, adminActionRateLimit, (req, res) => {
       <a href="/admin" class="btn-outline">← Back</a>
     </div>
     ${!aiOk ? `<div style="background:#fff3cd;color:#856404;padding:1rem;border-radius:8px;margin-bottom:1.5rem">
-      ⚠️ <strong>OPENAI_API_KEY is not set.</strong> Add it to your environment to enable AI generation.
+      ⚠️ <strong>AI is not configured.</strong> Set <code>AI_GATEWAY_API_KEY</code> (preferred) or <code>OPENAI_API_KEY</code> to enable AI generation.
     </div>` : ''}
     <div style="display:flex;gap:1rem;align-items:center;margin-bottom:1.5rem;flex-wrap:wrap">
       <form method="POST" action="/admin/ai/${esc(p.id)}" style="margin:0">
         <input type="hidden" name="_csrf" value="${esc(csrfToken(req))}" />
-        <button type="submit" class="btn" ${!aiOk ? 'disabled title="Set OPENAI_API_KEY first"' : ''}>
+        <button type="submit" class="btn" ${!aiOk ? 'disabled title="Set AI_GATEWAY_API_KEY or OPENAI_API_KEY first"' : ''}>
           ${content ? '🔄 Regenerate' : '✨ Generate Now'}
         </button>
       </form>
@@ -570,8 +570,8 @@ router.post('/ai/:id', requireAuth, requireCsrf, adminActionRateLimit, async (re
     WHERE p.id=?
   `).get(req.params.id);
   if (!p) return res.redirect('/admin');
-  if (!process.env.OPENAI_API_KEY)
-    return res.status(400).send('OPENAI_API_KEY not configured');
+  if (!aiConfigured())
+    return res.status(400).send('AI not configured (set AI_GATEWAY_API_KEY or OPENAI_API_KEY)');
 
   try {
     await generateListingContent(p, db);

--- a/tests/ai-generator-routing.test.js
+++ b/tests/ai-generator-routing.test.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Unit tests for AI provider routing in api/ai-generator.js.
+ *
+ * Pure environment-resolution logic — no network calls. Verifies that the
+ * Vercel AI Gateway path activates only when AI_GATEWAY_API_KEY is set, and
+ * that direct-OpenAI behavior is unchanged otherwise.
+ *
+ * Run: node tests/ai-generator-routing.test.js
+ */
+
+const assert = require('assert');
+const {
+  resolveAiProvider,
+  supportsJsonObjectFormat,
+  aiConfigured
+} = require('../api/ai-generator');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function test(description, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`✓ ${description}`);
+  } catch (error) {
+    failed++;
+    failures.push({ description, error: error.message });
+    console.log(`✗ ${description}`);
+    console.log(`  Error: ${error.message}`);
+  }
+}
+
+// ── Nothing configured ────────────────────────────────────────────────────────
+test('resolveAiProvider returns null when no key is set', () => {
+  assert.strictEqual(resolveAiProvider({}), null);
+});
+test('aiConfigured is false when no key is set', () => {
+  assert.strictEqual(aiConfigured({}), false);
+});
+
+// ── Direct OpenAI (legacy default) — behavior must be unchanged ────────────────
+test('OPENAI_API_KEY only → direct OpenAI, gpt-4o, gpt-4o-mini fallback', () => {
+  const p = resolveAiProvider({ OPENAI_API_KEY: 'sk-test' });
+  assert.strictEqual(p.mode, 'openai');
+  assert.strictEqual(p.hostname, 'api.openai.com');
+  assert.strictEqual(p.path, '/v1/chat/completions');
+  assert.strictEqual(p.apiKey, 'sk-test');
+  assert.strictEqual(p.primaryModel, 'gpt-4o');
+  assert.strictEqual(p.fallbackModel, 'gpt-4o-mini');
+});
+test('OPENAI_MODEL override drops the gpt-4o-mini auto-fallback', () => {
+  const p = resolveAiProvider({ OPENAI_API_KEY: 'sk-test', OPENAI_MODEL: 'gpt-4o-mini' });
+  assert.strictEqual(p.primaryModel, 'gpt-4o-mini');
+  assert.strictEqual(p.fallbackModel, null);
+});
+
+// ── Vercel AI Gateway (preferred) ─────────────────────────────────────────────
+test('AI_GATEWAY_API_KEY → gateway host, gpt-5.4 primary, haiku fallback', () => {
+  const p = resolveAiProvider({ AI_GATEWAY_API_KEY: 'vck-test' });
+  assert.strictEqual(p.mode, 'gateway');
+  assert.strictEqual(p.hostname, 'ai-gateway.vercel.sh');
+  assert.strictEqual(p.path, '/v1/chat/completions');
+  assert.strictEqual(p.apiKey, 'vck-test');
+  assert.strictEqual(p.primaryModel, 'openai/gpt-5.4');
+  assert.strictEqual(p.fallbackModel, 'anthropic/claude-haiku-4.5');
+});
+test('gateway takes precedence over a direct OpenAI key', () => {
+  const p = resolveAiProvider({ AI_GATEWAY_API_KEY: 'vck', OPENAI_API_KEY: 'sk' });
+  assert.strictEqual(p.mode, 'gateway');
+  assert.strictEqual(p.apiKey, 'vck');
+});
+test('AI_GATEWAY_MODEL / AI_GATEWAY_FALLBACK_MODEL overrides are honored', () => {
+  const p = resolveAiProvider({
+    AI_GATEWAY_API_KEY: 'vck',
+    AI_GATEWAY_MODEL: 'openai/gpt-5.5',
+    AI_GATEWAY_FALLBACK_MODEL: 'anthropic/claude-sonnet-4.6'
+  });
+  assert.strictEqual(p.primaryModel, 'openai/gpt-5.5');
+  assert.strictEqual(p.fallbackModel, 'anthropic/claude-sonnet-4.6');
+});
+test('identical primary and fallback collapses fallback to null', () => {
+  const p = resolveAiProvider({
+    AI_GATEWAY_API_KEY: 'vck',
+    AI_GATEWAY_FALLBACK_MODEL: 'openai/gpt-5.4'
+  });
+  assert.strictEqual(p.fallbackModel, null);
+});
+test('aiConfigured is true for either key', () => {
+  assert.strictEqual(aiConfigured({ OPENAI_API_KEY: 'sk' }), true);
+  assert.strictEqual(aiConfigured({ AI_GATEWAY_API_KEY: 'vck' }), true);
+});
+
+// ── response_format gating ────────────────────────────────────────────────────
+test('json_object response_format only for OpenAI-family models', () => {
+  assert.strictEqual(supportsJsonObjectFormat('gpt-4o'), true);
+  assert.strictEqual(supportsJsonObjectFormat('openai/gpt-5.4'), true);
+  assert.strictEqual(supportsJsonObjectFormat('anthropic/claude-haiku-4.5'), false);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failures.length) {
+  console.log('\nFailures:');
+  failures.forEach(f => console.log(`  ✗ ${f.description}: ${f.error}`));
+}
+process.exit(failed ? 1 : 0);

--- a/tests/ai-generator-routing.test.js
+++ b/tests/ai-generator-routing.test.js
@@ -101,6 +101,18 @@ test('json_object response_format only for OpenAI-family models', () => {
   assert.strictEqual(supportsJsonObjectFormat('openai/gpt-5.4'), true);
   assert.strictEqual(supportsJsonObjectFormat('anthropic/claude-haiku-4.5'), false);
 });
+test('supportsJsonObjectFormat is defensive against bad model values', () => {
+  assert.strictEqual(supportsJsonObjectFormat(''), false);
+  assert.strictEqual(supportsJsonObjectFormat(null), false);
+  assert.strictEqual(supportsJsonObjectFormat(undefined), false);
+});
+
+// ── Whitespace / blank env handling ───────────────────────────────────────────
+test('blank or whitespace-only keys are treated as unset', () => {
+  assert.strictEqual(resolveAiProvider({ AI_GATEWAY_API_KEY: '   ' }), null);
+  assert.strictEqual(resolveAiProvider({ OPENAI_API_KEY: '' }), null);
+  assert.strictEqual(aiConfigured({ AI_GATEWAY_API_KEY: '  ', OPENAI_API_KEY: '' }), false);
+});
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failures.length) {


### PR DESCRIPTION
## What

Routes the admin listing-content generator (`api/ai-generator.js`, `POST /admin/ai/:id`) through the **Vercel AI Gateway** when `AI_GATEWAY_API_KEY` is set, with model failover and a model upgrade off the dated `gpt-4o`.

## Why

The generator called OpenAI `gpt-4o` directly over raw HTTPS with a single key — no failover, no spend cap, no observability, and a stale model. The gateway gives unified spend tracking, one place to cap cost, and automatic failover.

## Safe by construction

**No behavior change until the gateway key is provisioned.** With `AI_GATEWAY_API_KEY` unset, the code calls OpenAI directly exactly as before (`gpt-4o` → `gpt-4o-mini` on access errors). Merging/deploying this **cannot** take the generator down before the key exists.

When `AI_GATEWAY_API_KEY` **is** set (in Railway):
- Primary model `openai/gpt-5.4` — override `AI_GATEWAY_MODEL`
- Fails over to `anthropic/claude-haiku-4.5` on transient/model errors — override `AI_GATEWAY_FALLBACK_MODEL`
- `response_format: json_object` is sent only for OpenAI-family models (Anthropic relies on the prompt's "return only JSON" instruction)
- Takes precedence over `OPENAI_API_KEY`

`api/routes/admin.js` now enables AI generation when **either** key is present (was `OPENAI_API_KEY`-only), so a gateway-only setup works. Auth/CSRF/rate-limit on the route are unchanged.

## Manual step (only the owner can do)

1. Vercel dashboard → **AI Gateway** → create an API key.
2. Railway (`alert-laughter` / `wv-property-intelligence`) → add env `AI_GATEWAY_API_KEY`.
3. Set a **monthly budget cap** in the gateway dashboard.

Routing flips automatically on the next request — no redeploy needed.

## Verification

- `node --check` — ai-generator.js, admin.js, server.js ✓
- routing unit test `tests/ai-generator-routing.test.js` — **10/10** ✓
- existing security suite — **52/52, 0 failed** ✓
- preflight startup smoke — **PASS** ✓

## Out of scope (separate finding)

`app/index.html` ships a public **"MalickLand Assistant"** widget that calls `fetch('/api/chat')`, but **no `/api/chat` route is mounted in `server.js` on `main`** — that public chatbot is backend-less in production (it likely lives only on the unmerged consolidation branch). Flagged for a follow-up; this PR covers the admin generator only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route the admin listing content generator through a configurable AI provider that prefers the Vercel AI Gateway when available while preserving existing direct OpenAI behavior as a fallback.

New Features:
- Add support for using the Vercel AI Gateway as the primary backend for the admin listing content generator, with configurable primary and fallback models and automatic failover.
- Expose AI configuration helpers to determine whether an AI provider is available from environment variables and to gate admin UI behavior accordingly.

Enhancements:
- Generalize AI request handling to work with both OpenAI and gateway-backed providers while maintaining JSON response handling only where supported.
- Update admin UI messaging and validation to treat either the gateway key or a direct OpenAI key as sufficient to enable AI generation.

Tests:
- Add unit tests for AI provider resolution, gateway precedence, model selection, fallback behavior, configuration detection, and response_format gating.