### PR TITLE
Fix dead public navigation aliases

### DIFF
--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -141,6 +141,21 @@ router.get('/advent-drive-land-hampshire-county-wv', publicReadRateLimit, (_req,
   res.redirect(301, '/37-advent');
 });
 
+router.get('/contact', publicReadRateLimit, (_req, res) => {
+  res.redirect(302, '/#contact-form');
+});
+
+router.get('/about', publicReadRateLimit, (_req, res) => {
+  res.redirect(302, '/#about');
+});
+
+router.get('/search', publicReadRateLimit, (req, res) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
+  const queryStart = req.originalUrl.indexOf('?');
+  const query = queryStart === -1 ? '' : req.originalUrl.slice(queryStart);
+  return res.redirect(302, `/listings${query}`);
+});
+
 // County landing pages: /wv/<county>-county → server-rendered page listing that county's
 // active properties. Slug is validated against the counties table; unknown → 404 handler.
 router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {

--- a/tests/verify-security-fixes.test.js
+++ b/tests/verify-security-fixes.test.js
@@ -411,6 +411,21 @@ test('public property-page routes use publicReadRateLimit in routes/public.js', 
     "Public property-page routes (/listing/:id, /properties/:id) are missing publicReadRateLimit in routes/public.js");
 });
 
+test('public navigation aliases avoid dead /contact, /about, and /search routes', () => {
+  assert(publicRoutesCode.includes("router.get('/contact', publicReadRateLimit"),
+    'GET /contact should be an explicit public route');
+  assert(publicRoutesCode.includes("router.get('/about', publicReadRateLimit"),
+    'GET /about should be an explicit public route');
+  assert(publicRoutesCode.includes("router.get('/search', publicReadRateLimit"),
+    'GET /search should be an explicit public route');
+  assert(publicRoutesCode.includes("res.redirect(302, '/#contact-form')"),
+    'GET /contact should redirect to the homepage contact form anchor');
+  assert(publicRoutesCode.includes("res.redirect(302, '/#about')"),
+    'GET /about should redirect to the homepage about anchor');
+  assert(publicRoutesCode.includes("return res.redirect(302, `/listings${query}`)"),
+    'GET /search should preserve query params when listings are enabled');
+});
+
 // ============================================================
 // Test Suite 7: Gmail Helper Integrity (api/google.js)
 // ============================================================


### PR DESCRIPTION
## Summary
- Add explicit public redirects for /contact and /about to their homepage anchors.
- Add /search redirect behavior that returns home while listings are disabled and preserves query params when listings are enabled.
- Add regression coverage for these public navigation aliases.

## Validation
- cd api && npm ci
- cd api && node --check server.js && node --check middleware/auth.js && node --check routes/admin.js && node --check routes/api.js && node --check routes/public.js
- node tests/verify-security-fixes.test.js (53 passed, 0 failed)
- Local disabled-listings smoke on :3061: /contact -> 302 /#contact-form; /about -> 302 /#about; /search -> 302 /; /listings -> 302 /; /api/health -> 200; gzip -> 200 gzip
- Local enabled-listings smoke on :3062: /search -> 302 /listings; /search?county=Hampshire&minPrice=100000 -> 302 /listings?county=Hampshire&minPrice=100000

No production deploy performed by Codex; per AGENTS.md, merge/deploy needs Phil approval.

## Summary by Sourcery

Add explicit public routes for legacy navigation aliases and ensure they redirect to the appropriate homepage or listings destinations.

New Features:
- Expose /contact and /about public routes that redirect to their respective homepage anchors.
- Add a /search public route that redirects to / or /listings depending on whether public listings are enabled while preserving query parameters when enabled.

Tests:
- Extend security/regression tests to assert the presence and behavior of the /contact, /about, and /search public navigation aliases.