### PR TITLE
feat(ai): add direct-Anthropic provider (Claude without the gateway)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -45,16 +45,30 @@ GOOGLE_DRIVE_FOLDER_ID=
 # When unset, both features degrade gracefully (admin is a no-op; chat returns a
 # brokerage-safe "call Phil" fallback) — the site never crashes for a missing key.
 #
-# Preferred — route through the Vercel AI Gateway for model failover, spend
-# tracking, observability, and one place to cap cost. Get a key from the Vercel
-# dashboard → AI Gateway. When set, this takes precedence over OPENAI_API_KEY.
+# Provider precedence: AI_GATEWAY_API_KEY → ANTHROPIC_API_KEY → OPENAI_API_KEY.
+# The first one set wins; set exactly one.
+#
+# Option 1 — Vercel AI Gateway: model failover, spend tracking, observability,
+# one place to cap cost. NOTE: Vercel's free gateway credits do NOT cover Claude
+# (premium models 403 until you add paid credits). Get a key from the Vercel
+# dashboard → AI Gateway.
 AI_GATEWAY_API_KEY=
 # Optional model overrides. Browse slugs: https://ai-gateway.vercel.sh/v1/models
 # Defaults: AI_GATEWAY_MODEL=openai/gpt-5.4  AI_GATEWAY_FALLBACK_MODEL=anthropic/claude-haiku-4.5
 AI_GATEWAY_MODEL=
 AI_GATEWAY_FALLBACK_MODEL=
 #
-# Direct OpenAI — used only when AI_GATEWAY_API_KEY is empty.
+# Option 2 — Direct Anthropic (Claude without the gateway; cheapest path to
+# Claude). Used only when AI_GATEWAY_API_KEY is empty. Get key:
+# https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=
+# Optional model overrides (defaults: haiku primary, sonnet auto-fallback).
+# For richer admin listing copy, set ANTHROPIC_MODEL=claude-sonnet-4-6.
+# Defaults: ANTHROPIC_MODEL=claude-haiku-4-5  ANTHROPIC_FALLBACK_MODEL=claude-sonnet-4-6
+ANTHROPIC_MODEL=
+ANTHROPIC_FALLBACK_MODEL=
+#
+# Option 3 — Direct OpenAI — used only when the two above are empty.
 # Get key: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 # Optional model override (defaults to gpt-4o, auto-falls back to gpt-4o-mini on access errors)

--- a/api/ai-generator.js
+++ b/api/ai-generator.js
@@ -14,8 +14,10 @@
  *   - Landing page content
  *   - SMS blast
  *
- * Requires: AI_GATEWAY_API_KEY (preferred — routes via Vercel AI Gateway) or
- * OPENAI_API_KEY (direct) in environment
+ * Requires one of (in precedence order):
+ *   AI_GATEWAY_API_KEY  (Vercel AI Gateway — needs paid gateway credits for Claude)
+ *   ANTHROPIC_API_KEY   (direct Anthropic — Claude without the gateway)
+ *   OPENAI_API_KEY      (direct OpenAI)
  *
  * Usage:
  *   const { generateListingContent } = require('./ai-generator');
@@ -29,21 +31,25 @@ const path   = require('path');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 
-// ── AI provider calls — Vercel AI Gateway or direct OpenAI, no SDK ────────────────────────
+// ── AI provider calls — Vercel AI Gateway, direct Anthropic, or direct OpenAI, no SDK ─────
 
 const ENDPOINTS = {
-  gateway: { hostname: 'ai-gateway.vercel.sh', path: '/v1/chat/completions' },
-  openai:  { hostname: 'api.openai.com',       path: '/v1/chat/completions' }
+  gateway:   { hostname: 'ai-gateway.vercel.sh', path: '/v1/chat/completions' },
+  anthropic: { hostname: 'api.anthropic.com',    path: '/v1/messages' },
+  openai:    { hostname: 'api.openai.com',       path: '/v1/chat/completions' }
 };
 
