### PR TITLE
[codex] docs: record VPS production truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Stable foundations (do not redesign without the above):
 - SQLite via `better-sqlite3` (no PostgreSQL migration unless Phase 1 spec requires it)
 - `csrf-csrf` v3 double-submit CSRF protection
 - `express-session` + Bearer API key auth model
-- Railway + Docker deployment topology
+- Hostinger VPS + Docker Compose + Traefik deployment topology
 - Vanilla HTML/JS/CSS frontend (no build step)
 
 ---
@@ -85,8 +85,8 @@ Never report: "tests pass", "build succeeds", "no vulnerabilities" unless the co
 
 | Agent | Role | Allowed | Forbidden |
 |-------|------|---------|-----------|
-| **Claude Code** | Implementation | Branch work, code changes, PRs, documentation | Direct main push, deploy, printing secrets, self-authorized architecture changes |
-| **Codex** | Audit + Phil-authorized implementation | Code review, security skepticism, CI forensics, readiness verdicts; small scoped repo edits only when Phil explicitly authorizes implementation in the current task | Direct main push, deploys, printing secrets, self-authorized architecture/schema changes |
+| **Claude Code** | Implementation | Branch work, code changes, PRs, documentation, evidence collection | Direct main push, deploy, printing secrets, self-declared READY verdicts, self-authorized architecture changes |
+| **Codex** | Independent gatekeeper + Phil-authorized implementation | Code review, security skepticism, CI forensics, GitHub/VPS readiness verdicts; small scoped repo edits only when Phil explicitly authorizes implementation in the current task | Direct main push, deploys, printing secrets, self-authorized architecture/schema changes |
 | **Gemini** | Architecture Challenger | Architecture critique, threat modeling, vendor analysis | Touching code in active PRs |
 | **ChatGPT** | Spec / Orchestration | Task definition, phase specs, API contracts | Architecture decisions without DECISIONS.md entry |
 | **OpenHands** | Supervised Worker | Sandboxed implementation, branch edits, opening PRs | See restrictions below |
@@ -111,10 +111,10 @@ OpenHands operates in **supervised sandboxed mode only**. These are permanent co
 
 ### Forbidden (hard stops — no exceptions)
 - ❌ Merge pull requests
