### PR TITLE
fix(smoke): respect PUBLIC_LISTINGS_ENABLED in smoke-prod.sh

### DIFF
--- a/scripts/smoke-prod.sh
+++ b/scripts/smoke-prod.sh
@@ -4,11 +4,39 @@ set -euo pipefail
 BASE="${1:?usage: ./scripts/smoke-prod.sh https://your-site.com}"
 BASE="${BASE%/}"
 
+LOT="advent-dr-lot-hampshire-wv"
+
+http_code() { curl -s -o /dev/null -w '%{http_code}' "$1"; }
+
+# ── Always-on surfaces ────────────────────────────────────────────────
 curl -fsS "$BASE/api/health" >/dev/null
 curl -fsS "$BASE/" >/dev/null
 curl -fsS "$BASE/37-advent" >/dev/null
-# Active listing coverage (the Advent Dr Lot is the current active listing)
-curl -fsS "$BASE/api/properties/advent-dr-lot-hampshire-wv" >/dev/null
-curl -fsS "$BASE/properties/advent-dr-lot-hampshire-wv" >/dev/null
 
-echo "Production smoke passed"
+# ── Listing routes depend on PUBLIC_LISTINGS_ENABLED, surfaced at /api/config ──
+# When listings are OFF (the current production default), the listing detail API
+# intentionally returns 404 and the public listing page redirects, so the smoke
+# must respect the live flag instead of hard-failing on those routes.
+LISTINGS_ENABLED=$(curl -fsS "$BASE/api/config" \
+  | grep -oE '"listingsEnabled"[[:space:]]*:[[:space:]]*(true|false)' \
+  | grep -oE '(true|false)$' || true)
+
+if [ "$LISTINGS_ENABLED" = "true" ]; then
+  # Listings ON: the active Advent Dr Lot must serve on both API and public page.
+  curl -fsS "$BASE/api/properties/$LOT" >/dev/null
+  curl -fsS "$BASE/properties/$LOT" >/dev/null
+  echo "Production smoke passed (listings ENABLED)"
+elif [ "$LISTINGS_ENABLED" = "false" ]; then
+  # Listings OFF: detail API must be gated (404) and the public page must redirect.
+  api_code=$(http_code "$BASE/api/properties/$LOT")
+  page_code=$(http_code "$BASE/properties/$LOT")
+  [ "$api_code" = "404" ] || { echo "FAIL: /api/properties/$LOT expected 404 with listings off, got $api_code" >&2; exit 1; }
+  case "$page_code" in
+    301|302) ;;
+    *) echo "FAIL: /properties/$LOT expected a redirect with listings off, got $page_code" >&2; exit 1 ;;
+  esac
+  echo "Production smoke passed (listings DISABLED; listing routes correctly gated)"
+else
+  echo "FAIL: could not read listingsEnabled from $BASE/api/config" >&2
+  exit 1
+fi

--- a/scripts/smoke-prod.sh
+++ b/scripts/smoke-prod.sh
@@ -17,7 +17,8 @@ curl -fsS "$BASE/37-advent" >/dev/null
 # When listings are OFF (the current production default), the listing detail API
 # intentionally returns 404 and the public listing page redirects, so the smoke
 # must respect the live flag instead of hard-failing on those routes.
-LISTINGS_ENABLED=$(curl -fsS "$BASE/api/config" \
+CONFIG_RESP=$(curl -fsS "$BASE/api/config")
+LISTINGS_ENABLED=$(echo "$CONFIG_RESP" \
   | grep -oE '"listingsEnabled"[[:space:]]*:[[:space:]]*(true|false)' \
   | grep -oE '(true|false)$' || true)
 
@@ -38,5 +39,6 @@ elif [ "$LISTINGS_ENABLED" = "false" ]; then
   echo "Production smoke passed (listings DISABLED; listing routes correctly gated)"
 else
   echo "FAIL: could not read listingsEnabled from $BASE/api/config" >&2
+  echo "Response was: ${CONFIG_RESP:-<empty>}" >&2
   exit 1
 fi


### PR DESCRIPTION
## Problem
After #101, `scripts/smoke-prod.sh` hard-checks the active Advent Dr Lot listing routes. But production runs `PUBLIC_LISTINGS_ENABLED=false`, so `/api/properties/:id` returns **404 by design** → `curl -f` failed the whole smoke against live prod (caught during the post-deploy verification). The deployed site is healthy; only the smoke script was wrong.

## Fix
The script now reads `listingsEnabled` from `/api/config` and asserts behavior **per the flag**:
- **Listings ON** → the active lot must serve on API + page (200).
- **Listings OFF** → the detail API must be gated (**404**) and the public page must **redirect** — i.e., it verifies the flag is actually enforced instead of hard-failing.
- `/api/health`, `/`, and `/37-advent` are always checked.

## Verified
- `bash -n` clean.
- Ran live against `https://malickland.net` (listings OFF): **`Production smoke passed (listings DISABLED; listing routes correctly gated)`**, exit 0.

docs/tooling only — no app code, no deploy.

---

```text
CLAUDE HANDOFF
PR: #<this>
Head SHA: 4e530ba
What changed: scripts/smoke-prod.sh — flag-aware (reads /api/config listingsEnabled); fixes the post-#101 smoke failure when PUBLIC_LISTINGS_ENABLED=false.
What was tested: bash -n; live run vs https://malickland.net (listings OFF) → PASS exit 0.
Known unresolved: none.
Codex: please verify — gh pr view/checks; reviewThreads unresolved=0; no deploy intended (VPS stays e7c2114).
```

## Summary by Sourcery

Update the production smoke test script to respect the live PUBLIC_LISTINGS_ENABLED configuration when validating listing routes.

New Features:
- Add flag-aware checks in the smoke-prod script that read listingsEnabled from /api/config to determine expected behavior for listing routes.

Bug Fixes:
- Fix smoke-prod failures against production where PUBLIC_LISTINGS_ENABLED=false by aligning expected API and page responses with the configured listingsEnabled flag.

Enhancements:
- Verify that listing APIs return 200 when listings are enabled and enforce 404/redirect behavior when listings are disabled, while always checking core health and landing routes.

Tests:
- Rely on the updated smoke-prod.sh script as a more accurate post-deploy verification for production behavior under different listing configurations.