### PR TITLE
feat(listings): add publicListingsEnabled() feature flag

### DIFF
--- a/api/featureFlags.js
+++ b/api/featureFlags.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// ─────────────────────────────────────────────────────────────
+// TEMPORARY: public property listings are hidden from the site
+// until the inventory is cleaned up.
+//
+// To RESTORE listings later, either:
+//   • set env  PUBLIC_LISTINGS_ENABLED=true   (no code change), or
+//   • change the default below back to `return true`.
+//
+// When off: the homepage Featured/County sections + nav/footer
+// links are hidden, /listings + /wv/* + /listing/* redirect home,
+// and /api/listings returns empty. No listing data is deleted.
+// ─────────────────────────────────────────────────────────────
+function publicListingsEnabled() {
+  const v = process.env.PUBLIC_LISTINGS_ENABLED;
+  if (v === undefined || v === '') return false; // default: OFF for now
+  return v !== 'false';
+}
+
+module.exports = { publicListingsEnabled };

--- a/api/routes/api.js
+++ b/api/routes/api.js
@@ -8,6 +8,7 @@ const { requireApiKey }   = require('../middleware/auth');
 const { contactsRateLimit, publicReadRateLimit, generateDescRateLimit, apiWriteRateLimit } = require('../middleware/rate-limits');
 const { sendContactEmail } = require('../google');
 const { isValidEmail, normalizeAcreage, slugify, VALID_PROP_TYPES, VALID_PROP_STATUSES } = require('../helpers');
+const { publicListingsEnabled } = require('../featureFlags');
 
 const router = express.Router();
 
@@ -19,6 +20,7 @@ router.get('/config', (_req, res) => {
   res.json({
     gaId:    process.env.GA_MEASUREMENT_ID  || null,
     pixelId: process.env.META_PIXEL_ID      || null,
+    listingsEnabled: publicListingsEnabled(),
   });
 });
 