-- ❌ Deploy to Railway or any production environment
+- ❌ Deploy to any production environment
 - ❌ Access or read production secrets (`SESSION_SECRET`, `ADMIN_PASSWORD`, `API_KEY`, `DATABASE_PATH`, `OPENAI_API_KEY`, `GOOGLE_*`, `RESEND_API_KEY`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`, `LEAD_ALERT_TO_NUMBER`)
 - ❌ Push directly to `main`
-- ❌ Modify Railway environment variables
+- ❌ Modify Railway or VPS environment variables
 - ❌ Run smoke tests against production (`malickland.net`) without explicit human approval
 - ❌ Mutate production database
 - ❌ Print or log any secret values
@@ -137,8 +137,9 @@ OpenHands operates in **supervised sandboxed mode only**. These are permanent co
 5. Gemini challenges if architecture/security significant → appended to WORK_LOG.md
 6. Conflict resolution: repository docs decide; safer path wins
 7. All CI checks pass → **Phil Malick** approves PR merge
-8. **Phil Malick** approves → Railway deploy
-9. Claude or Codex verifies smoke → result appended to WORK_LOG.md
+8. **Phil Malick** approves production deploy → manual VPS deploy
+9. Codex verifies GitHub/VPS state or reviews Claude's evidence before READY is treated as final
+10. Claude or Codex verifies smoke → result appended to WORK_LOG.md
 ```
 
 No step may be skipped. No agent may self-authorize a step beyond their role.
@@ -199,7 +200,7 @@ bash scripts/preflight.sh
 
 ## Environment Variables (Never Touch in Code)
 
-Set in Railway. Do not hardcode, echo, print, or modify:
+Set in the production environment (`/docker/wv-property-intelligence/.env` on the VPS). Do not hardcode, echo, print, or modify without explicit Phil approval:
 
 **Core (required):**
 - `SESSION_SECRET`
@@ -210,14 +211,14 @@ Set in Railway. Do not hardcode, echo, print, or modify:
 **OpenAI:**
 - `OPENAI_API_KEY`
 
-**Google (Drive + Gmail):**
+**Google (Drive; Gmail is legacy only):**
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - `GOOGLE_REFRESH_TOKEN`
 - `GOOGLE_DRIVE_FOLDER_ID`
 - `GOOGLE_GMAIL_USER`
 
-**Email (Resend — primary path):**
+**Email (Resend — lead notification path):**
 - `RESEND_API_KEY`
 - `FROM_EMAIL`
 - `NOTIFICATION_EMAIL`
@@ -272,29 +273,52 @@ Every agent session that makes changes must append an entry to `WORK_LOG.md`. Th
 
 ---
 
-## External Assistant / Codex Handoff Protocol
+## External Assistant / Codex Gatekeeper Protocol
 
-Codex (and any external reviewer that cannot attach to the Cursor account) gets all context **through the repository**, not through Cursor session state:
+Codex is the independent readiness gatekeeper. GitHub and live VPS state are the only final sources of truth for merge/deploy readiness.
 
-- Paste relevant Cursor/agent output directly into the external assistant's chat when needed.
-- Share or attach the files the implementing agent created or changed.
-- Point the assistant at the same GitHub repo and branch so it can inspect committed or uncommitted changes locally. The canonical local checkout and remote are recorded in `PROJECT_STATE.md` and `docs/CANONICAL_MAP.md`.
-- Keep plans, rules, and decisions in tracked files (`.cursor/rules/`, `docs/`, and the root `*.md` coordination docs) so they survive across assistants — see the Repository Authority Rule above for which file owns which state.
+Claude Code and other implementing agents produce evidence; they do not self-declare a PR or deploy READY. A PR is READY only after Codex independently verifies live GitHub state and, when relevant, live VPS state.
 
-Every time an implementing agent finishes a chunk of work, hand off:
+### Implementer handoff format
 
-- The **branch** worked on (`git branch --show-current`).
-- The **files touched** (`git status` / `git diff --name-only`).
-- **What changed and why** (link the relevant `*.md` doc or commit message).
-
-Quick commands to copy/paste for a handoff:
-
-```bash
-git branch --show-current        # current branch
-git status                       # uncommitted changes
-git diff --name-only             # changed file paths
-git log --oneline -10            # recent commits
+```text
+CLAUDE HANDOFF
+PR:
+Head SHA:
+What changed:
+What was tested:
+Known unresolved:
+Do not claim ready until Codex verifies:
+- gh pr view ... head SHA / mergeStateStatus / mergeable
+- gh pr checks ...
+- reviewThreads unresolved non-outdated == 0
+- VPS SHA unchanged unless deploy approved
 ```
+
+### Codex verification response
+
+Codex independently verifies against GitHub/VPS and replies:
+
+```text
+VERDICT: READY / NOT READY
+
+Blocking facts:
+- ...
+
+Verified:
+- PR head SHA
+- check rollup
+- merge state
+- unresolved review-thread count
+- VPS SHA/container health when relevant
+```
+
+### Required truth checks
+
+- Green CI alone is not READY; unresolved review threads can still block merge.
+- A point-in-time CLEAN result can become stale after asynchronous bot re-review.
+- Production deploy proof must include the live VPS SHA and container health, not just a merge commit.
+- No deploy or production env change happens without Phil's explicit approval in the current task.
 
 ---
 
@@ -310,6 +334,7 @@ Active development repo: **`/Users/yhyh7/Projects/wv-property-intelligence`**. W
 4. Read `docs/CANONICAL_MAP.md` before malickland.net infrastructure or deployment work.
 5. Never run `wrangler deploy` for `listing-system/workers/` without explicit human approval and a recorded route-ownership decision.
 6. `malickland.cloud` is not `malickland.net`; treat OpenClaw/trading work as a separate project.
+7. Railway is a legacy twin with a separate DB; audit it before standby/shutdown, but do not treat it as current production.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md — Malickland 2.0
 > Agents must not substantially redesign any section without satisfying the Architectural Stability Rule in AGENTS.md.
-> Last verified: 2026-05-27
+> Last verified: 2026-06-17
 
 ---
 
@@ -14,20 +14,20 @@
 
 | Layer | Choice | Rationale |
 |-------|--------|-----------|
-| Runtime | Node.js 20 LTS | Railway-compatible, long-term support |
+| Runtime | Node.js 20 LTS | Long-term support; runs in Docker on VPS |
 | Framework | Express 5 | Active development, async error handling |
 | Database | SQLite via `better-sqlite3` | Zero infrastructure overhead, sufficient for current scale, synchronous API simplifies code |
 | Session store | `better-sqlite3-session-store` | Collocated with main DB; no Redis needed |
 | Auth | `express-session` (admin) + Bearer API key (REST) | Session for interactive admin; API key for programmatic access |
 | CSRF | `csrf-csrf` v3 (double-submit cookie) | Replaced deprecated `csurf`; session-bound via `req.sessionID` |
 | Security | `helmet`, `cors`, `express-rate-limit` | Defense in depth |
-| Email | Resend API (primary) / Gmail OAuth2 (fallback) | Resend: zero OAuth setup; Gmail: existing integration |
+| Email | Resend API | Single transactional provider for lead notifications |
 | SMS | Twilio (optional, feature-flagged) | `twilio` pkg NOT in package.json; feature disabled until leads system complete |
 | AI | OpenAI GPT-4o via raw HTTPS | No SDK — reduces dep surface |
 | Google APIs | Raw HTTPS (no `googleapis` SDK) | Fewer deps, smaller attack surface |
 | Images | `sharp` for compression | On-upload processing: 1200px/85q web, 1024px/80q MLS |
 | Frontend | Vanilla HTML/JS/CSS | No build step; zero bundler complexity |
-| Deploy | Railway + Docker (`api/Dockerfile`) | `main` branch auto-deploys via Railway webhook |
+| Deploy | Hostinger VPS + Docker Compose + Traefik | Manual deploy from `main` after approval and Codex gate |
 | CI | GitHub Actions | CodeQL, Semgrep, preflight.yml |
 
 ---
@@ -40,7 +40,7 @@ wv-property-intelligence/
 │   ├── server.js               ← Entry point: middleware composition + route mounting
 │   ├── db.js                   ← SQLite connection, CREATE TABLE, migrations, seed
 │   ├── helpers.js              ← normalizeAcreage, isSafePathComponent, safeListingPath, slugify, esc
-│   ├── google.js               ← Gmail (send) + Drive (upload) via raw HTTPS
+│   ├── google.js               ← Drive upload via raw HTTPS; Gmail code is legacy only
 │   ├── ai-generator.js         ← GPT-4o content generation, per-listing cache
 │   ├── db-migrate-ai.js        ← DB migration script for AI columns
 │   ├── Dockerfile              ← Multi-stage build
@@ -53,9 +53,9 @@ wv-property-intelligence/
 │   │   ├── admin.js            ← All /admin/* routes (624 LOC)
 │   │   ├── api.js              ← All /api/* routes (227 LOC)
 │   │   ├── public.js           ← robots.txt, sitemap.xml, /listing/:id, /properties/:id
-│   │   └── leads.js            ← Lead capture routes (NOT MOUNTED — missing deps)
+│   │   └── leads.js            ← Lead capture routes
 │   ├── services/
-│   │   ├── email.js            ← Transactional email (Resend primary, Gmail fallback)
+│   │   ├── email.js            ← Transactional email (Resend)
 │   │   ├── leadNotifications.js ← Lead alert + auto-reply email
 │   │   ├── leadFollowupWorker.js ← Lead follow-up scheduling
 │   │   └── twilioService.js    ← SMS alerts (disabled — twilio not in package.json)
@@ -205,15 +205,19 @@ CSRF: double-submit cookie via `csrf-csrf`. Applied to all mutating `/admin/*` r
 
 ```
 GitHub main branch
-    → Railway webhook → Docker build (api/Dockerfile)
-    → Container start: node server.js
-    → Railway persistent volume: DATABASE_PATH (/data/wv_property.db)
-    → Railway env vars: all secrets injected at runtime
+    → Phil approval + Codex GitHub/VPS gate
+    → manual VPS deploy from /docker/wv-property-intelligence/src
+    → Docker Compose build using api/Dockerfile
+    → Traefik routes malickland.net/www.malickland.net to container port 3000
+    → Docker volume wv-property-intelligence_wv-data mounted at /data
+    → env_file /docker/wv-property-intelligence/.env injects runtime secrets
 ```
 
-- **Cloudflare** is the DNS/SSL/security layer in front of Railway — handles DNS, TLS termination, and edge-level protection (DDoS, bot filtering). It is not a deployment platform; the application runs on Railway.
+- **Traefik** terminates TLS via Let's Encrypt and routes the live apex on the VPS.
+- **Cloudflare** manages DNS, including Resend DNS records for `updates.malickland.net`.
+- **Railway** still serves a legacy twin with a separate database. It is not current production truth and must be audited before shutdown.
 - No application CDN, no load balancer, no Redis, no external database
-- Photos stored on Railway persistent volume at `listings/` path
+- Photos and SQLite data are persisted on the VPS Docker volume at `/data`
 - Single-process Node.js — no clustering
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ When sources conflict, prefer the safer, more conservative path and document the
 
 - Append an entry to `WORK_LOG.md` summarizing what changed and why.
 - Only update `docs/agent-handoff.md` when deployment topology or runtime guardrails materially change; it remains a deployment-state reference only and may lag `main`.
-- Railway deployment (`main` branch) is triggered automatically on merge; only Phil Malick approves production deploys.
+- Production deploys are manual VPS actions after merge; only Phil Malick approves production deploys.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -49,7 +49,7 @@
 
 **Problem:** Datastore selection for a single-server low-traffic real estate site.
 **Decision:** SQLite via `better-sqlite3`. No PostgreSQL migration planned until Phase 1+ requires it.
-**Reasoning:** Zero infrastructure overhead, synchronous API (simpler code), adequate for current scale, Railway-compatible with persistent volume.
+**Reasoning:** Zero infrastructure overhead, synchronous API (simpler code), adequate for current scale, Docker-volume compatible on the VPS.
 **Alternatives:** PostgreSQL (Neon, Railway Postgres) — planned for Phase 1+ if concurrent writes become bottleneck.
 **Files:** `api/db.js`, `database/schema.sql`
 
@@ -101,9 +101,28 @@
 
 **Problem:** The homepage "MalickLand Assistant" chat widget POSTs to `/api/chat`, but no such route existed on `main`, so the button 404'd in production. Two paths: (A) build the backend, or (B) remove/hide the widget.
 **Decision:** Build the backend (option A). Add a public, per-IP rate-limited, same-origin `POST /api/chat` that reuses the gateway-aware AI plumbing from PR #90 (`resolveAiProvider` + the generalized `requestChat`, surfaced as `generateChatReply`). It routes through the Vercel AI Gateway when `AI_GATEWAY_API_KEY` is set (model `openai/gpt-5.4`, failover `anthropic/claude-haiku-4.5`) and falls back to direct OpenAI otherwise.
-**Reasoning:** The widget is a complete, polished frontend (greeting → Q&A → lead handoff → analytics), and the gateway plumbing was merged specifically to be reused — the backend was the known follow-up to PR #90. Removing a finished feature is the wasteful path. The route is safe-by-default (graceful fallback when no AI key) so it cannot break the Railway auto-deploy.
+**Reasoning:** The widget is a complete, polished frontend (greeting → Q&A → lead handoff → analytics), and the gateway plumbing was merged specifically to be reused — the backend was the known follow-up to PR #90. Removing a finished feature is the wasteful path. The route is safe-by-default (graceful fallback when no AI key) so it cannot break the deployed app when no provider is configured.
 **Brokerage-safety:** A strict server-injected system prompt forbids ROI/appreciation/legal/tax/financing claims and inventing listings/prices; valuations are routed to a CMA from Phil. The client cannot override it — `sanitizeChatMessages()` strips any client-supplied `system` role. This aligns with the WV first-screen disclosure posture and mirrors `buildPrompt` in `ai-generator.js`.
-**Cost control:** Per-IP rate limit (15/min), trimmed history (≤10 turns / ≤6000 chars), capped output (~500 tokens). The endpoint is a no-op cost-wise until `AI_GATEWAY_API_KEY` is set in Railway.
+**Cost control:** Per-IP rate limit (15/min), trimmed history (≤10 turns / ≤6000 chars), capped output (~500 tokens). The endpoint is a no-op cost-wise until `AI_GATEWAY_API_KEY` is set in the production environment.
 **Alternatives considered:** (B) remove the widget — rejected; throws away finished UX and the planned feature. Giving the model live DB/listing context — deferred to a follow-up to keep this change conservative and avoid fabrication risk.
 **Security impact:** Neutral-to-positive — new public endpoint, but defended in depth (same-origin + JSON guards reused from the lead routes, rate limit, prompt-injection stripping, server-controlled prompt, bounded I/O). No new dependencies.
 **Files:** `api/ai-generator.js`, `api/utils/chatAssistant.js`, `api/routes/chat.js`, `api/middleware/rate-limits.js`, `api/server.js`, `scripts/preflight.sh`, `tests/chat-assistant.test.js`, `api/.env.example`
+
+---
+
+## 2026-06-17 — Production truth is VPS/Traefik; Railway is a legacy twin
+
+**Problem:** Repository docs still described Railway as production even after `malickland.net` had moved to a Hostinger VPS. Agents were planning Railway fixes and greenfield VPS work from stale docs, causing confusion and risking production mistakes.
+**Decision:** The canonical production target is the Hostinger VPS at `31.97.58.203`, running Docker Compose behind Traefik. `main` does not auto-deploy; production deploys are manual and require Phil approval plus a Codex GitHub/VPS gate check. Railway remains a legacy twin with a separate database and must be audited before standby or shutdown.
+**Reasoning:** Live DNS, curl, Docker, Git, and Resend delivery checks verified the VPS as current production. Keeping Railway language as production truth is more dangerous than treating it as a legacy audit target.
+**Alternatives:** Continue documenting Railway as production — rejected because it contradicts live runtime truth. Delete all Railway references immediately — rejected because the Railway twin still needs an audit before shutdown.
+**Files:** `README.md`, `ARCHITECTURE.md`, `PROJECT_STATE.md`, `docs/CANONICAL_MAP.md`, `docs/agent-handoff.md`, `docs/RAILWAY_TWIN_AUDIT.md`
+
+---
+
+## 2026-06-17 — Codex owns READY verdicts
+
+**Problem:** Implementing agents reported PRs as ready from point-in-time checks while asynchronous review bots could still add or reopen blocking review threads.
+**Decision:** Implementing agents produce evidence and handoffs. Codex independently verifies GitHub and VPS state and owns the READY / NOT READY verdict. Green CI alone is not ready; zero unresolved non-outdated review threads, correct head SHA, merge state, and VPS state must be checked live.
+**Reasoning:** This reduces handoff churn and makes GitHub plus VPS runtime truth the shared coordination layer.
+**Files:** `AGENTS.md`

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE.md — Malickland 2.0
 
-> **Last verified:** 2026-06-04 (canonical branch `main` @ `a479bfb`; PR #86 merged after PR #84)
+> **Last verified:** 2026-06-17 (canonical branch `main` @ `b9d1198`; PR #97 merged and deployed to VPS)
 > **Authority:** Product completeness and repo workspace truth. Use `docs/CANONICAL_MAP.md` for repo/domain/stack disambiguation. Deployment runbooks and guardrails remain in `docs/agent-handoff.md`.
 
 ---
@@ -11,8 +11,8 @@
 |------|--------|
 | **Active repo** | `/Users/yhyh7/Projects/wv-property-intelligence` |
 | **Remote** | `https://github.com/malickland-304/wv-property-intelligence.git` |
-| **Production branch** | `origin/main` @ `a479bfb` (PR #86 merged 2026-06-04) |
-| **Last merged PR** | #86 codex governance and compliance copy — merged into `main` after PR #84 |
+| **Production branch** | `origin/main` @ `b9d1198` (PR #97 merged 2026-06-17) |
+| **Last merged PR** | #97 Resend lead notifications — merged into `main` after #96 honesty fix |
 
 PR #76 is merged and live; PR #77 is merged on top. Compare future work against `origin/main`, not a stale local `main`.
 
@@ -30,7 +30,7 @@ Local `main` checkout may lag `origin/main`; always `git fetch origin` and compa
 
 ## GitHub / PR status (2026-06-04)
 
-Open pull requests: **0**. Open issue count must be re-checked live in GitHub before acting; this document is not the live issue tracker.
+Open pull requests must be re-checked live in GitHub before acting; this document is not the live issue tracker.
 
 | PR | Status |
 |----|--------|
@@ -42,6 +42,8 @@ Open pull requests: **0**. Open issue count must be re-checked live in GitHub be
 | **#76** (public navigation links fix) | ✅ Merged — `dc8cc53` on `origin/main` (2026-05-31); production smoke passed |
 | **#84** (lead hardening review followups) | ✅ Merged — `48c891d` on `origin/main` (2026-06-01); all required PR checks green before merge |
 | **#86** (governance and compliance copy) | ✅ Merged — `a479bfb` on `origin/main` (2026-06-04) |
+| **#96** (lead pipeline honesty) | ✅ Merged — frontend no longer reports success on failed contact POST |
+| **#97** (Resend lead notifications) | ✅ Merged — `b9d1198` on `origin/main` (2026-06-17); deployed to VPS and end-to-end lead delivery verified |
 | **#77** (Cursor workspace guardrails) | ✅ Merged — `b34e2fb` on `origin/main` (2026-05-31) |
 | **#78** (post-PR76 docs refresh) | ✅ Merged — `0908cd4` on `origin/main` (2026-05-31) |
 
@@ -52,7 +54,7 @@ Open pull requests: **0**. Open issue count must be re-checked live in GitHub be
 | Item | Status |
 |------|--------|
 | Live URL | https://malickland.net |
-| Railway deploy / live smoke | ✅ Latest confirmed live read-only smoke remains 2026-05-31 after PR #76: `/api/health`, `/listings`, `/37-advent`, legacy Advent redirect |
+| Production host / live smoke | ✅ Hostinger VPS `31.97.58.203` behind Traefik; latest confirmed live smoke 2026-06-17: `/api/health` 200 and homepage 200 |
 | Health endpoint | **`GET /api/health`** — not `/health` (mounted in `api/routes/api.js`) |
 | npm audit | ✅ 0 vulnerabilities (verified on fix branch 2026-05-31) |
 | Security test suite | ✅ **52/52** locally on 2026-06-04 (`node tests/verify-security-fixes.test.js`) |
@@ -62,7 +64,7 @@ Open pull requests: **0**. Open issue count must be re-checked live in GitHub be
 | Governance files | ✅ `README.md`, `CONTRIBUTING.md`, `.github/CODEOWNERS`, issue templates, and PR template present |
 | GitHub security queues | ✅ Open code-scanning alerts: 0; Dependabot alerts: 0; secret-scanning alerts: 0 (2026-05-31 API audit) |
 | Remote branches | ✅ Only protected `main` remains on `origin` after stale branch cleanup (2026-05-31) |
-| GitHub environments | Railway deployment statuses use `alert-laughter / production`; `production` and `copilot` environments exist but are not deployment-gating for Railway |
+| GitHub environments | GitHub checks gate merges; VPS deploy is manual and requires Phil approval plus Codex verification |
 
 ---
 
@@ -71,7 +73,7 @@ Open pull requests: **0**. Open issue count must be re-checked live in GitHub be
 | Layer | Choice |
 |-------|--------|
 | **This repo** | Node.js 20 / **Express 5** monolith, **SQLite** (`better-sqlite3`), **vanilla HTML** in `app/` (no frontend build) |
-| **Deploy** | **Railway** + Docker (`api/Dockerfile`), `main` auto-deploys |
+| **Deploy** | **Hostinger VPS** + Docker Compose + Traefik; `main` does not auto-deploy |
 | **Not this product** | The separate **malickland.net Next.js** tree under Documents — different codebase; do not conflate env or deploy |
 | **Not used** | **Supabase**, PostgreSQL, Vercel app router, etc. |
 
@@ -100,11 +102,11 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 | Frontend | Vanilla HTML/JS/CSS (no build step) |
 | Auth | `express-session` (admin) + Bearer API key (REST) |
 | CSRF | `csrf-csrf` v3 (double-submit cookie) |
-| Email | Resend (primary) or Gmail OAuth (fallback) — `api/services/email.js` |
+| Email | Resend single-provider path — `api/services/email.js`; Gmail is not used for lead alerts |
 | SMS | Twilio — `api/services/twilioService.js` (twilio pkg NOT in package.json — feature disabled) |
 | AI | OpenAI GPT-4o via HTTPS — `api/ai-generator.js` |
-| Google | Drive + Gmail via `api/google.js` (raw HTTPS, no googleapis SDK) |
-| Deploy | Railway + Docker (`api/Dockerfile`), branch `main` auto-deploys |
+| Google | Drive via `api/google.js` (raw HTTPS, no googleapis SDK); Gmail remains legacy code only |
+| Deploy | Hostinger VPS + Docker Compose + Traefik; manual deploy after approved merge |
 
 ---
 
@@ -116,7 +118,7 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 - ✅ Admin panel: listing CRUD, photo uploads (with sharp compression), due-diligence notes
 - ✅ AI marketing content generation (GPT-4o, per-listing)
 - ✅ Google Drive photo backup
-- ✅ Gmail contact notification
+- ✅ Resend contact and lead notification
 - ✅ Sitemap + robots.txt
 - ✅ Rate limiting on all public endpoints
 - ✅ CSRF protection on all admin mutating routes
@@ -127,12 +129,13 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 ## Incomplete / broken
 
-### 🟡 Follow-up — External lead integrations
+### 🟡 Follow-up — External lead integrations and cleanup
 
 - `api/routes/leads.js` is mounted in `server.js`
 - Public lead/contact POSTs require JSON plus same-origin request headers
 - `api/services/googleSheets.js` is a no-op adapter until real Sheets append support is implemented
 - `twilio` is still optional and not in `package.json`; SMS alerts remain disabled unless that dependency and env are added
+- Railway still serves a legacy twin with a separate DB. Audit it for buried leads before shutdown or standby documentation.
 
 ### 🟢 Test suite — fixed on `main` (PR #73 governance merge)
 
@@ -142,7 +145,7 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 ### 🟡 MEDIUM — Services layer undocumented
 
-- `api/services/email.js` (Resend/Gmail), `twilioService.js`, `leadFollowupWorker.js` exist but are thinly documented in env-var lists
+- `api/services/email.js` (Resend), `twilioService.js`, `leadFollowupWorker.js` exist but are thinly documented in env-var lists
 - Env vars: `RESEND_API_KEY`, `FROM_EMAIL`, `NOTIFICATION_EMAIL`, `TWILIO_*`, `LEAD_ALERT_TO_NUMBER` — see `AGENTS.md`
 
 ### 🟢 LOW — OpenHands runtime not activated
@@ -156,7 +159,7 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 | Bug | Severity | Notes |
 |-----|----------|-------|
-| leads.js missing deps | High | Not mounted; would crash if mounted |
+| Railway twin separate DB | Medium | Legacy Railway origin remains up and must be audited before standby/shutdown |
 | Stale or wrong Cursor workspace | Ops | Cursor sessions have used `openclaw-system` and stale Documents/GitHub checkouts; reopen Cursor at `/Users/yhyh7/Projects/wv-property-intelligence` and verify `workspace_roots` before production work |
 
 ---
@@ -172,7 +175,7 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 ## Architecture notes
 
 - Routes: `server.js` → `routes/admin.js`, `routes/api.js` (`/api/health`), `routes/public.js`
-- `routes/leads.js` exists but unmounted
+- `routes/leads.js` is mounted behind JSON and same-origin guards
 - Services: `email.js`, `twilioService.js`, `leadFollowupWorker.js`, `leadNotifications.js`
 - Utils: `validators.js`, `propertyMarketing.js`, `sqliteSessionStore.js`
 - DB: `db.js` — SQLite with migrations
@@ -182,7 +185,7 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 ## Product roadmap (approved, per AGENTS.md)
 
-- **Phase 0** (current): OpenHands executor validation
+- **Phase 0**: Lead capture and Resend notifications live on VPS (complete 2026-06-17); cleanup/docs in progress
 - **Phase 1**: Document Registry skeleton (SQLite tables) — spec required first
 - **Phase 2**: AI Review Queue
 - **Phase 3**: Drive event automation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MalickLand — WV Property Intelligence
 
-West Virginia real estate listing platform. Admin panel, public listing pages, photo uploads, AI marketing content, and Google Drive/Gmail integration.
+West Virginia real estate listing platform. Admin panel, public listing pages, photo uploads, AI marketing content, Google Drive backup, and Resend lead notifications.
 
 **Live site:** [malickland.net](https://malickland.net)
 
@@ -15,9 +15,9 @@ West Virginia real estate listing platform. Admin panel, public listing pages, p
 | Database | SQLite via better-sqlite3 |
 | Auth | Session-based (admin panel) + API key (REST) |
 | Images | Local disk + Google Drive backup |
-| Email | Gmail API via OAuth2 |
+| Email | Resend transactional email |
 | AI | OpenAI GPT-4o (listing content generation) |
-| Deploy | Railway (Docker) |
+| Deploy | Hostinger VPS (`31.97.58.203`) + Docker Compose + Traefik |
 
 ---
 
@@ -29,7 +29,7 @@ wv-property-intelligence/
 │   ├── server.js           ← Entry point, middleware, static routes
 │   ├── db.js               ← SQLite connection, schema, migrations, seeding
 │   ├── helpers.js          ← Shared utilities (esc, slugify, etc.)
-│   ├── google.js           ← Gmail + Drive integration (no SDK)
+│   ├── google.js           ← Google Drive integration (no SDK); Gmail code is legacy
 │   ├── ai-generator.js     ← OpenAI listing content engine
 │   ├── db-migrate-ai.js    ← One-time migration script (ai_content columns)
 │   ├── middleware/
@@ -56,7 +56,7 @@ wv-property-intelligence/
 │   └── _template/          ← Folder structure reference
 ├── api/Dockerfile          ← Multi-stage Docker build
 ├── compose.yml             ← Local Docker Compose
-└── railway.json            ← Railway deploy config
+└── railway.json            ← Legacy Railway config (Railway twin remains for audit only)
 ```
 
 ---
@@ -92,7 +92,7 @@ Required to run:
 - `ADMIN_PASSWORD` — admin panel password
 
 Optional integrations:
-- **Gmail notifications:** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN`, `GOOGLE_GMAIL_USER`, `NOTIFICATION_EMAIL`
+- **Resend notifications:** `RESEND_API_KEY`, `FROM_EMAIL`, `NOTIFICATION_EMAIL`
 - **Drive photo backup:** `GOOGLE_DRIVE_FOLDER_ID`
 - **AI content generation:** `OPENAI_API_KEY` (optional `OPENAI_MODEL`)
 - **REST API auth:** `API_KEY`
@@ -135,7 +135,7 @@ All require session auth (`/admin/login`).
 | `GET /admin/report/:id` | Comps + due diligence |
 | `GET /admin/ai/:id` | AI content viewer |
 | `POST /admin/ai/:id` | Generate/regenerate AI content |
-| `GET /admin/integrations` | Gmail + Drive status |
+| `GET /admin/integrations` | Integration status |
 
 ---
 
@@ -149,11 +149,13 @@ Cost: ~$0.01–0.03 per listing. Access via **Admin → AI** button on any listi
 
 ---
 
-## Deploy (Railway)
+## Deploy (VPS)
 
-Push to `main` triggers an automated deploy. Railway uses `railway.json` and the multi-stage Docker build in `api/Dockerfile`.
+Production currently runs on the Hostinger VPS at `31.97.58.203` in Docker Compose behind Traefik. The live source checkout is `/docker/wv-property-intelligence/src`; the Compose project reads `/docker/wv-property-intelligence/.env`, builds `api/Dockerfile`, and persists SQLite data on the `wv-property-intelligence_wv-data` Docker volume mounted at `/data`.
 
-For persistent data, create a Railway Volume, mount it at `/data`, and set `DATABASE_PATH=/data/wv_property.db`.
+Merging to `main` does not by itself deploy to the VPS. Production deploys require explicit Phil approval, a final Codex GitHub/VPS gate check, and a manual VPS deploy.
+
+Railway is still reachable as a separate legacy twin and must be audited for any un-migrated leads before shutdown. Do not treat Railway as production truth for `malickland.net`.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ Reports in **English** are preferred.
 
 ---
 
-## Operational Security — Railway CLI
+## Operational Security — Railway CLI (Legacy Twin)
 
 The `railway variables` CLI command exposes **all environment variable values verbatim** in terminal output, including production secrets (`SESSION_SECRET`, `ADMIN_PASSWORD`, `API_KEY`, `RESEND_API_KEY`, `OPENAI_API_KEY`, Google OAuth tokens, and Twilio credentials).
 
@@ -48,6 +48,6 @@ The `railway variables` CLI command exposes **all environment variable values ve
 - CI logs or GitHub Actions output
 - Any environment where terminal output may be captured or retained
 
-**Use the Railway dashboard instead** (`app.railway.app`) to view or modify production environment variables. Dashboard access is authenticated and does not expose secrets in logs.
+**Use the Railway dashboard instead** (`app.railway.app`) for the legacy Railway twin audit. Dashboard access is authenticated and does not expose secrets in logs.
 
 This restriction applies to all agents and human operators with Railway access. Any agent that runs `railway variables` and captures its output must treat the session as potentially compromised and stop immediately per the AGENTS.md Autonomous Safety Stop Rule.

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,7 +13,7 @@
 
 ## High Priority
 
-- [ ] **Public assistant backend (`POST /api/chat`)** — homepage "MalickLand Assistant" widget had no backend (404 in prod). Added a public, per-IP rate-limited, same-origin chat route reusing the PR #90 gateway-aware AI plumbing (`generateChatReply`); strict brokerage-safe system prompt; safe-by-default with no AI key. Acceptance: security suite 52/52, new chat suite 14/14, preflight green (incl. assistant smoke). **Claude Code** — PR open, awaiting Phil review (do not merge without approval); set `AI_GATEWAY_API_KEY` in Railway after merge to enable live replies.
+- [ ] **Public assistant backend (`POST /api/chat`)** — homepage "MalickLand Assistant" widget had no backend (404 in prod). Added a public, per-IP rate-limited, same-origin chat route reusing the PR #90 gateway-aware AI plumbing (`generateChatReply`); strict brokerage-safe system prompt; safe-by-default with no AI key. Acceptance: security suite 52/52, new chat suite 14/14, preflight green (incl. assistant smoke). **Claude Code** — PR open, awaiting Phil review (do not merge without approval); set `AI_GATEWAY_API_KEY` in the VPS environment after merge/deploy approval to enable live replies.
 - [ ] **OpenHands executor activation** — provision fine-grained GitHub token; start executor; run first supervised task — waiting on developer action; Issue #66 is fixed and Issue #65 is closed, so create or pick a current task — **developer action**
 
 ---
@@ -59,6 +59,8 @@
 - [x] GitHub environments audited — Railway deployments report to `alert-laughter / production`; unused `production`/`copilot` environments documented as non-gating — 2026-05-31
 - [x] Issue #85 governance follow-up — added `CONTRIBUTING.md`, `.github/CODEOWNERS`, manual stale-work cadence, and non-mutating smoke guidance — 2026-06-04
 - [x] `docs/agent-handoff.md` refresh — corrected merged PR state, lead-route status, and maintenance notes — 2026-06-04
+- [ ] **Railway twin audit** — legacy Railway origin still serves a separate DB; audit contacts/leads before standby-or-shutdown decision — see `docs/RAILWAY_TWIN_AUDIT.md`
+- [ ] **Lead pipeline smoke checklist** — use `docs/LEAD_PIPELINE_SMOKE.md` after lead deploys or delivery incidents
 - [x] `brace-expansion` patched, `cookie` transitive vuln contained
 - [x] Create PROJECT_STATE.md, TASKS.md, DECISIONS.md, QA_CHECKLIST.md — 2026-05-27 (Claude Code)
 - [x] Create ARCHITECTURE.md, WORK_LOG.md — 2026-05-27 (Claude Code)

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -599,3 +599,41 @@ button 404'd in production. Implemented option (A): a public, rate-limited, same
 
 ### Recommended Next Task
 - Phil: review/approve the PR; if approved and merged, set `AI_GATEWAY_API_KEY` in Railway and smoke `POST /api/chat` on production with a same-origin request.
+
+---
+
+## 2026-06-17 — Codex (GPT-5)
+
+### Objective
+Document the post-Phase-0 production truth and coordination protocol after lead
+notifications were fixed and verified on the Hostinger VPS.
+
+### Changes Made
+- `README.md`, `ARCHITECTURE.md`, `PROJECT_STATE.md`, `docs/CANONICAL_MAP.md`,
+  and `docs/agent-handoff.md` now describe current production as Hostinger VPS
+  `31.97.58.203` running Docker Compose behind Traefik, with Railway retained
+  only as a legacy twin that needs a data audit before standby or shutdown.
+- `AGENTS.md` now records the Codex gatekeeper protocol: implementing agents
+  produce evidence, Codex owns READY / NOT READY verdicts, and production deploy
+  proof requires GitHub plus live VPS verification.
+- `docs/LEAD_PIPELINE_SMOKE.md` added a manual smoke checklist for contact/lead
+  capture, Resend delivery, and safe production proof.
+- `docs/RAILWAY_TWIN_AUDIT.md` added a read-only audit plan for comparing the
+  legacy Railway twin's DB against the VPS before any shutdown decision.
+- `CONTRIBUTING.md`, `TASKS.md`, `DECISIONS.md`, and `SECURITY.md` were updated
+  where stale Railway-production language would mislead future agents.
+
+### Verification (Truthfulness Rule applies)
+- Command: `rg -n "Railway|railway|Gmail|gmail|Resend|VPS|Traefik|auto-deploy|auto deploy|Cloudflare Pages" README.md AGENTS.md ARCHITECTURE.md PROJECT_STATE.md CONTRIBUTING.md TASKS.md DECISIONS.md SECURITY.md docs` → RUN; remaining Railway/Gmail hits are either legacy/historical references or explicit future work.
+- Command: `git diff --check` → PASSED.
+- Command: `rg -n "Cloudflare Pages|Railway deploy|Railway deployment|main auto-deploy|auto-deploys to Railway|Railway as production|Gmail notification|Gmail lead|Gmail \\+ Drive|alert-laughter|AI key in Railway|set .* in Railway|production = Railway" README.md AGENTS.md ARCHITECTURE.md PROJECT_STATE.md CONTRIBUTING.md TASKS.md DECISIONS.md SECURITY.md WORK_LOG.md docs` → RUN; current docs hits are intentional legacy/audit references; remaining stale hits are historical `WORK_LOG.md` entries superseded by this entry.
+
+### Security Notes
+- No production deployment, production data mutation, schema migration, secret readout, or environment variable change performed.
+- No Railway CLI mutation or VPS command was run in this docs-only session.
+
+### Remaining Risks / Requires Human Decision
+1. Railway twin audit still requires authenticated Railway access and Phil's
+   explicit decision on standby vs shutdown after counts are compared.
+2. Lead-pipeline smoke cleanup steps that delete any test rows require explicit
+   Phil approval before mutation.

--- a/docs/CANONICAL_MAP.md
+++ b/docs/CANONICAL_MAP.md
@@ -1,18 +1,21 @@
 # CANONICAL_MAP.md — MalickLand Production Map
 
-> Last verified: 2026-05-31 by Codex using local git state plus read-only DNS/curl probes.
+> Last verified: 2026-06-17 by Codex using read-only DNS/curl, GitHub, and VPS probes.
 > Use this file to prevent repo, domain, and stack confusion before touching MalickLand production work.
 
 ## Canonical Truth
 
 | Layer | Current truth | Evidence |
 |-------|---------------|----------|
-| Live domain | `https://malickland.net` | DNS resolves to `66.33.22.228`; responses are served by Railway |
-| Production stack | Express 5 monolith: `api/` JSON + `app/` static HTML | `railway.toml`, `api/Dockerfile`, `api/server.js`, live `/api/health` |
+| Live domain | `https://malickland.net` | DNS resolves to `31.97.58.203`; responses are served by the Hostinger VPS |
+| Production stack | Express 5 monolith: `api/` JSON + `app/` static HTML, Docker Compose, Traefik, Let's Encrypt | `/docker/wv-property-intelligence/compose.yml`, `api/Dockerfile`, `api/server.js`, live `/api/health` |
 | Production repo | `malickland-304/wv-property-intelligence` | `origin` in `/Users/yhyh7/Projects/wv-property-intelligence` |
-| Production branch | `origin/main` | `origin/main` at `b34e2fb` on 2026-05-31 (PR #77 merged after PR #76) |
+| Production branch | `origin/main` | `origin/main` at `b9d1198` on 2026-06-17 (PR #97 merged) |
 | Canonical local checkout | `/Users/yhyh7/Projects/wv-property-intelligence` | Use this checkout only; run `git fetch origin --prune` and compare against `origin/main` before work |
-| Health URL | `https://malickland.net/api/health` | Live probe returned 200 JSON on 2026-05-31 |
+| Health URL | `https://malickland.net/api/health` | Live probe returned 200 JSON on 2026-06-17 |
+| Production data | SQLite on Docker volume `wv-property-intelligence_wv-data` mounted at `/data` | VPS container `wv-property-intelligence` |
+| Lead notifications | Resend from `noreply@updates.malickland.net` to `phil@malickland.net` | PR #97, VPS startup `Resend configured: true`, Resend delivery logs confirmed delivered test messages |
+| Legacy twin | Railway origin `https://wv-property-intelligence-production.up.railway.app` | Separate DB; audit before standby/shutdown decision |
 | Not production | `malickland-304/malickland.net` | Separate dirty Next.js checkout under Documents; live site is not serving Next.js routes |
 | Not deployed | `listing-system/workers/` | Cloudflare Worker config is experimental/template-level and must not be deployed to apex without an architecture decision |
 | Separate project | `malickland.cloud` | OpenClaw/trading infrastructure; not the MalickLand real estate website |
@@ -61,7 +64,7 @@ Purpose:
 | `/Users/yhyh7/Documents/GitHub/wv-property-intelligence` | Stale clone from earlier consolidation work |
 | `/Users/yhyh7/Documents/Documents - Philip's MacBook Pro - 4/GitHub/malickland.net` | Separate Next.js experiment/prototype, not current production |
 | `/Users/yhyh7/Projects/wv-realestate` | Empty/dead checkout at last verification |
-| `listing-system/workers/` | Experimental Worker path that would conflict with Railway apex routes if deployed blindly |
+| `listing-system/workers/` | Experimental Worker path that would conflict with VPS/Traefik apex routes if deployed blindly |
 
 ## Guardrails
 
@@ -70,8 +73,10 @@ Purpose:
 3. Health is `/api/health`, not `/health`.
 4. Do not edit the Next.js `malickland.net` repo for production fixes unless a documented architecture decision changes the production stack.
 5. Do not run `wrangler deploy` for `listing-system/workers/` without explicit human approval and a recorded route-ownership decision.
-6. Before claiming production deployment, verify Railway or run read-only live smoke checks.
+6. Before claiming production deployment, verify GitHub `origin/main`, live VPS SHA, container health, and read-only live smoke checks.
 
 ## Known Follow-Up
 
-The homepage links `/wv/hampshire-county`, `/wv/hardy-county`, and other county routes, but no matching static pages or Express route currently exists. Track this separately from the public navigation repair.
+Known follow-ups:
+- Audit the Railway twin database for any leads not present on the VPS before deciding standby vs shutdown.
+- Keep `docs/LEAD_PIPELINE_SMOKE.md` current with the manual post-deploy lead verification path.

--- a/docs/LEAD_PIPELINE_SMOKE.md
+++ b/docs/LEAD_PIPELINE_SMOKE.md
@@ -1,0 +1,45 @@
+# Lead Pipeline Smoke Checklist
+
+Use this after a lead-pipeline deploy or when diagnosing delivery. Do not print secret values.
+
+## Preconditions
+
+- Phil explicitly approved the production smoke.
+- `malickland.net` is expected to point to the Hostinger VPS.
+- The VPS app should be at the approved `origin/main` SHA.
+
+## Read-only checks
+
+```bash
+dig +short malickland.net A
+curl -fsS https://malickland.net/api/health
+ssh root@31.97.58.203 'cd /docker/wv-property-intelligence/src && git rev-parse HEAD'
+ssh root@31.97.58.203 'docker ps --filter name=wv-property-intelligence --format "{{.Names}} {{.Status}}"'
+ssh root@31.97.58.203 'for k in RESEND_API_KEY FROM_EMAIL NOTIFICATION_EMAIL; do docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" wv-property-intelligence | grep -q "^${k}=" && echo "${k}=present" || echo "${k}=missing"; done'
+```
+
+Expected:
+
+- DNS returns `31.97.58.203`.
+- `/api/health` returns `{"status":"ok",...}`.
+- VPS SHA matches the approved deploy SHA.
+- Container is healthy.
+- Resend-related env keys are present.
+
+## Controlled live lead test
+
+Only run with Phil approval. Submit one clearly labeled test lead through the live public form or an equivalent same-origin request. Do not use real customer data.
+
+Expected evidence:
+
+- HTTP response is `201`.
+- `contacts` count increases by one.
+- Logs include a Resend send success, for example `[Resend] email sent`.
+- Resend event log shows `Delivered` to `phil@malickland.net`.
+- Remove the test contact row after evidence is captured, only with Phil approval.
+
+## Do not claim done unless
+
+- The row was saved.
+- Resend accepted and delivered the email.
+- Phil confirms inbox receipt, or Resend delivery logs are captured as the authoritative delivery signal.

--- a/docs/RAILWAY_TWIN_AUDIT.md
+++ b/docs/RAILWAY_TWIN_AUDIT.md
@@ -1,0 +1,55 @@
+# Railway Twin Audit Plan
+
+Railway is no longer the current production target for `malickland.net`. It still serves a legacy twin at `https://wv-property-intelligence-production.up.railway.app` with a separate database. Audit it before deciding standby vs shutdown.
+
+## Goal
+
+Determine whether Railway contains any contacts/leads not present on the VPS, without printing secrets or mutating Railway state.
+
+## Preconditions
+
+- Phil authorizes the audit in the current task.
+- Railway CLI is authenticated by Phil (`railway login`) or the dashboard is available.
+- No `railway variables` raw output is pasted into logs or chat.
+
+## Safe audit steps
+
+1. Confirm the Railway service still responds:
+
+   ```bash
+   curl -fsS https://wv-property-intelligence-production.up.railway.app/api/health
+   ```
+
+2. Identify how Railway persists SQLite data:
+
+   - Prefer Railway dashboard volume/file inspection if available.
+   - If CLI access is used, list only metadata and paths; do not print env values.
+
+3. Count records in the Railway DB:
+
+   - `contacts`: count, first timestamp, last timestamp.
+   - `leads`: count, first timestamp, last timestamp.
+
+4. Compare to VPS counts:
+
+   ```bash
+   ssh root@31.97.58.203 'docker exec wv-property-intelligence sh -lc "node -e \"const { db } = require(\\\"./db\\\"); for (const t of [\\\"contacts\\\",\\\"leads\\\"]) console.log(t, db.prepare(\\\"select count(*) as c, min(created_at) as first, max(created_at) as last from \\\" + t).get());\""'
+   ```
+
+5. If Railway has unique rows:
+
+   - Export only the minimum needed fields.
+   - Redact or handle PII carefully.
+   - Decide whether to migrate, archive, or discard with Phil approval.
+
+## Decision outcomes
+
+- **Shutdown:** Only after Railway has no unique leads/contacts and no dependency on its origin URL remains.
+- **Warm standby:** Document its purpose, DB divergence, and a maintenance owner.
+- **Archive:** Export DB backup, store securely, then shut down.
+
+## Hard stops
+
+- Do not run raw `railway variables` in recorded logs.
+- Do not mutate Railway env vars, volumes, or database during the audit.
+- Do not shut down Railway until Phil approves the specific outcome.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -17,15 +17,15 @@
 | Item | Status |
 |------|--------|
 | HEAD (main) | See `PROJECT_STATE.md` — verify with `git rev-parse origin/main` before work |
-| Railway deployment | ✅ Tracks `main` — confirm HEAD in Railway Dashboard → Deployments |
+| VPS deployment | ✅ Manual deploy from `main` to Hostinger VPS `31.97.58.203`; verify live SHA on the box |
 | Authenticated smoke | ✅ PASSED (7/7) — 2026-05-27 |
 | Production smoke path | ✅ `scripts/smoke-prod.sh` is read-only (`GET` health + property page checks only) |
 | npm audit | 0 vulnerabilities (main) |
 | GitHub security queues | ✅ clean — open code-scanning, Dependabot, and secret-scanning alerts all zero on 2026-05-31 |
 | GitHub branch protection | ✅ required checks + conversation resolution; PR review/admin gates intentionally off per `DECISIONS.md` 2026-05-31 |
-| GitHub deployment environments | Railway reports deployments to `alert-laughter / production`; `production` and `copilot` environments exist but do not gate Railway deploys |
+| GitHub deployment environments | GitHub checks gate merge readiness; VPS deployment is manual and requires Phil approval |
 | OpenHands executor | ⏳ NOT LIVE — awaiting token provisioning and runtime start |
-| `API_KEY` in Railway | confirmed present |
+| Legacy Railway twin | Still reachable with separate DB; audit before standby/shutdown |
 
 ---
 
@@ -96,7 +96,7 @@ Issue #66 was fixed by merged PRs #68/#69. The OpenHands npm install blocker now
 - Read this file before acting
 - **Do not commit directly to `main`** unless explicitly approved by the user
 - **Do not mutate production data** during smoke tests
-- **Do not print or echo Railway secrets**
+- **Do not print or echo production secrets**
 - Confirm deployment success before claiming production completion
 - `ADMIN_PASSWORD` for smoke must be supplied at runtime — never hardcoded
 - **Verify your branch before acting:** `git branch --show-current`. If not on the intended branch, `git fetch origin && git checkout main && git pull origin main` before starting work
@@ -108,11 +108,11 @@ Issue #66 was fixed by merged PRs #68/#69. The OpenHands npm install blocker now
 OpenHands operates in supervised sandboxed mode. Non-negotiable:
 - ❌ No autonomous deploys
 - ❌ No merge authority
-- ❌ No Railway production access
+- ❌ No production environment access unless Phil explicitly authorizes it for the current task
 - ❌ No production secrets in sandbox
 - ❌ No direct `main` push
 - Hard limits: 10 iterations max, 30 minutes max, fail closed
-- Sandbox contains only GitHub repo access — no Railway token, no prod DB, no prod API keys
+- Sandbox contains only GitHub repo access — no production token, no prod DB, no prod API keys
 
 ---
 
@@ -135,7 +135,7 @@ See `AGENTS.md` for full operating rules, forbidden actions, and workflow.
 - **CSRF:** `csrf-csrf@^3.2.2` active (PR #63 merged 2026-05-27). Double-submit cookie pattern, `req.csrfToken()` polyfill, session-bound. `csurf` fully removed.
 - **Google APIs:** `api/google.js` uses Node `https` directly — the `googleapis` npm package is NOT a dependency.
 - **Routes:** `/api/properties` and `/api/listings` are alias routes for the same handler. `/properties/:slug` and `/listing/:slug` are both active.
-- **Deploy:** Railway via Dockerfile, branch `main` auto-deploys.
+- **Deploy:** Hostinger VPS via Docker Compose and Traefik. Branch `main` does not auto-deploy.
 - **Smoke scripts:** `scripts/preflight.sh`, `scripts/smoke-admin.sh`, `scripts/smoke-prod.sh`, `scripts/check-env.sh`
 - **Lead capture:** `/api/leads` is mounted; the Google Sheets adapter is local-safe when sheet credentials are absent
 - **CI:** `.github/workflows/preflight.yml` runs `preflight.sh` on all PRs and pushes to `main`.


### PR DESCRIPTION
## What changed

- Updates production docs to state the current truth: `malickland.net` runs on the Hostinger VPS `31.97.58.203` with Docker Compose and Traefik, not Railway.
- Records Railway as a legacy twin with a separate database that must be audited before standby or shutdown.
- Adds the Codex gatekeeper protocol to `AGENTS.md`: implementing agents produce evidence, Codex owns READY / NOT READY, and production proof requires GitHub plus live VPS verification.
- Adds `docs/LEAD_PIPELINE_SMOKE.md` for manual lead capture and Resend delivery checks.
- Adds `docs/RAILWAY_TWIN_AUDIT.md` for a read-only Railway twin DB comparison plan.

## Why

Phase 0 fixed the lead pipeline on the VPS, but repo docs still had stale Railway-production language. That caused agents to plan against the wrong production target and blurred merge, deploy, and readiness authority.

## Validation

- `git diff --check`
- Focused stale-reference scan for Railway/Gmail/Cloudflare Pages production wording across current docs
- No code, schema, production data, VPS env, Railway env, deploy, or secret changes

## Notes

This PR does not touch production. It only records the current operating model and the next read-only audit path.

## Summary by Sourcery

Update documentation and governance files to reflect the Hostinger VPS as the current production environment, formalize Codex as the independent readiness gatekeeper, and add checklists for lead pipeline verification and auditing the legacy Railway twin.

Enhancements:
- Clarify deployment topology across README, ARCHITECTURE, PROJECT_STATE, CANONICAL_MAP, AGENTS, agent-handoff, CONTRIBUTING, TASKS, DECISIONS, and SECURITY to designate the Hostinger VPS with Docker Compose and Traefik as the canonical production stack and Railway as a legacy twin.
- Refine agent roles and workflow so implementing agents collect evidence while Codex owns final READY/NOT READY verdicts based on GitHub and VPS state, with explicit handoff and verification protocols.
- Update product and architecture docs to record Resend as the sole lead notification provider, with Gmail usage limited to legacy or non-lead paths, and to reflect the current lead capture and routes status.

Documentation:
- Add docs/LEAD_PIPELINE_SMOKE.md with a manual checklist for verifying end-to-end lead capture and Resend delivery on the VPS after deploys or incidents.
- Add docs/RAILWAY_TWIN_AUDIT.md describing a safe, read-only plan to compare the legacy Railway twin database against VPS data before any standby or shutdown decision.

Chores:
- Append a WORK_LOG entry summarizing the documentation refresh, production truth update, and governance changes for Codex readiness ownership.