### PR TITLE
fix(leads): contact pipeline honesty — no silent lead loss (Ticket 0.2)

### DIFF
--- a/api/google.js
+++ b/api/google.js
@@ -72,13 +72,13 @@ async function sendContactEmail(contact, property) {
   const { GOOGLE_GMAIL_USER, NOTIFICATION_EMAIL } = process.env;
   if (!GOOGLE_GMAIL_USER || !NOTIFICATION_EMAIL) {
     console.warn('[Gmail] sendContactEmail skipped: GOOGLE_GMAIL_USER or NOTIFICATION_EMAIL not configured');
-    return;
+    return false;
   }
 
   const token = await getAccessToken().catch(() => null);
   if (!token) {
     console.warn('[Gmail] sendContactEmail skipped: OAuth token unavailable — check GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN');
-    return;
+    return false;
   }
 
   try {
@@ -131,11 +131,13 @@ async function sendContactEmail(contact, property) {
 
     if (res.status === 200) {
       console.log(`[Gmail] Inquiry notification sent to ${NOTIFICATION_EMAIL}`);
+      return true;
     } else {
       throw new Error('Gmail send failed: ' + JSON.stringify(res.body));
     }
   } catch (err) {
     console.error('[Gmail] Failed to send inquiry email:', err.message);
+    return false;
   }
 }
 

--- a/api/routes/api.js
+++ b/api/routes/api.js
@@ -113,7 +113,15 @@ router.post('/contacts', contactsRateLimit, (req, res) => {
                   FROM properties p LEFT JOIN counties c ON c.id=p.county_id
                   WHERE p.id=?`).get(property_id)
     : null;
-  sendContactEmail({ name, email, phone, message: combinedMessage, source }, property).catch(() => {});
+  sendContactEmail({ name, email, phone, message: combinedMessage, source }, property)
+    .then((sent) => {
+      if (!sent) {
+        console.warn(`[Contacts] Lead #${result.lastInsertRowid} <${email}> CAPTURED but NOT notified — email provider unconfigured or send failed.`);
+      }
+    })
+    .catch((err) => {
+      console.error(`[Contacts] Lead #${result.lastInsertRowid} <${email}> notification error:`, err && err.message ? err.message : err);
+    });
 
   res.status(201).json({ id: result.lastInsertRowid });
 });