-const DEFAULT_GATEWAY_MODEL          = 'openai/gpt-5.4';
-const DEFAULT_GATEWAY_FALLBACK_MODEL = 'anthropic/claude-haiku-4.5';
-const DEFAULT_OPENAI_MODEL           = 'gpt-4o';
+const DEFAULT_GATEWAY_MODEL            = 'openai/gpt-5.4';
+const DEFAULT_GATEWAY_FALLBACK_MODEL   = 'anthropic/claude-haiku-4.5';
+const DEFAULT_ANTHROPIC_MODEL          = 'claude-haiku-4-5';
+const DEFAULT_ANTHROPIC_FALLBACK_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_OPENAI_MODEL             = 'gpt-4o';
+const ANTHROPIC_VERSION                = '2023-06-01';
 
 /**
  * Pick provider, endpoint, key, and models from the environment.
  * Pure (no I/O) so it is unit-testable. Returns null when nothing is configured.
- * The gateway takes precedence over a direct OpenAI key when both are present.
+ * Precedence: gateway → direct Anthropic → direct OpenAI.
  */
 function resolveAiProvider(env = process.env) {
   const gatewayKey = env.AI_GATEWAY_API_KEY?.trim();
@@ -54,6 +60,19 @@ function resolveAiProvider(env = process.env) {
       mode: 'gateway',
       ...ENDPOINTS.gateway,
       apiKey: gatewayKey,
+      primaryModel,
+      fallbackModel: fallbackModel === primaryModel ? null : fallbackModel
+    };
+  }
+
+  const anthropicKey = env.ANTHROPIC_API_KEY?.trim();
+  if (anthropicKey) {
+    const primaryModel  = env.ANTHROPIC_MODEL?.trim()          || DEFAULT_ANTHROPIC_MODEL;
+    const fallbackModel = env.ANTHROPIC_FALLBACK_MODEL?.trim() || DEFAULT_ANTHROPIC_FALLBACK_MODEL;
+    return {
+      mode: 'anthropic',
+      ...ENDPOINTS.anthropic,
+      apiKey: anthropicKey,
       primaryModel,
       fallbackModel: fallbackModel === primaryModel ? null : fallbackModel
     };
@@ -75,27 +94,104 @@ function resolveAiProvider(env = process.env) {
   return null;
 }
 
-/** True when any AI provider is configured (gateway or direct OpenAI). */
+/** True when any AI provider is configured (gateway, direct Anthropic, or direct OpenAI). */
 function aiConfigured(env = process.env) {
-  return Boolean(env.AI_GATEWAY_API_KEY?.trim() || env.OPENAI_API_KEY?.trim());
+  return Boolean(
+    env.AI_GATEWAY_API_KEY?.trim() ||
+    env.ANTHROPIC_API_KEY?.trim() ||
+    env.OPENAI_API_KEY?.trim()
+  );
 }
 
 // response_format:{type:'json_object'} is an OpenAI-family feature. Send it for
-// OpenAI models (direct, or gateway openai/*); for other gateway providers
-// (e.g. anthropic/*) rely on the prompt's "return ONLY valid JSON" instruction.
+// OpenAI models (direct gpt-*, or gateway openai/*); for Anthropic models
+// (direct claude-* or gateway anthropic/*) rely on the prompt's "return ONLY
+// valid JSON" instruction + parseJsonLoose(). Bare ids without a "/" are direct
+// OpenAI EXCEPT bare Claude ids, which the direct-Anthropic path now produces.
 function supportsJsonObjectFormat(model) {
   if (!model || typeof model !== 'string') return false;
+  if (/claude|anthropic/i.test(model)) return false;
   return !model.includes('/') || model.startsWith('openai/');
+}
+
+// Build the provider-specific HTTP headers + JSON body for one chat request.
+// OpenAI-family (direct OpenAI, or any gateway model) uses /v1/chat/completions
+// with Bearer auth and an inline system role. Anthropic uses /v1/messages with
+// x-api-key, the anthropic-version header, and a top-level `system` field
+// (role:'system' is NOT allowed inside the messages array there).
+function buildProviderRequest(mode, messages, model, apiKey, options) {
+  const { json, temperature, maxTokens } = options;
+
+  if (mode === 'anthropic') {
+    const systemText = messages
+      .filter((m) => m && m.role === 'system')
+      .map((m) => String(m.content || ''))
+      .join('\n\n')
+      .trim();
+    const turns = messages
+      .filter((m) => m && (m.role === 'user' || m.role === 'assistant'))
+      .map((m) => ({ role: m.role, content: String(m.content || '') }));
+    const payload = { model, max_tokens: maxTokens, temperature, messages: turns };
+    if (systemText) payload.system = systemText;
+    return {
+      headers: {
+        'Content-Type':      'application/json',
+        'x-api-key':         apiKey,
+        'anthropic-version': ANTHROPIC_VERSION
+      },
+      body: JSON.stringify(payload)
+    };
+  }
+
+  const payload = { model, messages, temperature, max_tokens: maxTokens };
+  if (json && supportsJsonObjectFormat(model)) payload.response_format = { type: 'json_object' };
+  return {
+    headers: {
+      'Content-Type':  'application/json',
+      'Authorization': 'Bearer ' + apiKey
+    },
+    body: JSON.stringify(payload)
+  };
+}
+
+// Pull the assistant's text out of a provider response. Anthropic returns a
+// `content` array of typed blocks; OpenAI returns choices[].message.content.
+function extractResponseText(mode, parsed) {
+  if (mode === 'anthropic') {
+    if (!Array.isArray(parsed?.content)) return null;
+    const text = parsed.content
+      .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text)
+      .join('');
+    return text || null;
+  }
+  return parsed?.choices?.[0]?.message?.content || null;
+}
+
+// Tolerant JSON extraction for the structured listing generator. response_format
+// guarantees clean JSON on OpenAI, but Anthropic returns plain text that may be
+// wrapped in ```json fences or carry minor preamble — strip to the outermost
+// object before parsing.
+function parseJsonLoose(content) {
+  try { return JSON.parse(content); } catch { /* fall through to fence/braces strip */ }
+  let s = String(content).trim();
+  const fence = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) s = fence[1].trim();
+  const first = s.indexOf('{');
+  const last  = s.lastIndexOf('}');
+  if (first !== -1 && last > first) s = s.slice(first, last + 1);
+  return JSON.parse(s);
 }
 
 // options.json (default true) keeps the structured-JSON behavior the listing
 // generator relies on. Pass { json: false } for free-text chat completions
 // (the public assistant): no response_format, raw string content returned.
 function requestChat(messages, model, endpoint, options = {}) {
-  const { json = true, temperature = 0.7, maxTokens = 2500 } = options;
-  const payload = { model, messages, temperature, max_tokens: maxTokens };
-  if (json && supportsJsonObjectFormat(model)) payload.response_format = { type: 'json_object' };
-  const body = JSON.stringify(payload);
+  const { json = true, temperature = 0.7, maxTokens = 2500, timeoutMs = 45000 } = options;
+  const { headers, body } = buildProviderRequest(
+    endpoint.mode, messages, model, endpoint.apiKey,
+    { json, temperature, maxTokens }
+  );
 
   return new Promise((resolve, reject) => {
     const req = https.request(
@@ -103,11 +199,7 @@ function requestChat(messages, model, endpoint, options = {}) {
         hostname: endpoint.hostname,
         path: endpoint.path,
         method: 'POST',
-        headers: {
-          'Content-Type':   'application/json',
-          'Authorization':  'Bearer ' + endpoint.apiKey,
-          'Content-Length': Buffer.byteLength(body)
-        }
+        headers: { ...headers, 'Content-Length': Buffer.byteLength(body) }
       },
       (res) => {
         let data = '';
@@ -118,11 +210,14 @@ function requestChat(messages, model, endpoint, options = {}) {
           try { parsed = data ? JSON.parse(data) : {}; } catch { /* non-JSON body (e.g. a 5xx HTML proxy page) */ }
 
           // Attach statusCode even when the body is not JSON, so isRetryableError()
-          // can fail over on a 5xx/429 gateway error page.
+          // can fail over on a 5xx/429 error page.
           if (status >= 400 || parsed?.error) {
             const message = parsed?.error?.message || (data ? data.slice(0, 200) : `HTTP ${status}`);
             const err = new Error(`AI API error (${status}): ${message}`);
             err.statusCode = status;
+            // Provider error discriminators: OpenAI uses error.code/error.type;
+            // Anthropic uses only error.type (authentication_error, rate_limit_error,
+            // overloaded_error, not_found_error, invalid_request_error).
             err.openaiCode = parsed?.error?.code || null;
             err.openaiType = parsed?.error?.type || null;
             return reject(err);
@@ -132,18 +227,18 @@ function requestChat(messages, model, endpoint, options = {}) {
             err.statusCode = status;
             return reject(err);
           }
-          const content = parsed.choices?.[0]?.message?.content;
+          const content = extractResponseText(endpoint.mode, parsed);
           if (!content) return reject(new Error('Empty response from AI provider'));
           if (!json) return resolve(content);
           try {
-            resolve(JSON.parse(content));
+            resolve(parseJsonLoose(content));
           } catch (e) {
             reject(new Error('Failed to parse AI response content: ' + e.message));
           }
         });
       }
     );
-    req.setTimeout(30000, () => req.destroy(new Error('AI request timed out')));
+    req.setTimeout(timeoutMs, () => req.destroy(new Error('AI request timed out')));
     req.on('error', reject);
     req.write(body);
     req.end();
@@ -171,16 +266,19 @@ function isRetryableError(err) {
 async function callProvider(messages, options = {}) {
   const provider = resolveAiProvider(options.env);
   if (!provider) {
-    throw new Error('No AI provider configured — set AI_GATEWAY_API_KEY (preferred) or OPENAI_API_KEY');
+    throw new Error('No AI provider configured — set AI_GATEWAY_API_KEY (preferred), ANTHROPIC_API_KEY, or OPENAI_API_KEY');
   }
 
-  const endpoint = { hostname: provider.hostname, path: provider.path, apiKey: provider.apiKey };
+  const endpoint = { hostname: provider.hostname, path: provider.path, apiKey: provider.apiKey, mode: provider.mode };
 
   try {
     return await requestChat(messages, provider.primaryModel, endpoint, options);
   } catch (err) {
+    // Direct OpenAI keeps its legacy access-error-only failover; gateway and
+    // direct Anthropic also fail over on transient errors (429/5xx/overloaded/
+    // timeout) so the cheap primary (haiku) escalates to the secondary (sonnet).
     const shouldFallback = provider.fallbackModel &&
-      (provider.mode === 'gateway' ? isRetryableError(err) : isModelAccessError(err));
+      (provider.mode === 'openai' ? isModelAccessError(err) : isRetryableError(err));
     if (shouldFallback) {
       console.warn(`[AI] Primary model ${provider.primaryModel} failed (${err.message}); falling back to ${provider.fallbackModel}`);
       return requestChat(messages, provider.fallbackModel, endpoint, options);

--- a/tests/ai-generator-routing.test.js
+++ b/tests/ai-generator-routing.test.js
@@ -74,6 +74,47 @@ test('gateway takes precedence over a direct OpenAI key', () => {
   assert.strictEqual(p.mode, 'gateway');
   assert.strictEqual(p.apiKey, 'vck');
 });
+
+// ── Direct Anthropic (Claude without the gateway) ─────────────────────────────
+test('ANTHROPIC_API_KEY → anthropic host/path, haiku primary, sonnet fallback', () => {
+  const p = resolveAiProvider({ ANTHROPIC_API_KEY: 'sk-ant-test' });
+  assert.strictEqual(p.mode, 'anthropic');
+  assert.strictEqual(p.hostname, 'api.anthropic.com');
+  assert.strictEqual(p.path, '/v1/messages');
+  assert.strictEqual(p.apiKey, 'sk-ant-test');
+  assert.strictEqual(p.primaryModel, 'claude-haiku-4-5');
+  assert.strictEqual(p.fallbackModel, 'claude-sonnet-4-6');
+});
+test('ANTHROPIC_MODEL / ANTHROPIC_FALLBACK_MODEL overrides are honored', () => {
+  const p = resolveAiProvider({
+    ANTHROPIC_API_KEY: 'sk-ant-test',
+    ANTHROPIC_MODEL: 'claude-sonnet-4-6',
+    ANTHROPIC_FALLBACK_MODEL: 'claude-haiku-4-5'
+  });
+  assert.strictEqual(p.primaryModel, 'claude-sonnet-4-6');
+  assert.strictEqual(p.fallbackModel, 'claude-haiku-4-5');
+});
+test('anthropic identical primary and fallback collapses fallback to null', () => {
+  const p = resolveAiProvider({
+    ANTHROPIC_API_KEY: 'sk-ant-test',
+    ANTHROPIC_FALLBACK_MODEL: 'claude-haiku-4-5'
+  });
+  assert.strictEqual(p.fallbackModel, null);
+});
+test('gateway takes precedence over a direct Anthropic key', () => {
+  const p = resolveAiProvider({ AI_GATEWAY_API_KEY: 'vck', ANTHROPIC_API_KEY: 'sk-ant' });
+  assert.strictEqual(p.mode, 'gateway');
+});
+test('direct Anthropic takes precedence over a direct OpenAI key', () => {
+  const p = resolveAiProvider({ ANTHROPIC_API_KEY: 'sk-ant', OPENAI_API_KEY: 'sk' });
+  assert.strictEqual(p.mode, 'anthropic');
+  assert.strictEqual(p.apiKey, 'sk-ant');
+});
+test('json_object response_format is never sent for bare Claude model ids', () => {
+  // Direct Anthropic model ids have no "/" — must NOT be treated as OpenAI-family.
+  assert.strictEqual(supportsJsonObjectFormat('claude-haiku-4-5'), false);
+  assert.strictEqual(supportsJsonObjectFormat('claude-sonnet-4-6'), false);
+});
 test('AI_GATEWAY_MODEL / AI_GATEWAY_FALLBACK_MODEL overrides are honored', () => {
   const p = resolveAiProvider({
     AI_GATEWAY_API_KEY: 'vck',


### PR DESCRIPTION
## Why
The chat assistant (#92) and listing generator (#90) only knew the Vercel AI Gateway and direct OpenAI. Vercel's **free gateway credits exclude premium models** (Claude 403s with `no_providers_available` until paid credits are added), so there was no zero-extra-cost path to Claude. This adds **direct Anthropic** as a third provider — the cheapest way to run both AI features on Claude.

## What
- **Provider precedence:** `AI_GATEWAY_API_KEY` → `ANTHROPIC_API_KEY` → `OPENAI_API_KEY`. First one set wins; existing gateway/OpenAI behavior is unchanged.
- **`requestChat` is now wire-format-aware.** Anthropic uses `api.anthropic.com /v1/messages` with `x-api-key` + `anthropic-version`, hoists `role:'system'` into the top-level `system` field (not allowed inside `messages` there), reads `content[].text`, and never sends `response_format`. OpenAI path byte-for-byte unchanged.
- **`parseJsonLoose`** for the structured listing path — Anthropic returns plain text, so strip ```json fences / preamble before `JSON.parse`.
- **Failover:** gateway **and** Anthropic escalate on transient errors (429 / 5xx / overloaded / timeout) so the cheap primary (haiku) escalates to the secondary (sonnet); direct OpenAI keeps its legacy access-error-only failover.
- Defaults: `claude-haiku-4-5` primary, `claude-sonnet-4-6` fallback — both env-overridable (`ANTHROPIC_MODEL` / `ANTHROPIC_FALLBACK_MODEL`).
- Safe-by-default unchanged: no key → admin no-ops, chat returns the brokerage-safe "call Phil" fallback.

## Testing
- **18/18** routing unit tests (6 new Anthropic cases: host/path/models, both overrides, precedence vs gateway and vs OpenAI, no `response_format` for bare Claude ids)
- **14/14** existing chat-assistant tests still green
- Offline request-shape assertion (correct host/headers, system hoisted, no `response_format`, fenced-JSON parsed)
- **Live end-to-end chat call** against the Anthropic API — brokerage-safe reply returned

After merge: set `ANTHROPIC_API_KEY` in Railway and the public assistant goes live (no Vercel top-up needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add direct Anthropic (Claude) as a first-class AI provider alongside the Vercel AI Gateway and direct OpenAI, including routing, request/response handling, and failover behavior.

New Features:
- Introduce direct Anthropic provider support with configurable primary and fallback Claude models and defined precedence relative to gateway and OpenAI keys.
- Support provider-aware chat requests that handle Anthropic’s message format, headers, and system prompt semantics while preserving existing OpenAI behavior.
- Allow tolerant JSON parsing of AI responses so structured listing generation can consume Anthropic’s plain-text JSON output.

Enhancements:
- Expand AI configuration detection to consider Anthropic keys and update error messaging accordingly.
- Refine JSON response_format handling to avoid sending json_object for Anthropic models or bare Claude IDs and to support configurable request timeouts.
- Adjust failover logic so gateway and Anthropic providers retry on transient errors while direct OpenAI maintains access-error-only fallback behavior.

Tests:
- Add routing and capability tests for the new Anthropic provider, including precedence, model overrides, fallback collapsing, and json_object support checks.