@@ -29,6 +31,7 @@ router.get('/counties', publicReadRateLimit, (_req, res) => {
 
 // ── Properties ────────────────────────────────────────────
 function sendPropertyList(req, res) {
+  if (!publicListingsEnabled()) return res.json({ total: 0, page: 1, properties: [] });
   try {
     const { q='', county='', type='', minPrice='', maxPrice='', page=1, limit=12 } = req.query;
     const conditions = ["p.status = 'active'"];
@@ -54,6 +57,7 @@ function sendPropertyList(req, res) {
 }
 
 function sendPropertyDetail(req, res) {
+  if (!publicListingsEnabled()) return res.status(404).json({ error: 'Not found' });
   const row = db.prepare(`
     SELECT p.id, p.listing_slug, p.address, p.city, p.zip, p.price, p.property_type,
            p.bedrooms, p.bathrooms, p.sqft, p.acreage AS lot_acres,

--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -7,6 +7,7 @@ const fs      = require('fs');
 const { db }           = require('../db');
 const { PROJECT_ROOT, esc } = require('../helpers');
 const { publicReadRateLimit } = require('../middleware/rate-limits');
+const { publicListingsEnabled } = require('../featureFlags');
 
 const router = express.Router();
 const HOMEPAGE_DISCLOSURE = 'WV Real Estate Agency, LLC | Sheila Judy, Broker | 501 East Main Street, Romney, WV 26757 | (540) 246-1421';
@@ -46,7 +47,7 @@ router.get('/sitemap.xml', publicReadRateLimit, (_req, res) => {
   ];
 
   let propertyPages = [];
-  try {
+  if (publicListingsEnabled()) try {
     const props = db.prepare(
       "SELECT listing_slug, id, updated_at FROM properties WHERE status = 'active'"
     ).all();
@@ -60,7 +61,7 @@ router.get('/sitemap.xml', publicReadRateLimit, (_req, res) => {
 
   // County landing pages — only counties with active listings (avoids thin-content pages).
   let countyPages = [];
-  try {
+  if (publicListingsEnabled()) try {
     const counties = db.prepare(
       "SELECT DISTINCT c.name FROM counties c JOIN properties p ON p.county_id = c.id WHERE p.status = 'active'"
     ).all();
@@ -93,6 +94,9 @@ router.get('/', publicReadRateLimit, (_req, res, next) => {
   try {
     const indexHtml = path.join(PROJECT_ROOT, 'app', 'index.html');
     let html = fs.readFileSync(indexHtml, 'utf8');
+    if (!publicListingsEnabled()) {
+      html = html.replace('<html lang="en">', '<html lang="en" class="listings-off">');
+    }
 
     html = replaceHomepageContent(
       html,
@@ -127,6 +131,7 @@ router.get('/', publicReadRateLimit, (_req, res, next) => {
 });
 
 router.get(['/listing/:id', '/properties/:id'], publicReadRateLimit, (_req, res) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
   const listingHtml = path.join(PROJECT_ROOT, 'app', 'listing.html');
   const indexHtml   = path.join(PROJECT_ROOT, 'app', 'index.html');
   res.sendFile(fs.existsSync(listingHtml) ? listingHtml : indexHtml);
@@ -139,6 +144,7 @@ router.get('/advent-drive-land-hampshire-county-wv', publicReadRateLimit, (_req,
 // County landing pages: /wv/<county>-county → server-rendered page listing that county's
 // active properties. Slug is validated against the counties table; unknown → 404 handler.
 router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
   const name = String(req.params.slug || '')
     .toLowerCase()
     .replace(/-county$/, '')
@@ -160,6 +166,13 @@ router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {
   } catch (err) {
     next(err);
   }
+});
+
+// Public listings search page (/listings → static app/listings.html when enabled).
+// Hidden while listings are disabled.
+router.get('/listings', publicReadRateLimit, (_req, res, next) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
+  next();
 });
 
 module.exports = router;

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <style>html.listings-off #listings,html.listings-off #countyBrowse,html.listings-off a[href="/listings"],html.listings-off a[href="#listings"],html.listings-off a[href^="/wv/"]{display:none!important}</style>
+  <style>html.listings-off #listings,html.listings-off #countyBrowse,html.listings-off a[href="/listings"],html.listings-off a[href="#listings"],html.listings-off a[href^="/wv/"],html.listings-off a[href="/37-advent"]{display:none!important}</style>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MalickLand | West Virginia Land, Homes & Property</title>
   <meta name="description" content="Find land, homes, farms, and rural property across all 55 West Virginia counties. AI-assisted property research, local expertise, responsive guidance." />

--- a/app/index.html
+++ b/app/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <style>html.listings-off #listings,html.listings-off #countyBrowse,html.listings-off a[href="/listings"],html.listings-off a[href="#listings"],html.listings-off a[href^="/wv/"]{display:none!important}</style>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MalickLand | West Virginia Land, Homes & Property</title>
   <meta name="description" content="Find land, homes, farms, and rural property across all 55 West Virginia counties. AI-assisted property research, local expertise, responsive guidance." />
@@ -15,6 +16,7 @@
   <!-- Analytics + Meta Pixel — loaded from /api/config (GA_MEASUREMENT_ID, META_PIXEL_ID) -->
   <script>
     fetch('/api/config').then(r=>r.json()).then(cfg=>{
+      if (cfg.listingsEnabled === false) document.documentElement.classList.add('listings-off');
       // Google Analytics 4
       if (cfg.gaId) {
         var s = document.createElement('script');
@@ -1290,7 +1292,7 @@
 </section>
 
 <!-- COUNTY LINKS -->
-<section style="background:#f9f6f0;padding:1.5rem 2rem;border-top:1px solid #e5e7eb">
+<section id="countyBrowse" style="background:#f9f6f0;padding:1.5rem 2rem;border-top:1px solid #e5e7eb">
   <div style="max-width:1200px;margin:0 auto">
     <p style="text-align:center;font-size:.8rem;color:#6b7280;margin-bottom:.85rem;text-transform:uppercase;letter-spacing:.5px;font-weight:600">Browse by County</p>
     <div style="display:flex;flex-wrap:wrap;gap:.5rem;justify-content:center">

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -45,7 +45,7 @@ echo "✓ Syntax OK"
 echo
 
 echo "== Startup smoke =="
-PORT="$PORT_TO_USE" DATABASE_PATH="$TMP_DIR/preflight.db" NODE_ENV=test API_KEY=preflight-api-key SESSION_SECRET=preflight-session-secret ADMIN_PASSWORD=preflight-admin-password node server.js > "$APP_LOG" 2>&1 &
+PORT="$PORT_TO_USE" DATABASE_PATH="$TMP_DIR/preflight.db" NODE_ENV=test PUBLIC_LISTINGS_ENABLED=true API_KEY=preflight-api-key SESSION_SECRET=preflight-session-secret ADMIN_PASSWORD=preflight-admin-password node server.js > "$APP_LOG" 2>&1 &
 PID=$!
 
 for _ in {1..30}; do


### PR DESCRIPTION
## Why

Public property listings need to be hidden temporarily while inventory is cleaned up — but nothing should be deleted and the flag should be trivially reversible without a code change.

## What

- New `api/featureFlags.js` — single `publicListingsEnabled()` function. Default: **OFF**. Override: set `PUBLIC_LISTINGS_ENABLED=true` in Railway env.
- `api/routes/api.js` — `/api/listings` returns empty result; `/api/listings/:id` returns 404 when off.
- `api/routes/public.js` — `/listings`, `/wv/*`, `/listing/*` redirect to homepage; sitemap omits property/county pages when off.
- `app/index.html` — CSS hides Featured Listings + County Browse sections; JS reads `/api/config` flag to add `listings-off` class immediately on load.

## What is NOT changed
- No listing data deleted
- No DB schema changes
- No Railway env variables modified (flag defaults to off without any env change)
- No AI, auth, or lead-capture behavior changed

## To restore listings
Set `PUBLIC_LISTINGS_ENABLED=true` in Railway — no deploy needed if already running, just restart.

## Summary by Sourcery

Add a feature flag to globally enable or disable public property listings and wire it through the API and public site.

New Features:
- Introduce a publicListingsEnabled() feature flag controlled by the PUBLIC_LISTINGS_ENABLED environment variable.
- Expose listingsEnabled in the /api/config response for frontend consumption.

Enhancements:
- Gate sitemap property and county URLs, public listing and county pages, and listings search routes behind the listings feature flag.
- Add HTML class and inline CSS to hide homepage featured listings, county browse section, and related navigation links when listings are disabled.