--- a/api/routes/api.js
+++ b/api/routes/api.js
@@ -116,11 +116,11 @@ router.post('/contacts', contactsRateLimit, (req, res) => {
   sendContactEmail({ name, email, phone, message: combinedMessage, source }, property)
     .then((sent) => {
       if (!sent) {
-        console.warn(`[Contacts] Lead #${result.lastInsertRowid} <${email}> CAPTURED but NOT notified — email provider unconfigured or send failed.`);
+        console.warn(`[Contacts] Lead #${result.lastInsertRowid} CAPTURED but NOT notified — email provider unconfigured or send failed.`);
       }
     })
     .catch((err) => {
-      console.error(`[Contacts] Lead #${result.lastInsertRowid} <${email}> notification error:`, err && err.message ? err.message : err);
+      console.error(`[Contacts] Lead #${result.lastInsertRowid} notification error:`, err && err.message ? err.message : err);
     });
 
   res.status(201).json({ id: result.lastInsertRowid });

--- a/app/index.html
+++ b/app/index.html
@@ -1533,13 +1533,21 @@ document.getElementById('leadModal').addEventListener('click', function(e) {
 async function submitForm(form, successId) {
   const data = {};
   new FormData(form).forEach((v, k) => data[k] = v);
+  const btn = form.querySelector('[type="submit"]');
+  const btnLabel = btn ? btn.textContent : null;
+  if (btn) { btn.disabled = true; btn.textContent = 'Sending…'; }
   try {
-    await fetch('/api/contacts', {
+    const r = await fetch('/api/contacts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
     });
-  } catch(e) {}
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+  } catch(e) {
+    if (btn) { btn.disabled = false; btn.textContent = btnLabel; }
+    alert("Sorry — something went wrong sending that. Please call Phil at (540) 246-1421 or email phil@malickland.net.");
+    return;
+  }
   pixelEvent('Lead', { content_name: 'contact_form' });
   if (window.gtag) gtag('event', 'generate_lead');
   form.style.display = 'none';
@@ -1857,13 +1865,18 @@ async function submitChatLead(btn) {
   btn.disabled = true; btn.textContent = 'Sending…';
   const summary = aiMessages.filter(m=>m.role==='user').map(m=>m.content).join(' | ');
   try {
-    await fetch('/api/contacts', {
+    const r = await fetch('/api/contacts', {
       method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ name, email, phone, message: 'Chat: ' + summary, source: 'website_chat' })
     });
-    pixelEvent('Lead', { content_name: 'ai_chat' });
-    if (window.gtag) gtag('event', 'generate_lead');
-  } catch(e) {}
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+  } catch(e) {
+    btn.disabled = false; btn.textContent = 'Send to Phil →';
+    alert("Sorry — that didn't go through. Please call Phil at (540) 246-1421 or email phil@malickland.net.");
+    return;
+  }
+  pixelEvent('Lead', { content_name: 'ai_chat' });
+  if (window.gtag) gtag('event', 'generate_lead');
   document.getElementById('chatBody').innerHTML = `<div class="chat-done">✅ Phil will follow up as soon as practical.<br/><br/>Call anytime: <a href="tel:+15402461421" style="color:var(--green);font-weight:700">(540) 246-1421</a></div>`;
 }
 </script>


### PR DESCRIPTION
## Ticket 0.2 — Lead Pipeline Honesty Fix

**Status: FOR AUDIT — do not merge yet.** Gated behind Codex audit → Phil's approval → Resend provider config. No deploy. Branched from `origin/main` (`063a00f`); came out of the Ticket 0.1 production-truth audit.

### Problem
Homepage contact forms POST to `/api/contacts`, which inserts the lead then calls Gmail `sendContactEmail` fire-and-forget. Two bugs hid failures:
1. Frontend showed success **without checking `r.ok`** (false success on 400/403/500/network error).
2. Backend **swallowed** the email result with `.catch(()=>{})`.

### Changes (3 files, +32/−9)
- **app/index.html** — `submitForm` + `submitChatLead` show success only on a `2xx`, show a clear error (with Phil's phone/email) + re-enable the button on failure, and fire conversion pixels only on real success. `pmSend` already checked `r.ok` (unchanged).
- **api/routes/api.js** — `/api/contacts` logs a WARN ("captured but NOT notified") / ERROR instead of swallowing. Lead is already persisted, so the `201` is unchanged.
- **api/google.js** — `sendContactEmail` returns `true` (sent) / `false` (skip|fail).

### What this does NOT do
- No email-provider switch (Resend wiring is a separate ticket).
- **Notifications still won't deliver after this** — the VPS is missing Gmail OAuth creds; this only makes the failure visible (ends silent loss). Delivery = the follow-up Resend ticket.
- No infra / Railway / deploy / feature-flag changes.

### Verification
- `node --check` passes both JS files.
- Real run of `sendContactEmail` with no creds → returns `false` + logs skip, no throw, no network.
- Full e2e (live form submit) not run locally (no deps/DB in worktree) → do as post-deploy smoke.

### For Codex to audit
1. `r.ok` gating + error UX in both frontend functions.
2. Backend logging doesn't leak PII beyond email/id; `201`-still-returns is intended.
3. Scope: only the 3 files; no infra/Resend/feature-flag touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure contact form and chat lead submissions only report success and fire analytics when the backend accepts the request, and surface email notification failures via logging instead of silently swallowing them.

New Features:
- Add user-facing error handling and messaging for failed contact form and chat lead submissions, including restoring the submit button state.

Bug Fixes:
- Gate contact form and chat lead success flows and conversion pixels on a successful /api/contacts response instead of assuming success.
- Prevent silent failures of contact notification emails by having sendContactEmail return a success flag and logging when sends are skipped or fail.

Enhancements:
- Improve backend logging around contact email delivery to distinguish captured-but-not-notified leads and unexpected notification errors.