### PR TITLE
fix: respect listings flag in production smoke

### DIFF
--- a/scripts/smoke-prod.sh
+++ b/scripts/smoke-prod.sh
@@ -7,8 +7,26 @@ BASE="${BASE%/}"
 curl -fsS "$BASE/api/health" >/dev/null
 curl -fsS "$BASE/" >/dev/null
 curl -fsS "$BASE/37-advent" >/dev/null
-# Active listing coverage (the Advent Dr Lot is the current active listing)
-curl -fsS "$BASE/api/properties/advent-dr-lot-hampshire-wv" >/dev/null
-curl -fsS "$BASE/properties/advent-dr-lot-hampshire-wv" >/dev/null
+
+CONFIG_JSON="$(curl -fsS "$BASE/api/config")"
+LISTINGS_ENABLED="$(
+  CONFIG_JSON="$CONFIG_JSON" node -e '
+    try {
+      const config = JSON.parse(process.env.CONFIG_JSON || "{}");
+      process.stdout.write(config.listingsEnabled ? "true" : "false");
+    } catch (err) {
+      console.error("Error parsing /api/config JSON:", err.message);
+      process.exit(1);
+    }
+  '
+)"
+
+if [[ "$LISTINGS_ENABLED" == "true" ]]; then
+  # Active listing coverage (the Advent Dr Lot is the current active listing).
+  curl -fsS "$BASE/api/properties/advent-dr-lot-hampshire-wv" >/dev/null
+  curl -fsS "$BASE/properties/advent-dr-lot-hampshire-wv" >/dev/null
+else
+  echo "Public listings disabled; skipped active listing route checks"
+fi
 
 echo "Production smoke passed"


### PR DESCRIPTION
## Summary
- update `scripts/smoke-prod.sh` to read `/api/config`
- keep core production checks for `/api/health`, `/`, and `/37-advent`
- skip active listing API/page checks when `listingsEnabled:false`
- still run Advent Dr Lot API/page checks when public listings are enabled

## Validation
- `bash -n scripts/smoke-prod.sh`
- `bash scripts/smoke-prod.sh https://malickland.net`
- mock `listingsEnabled:true` smoke against local Node server

## Deploy
- No deploy. Smoke tooling only.

## Summary by Sourcery

Gate production smoke checks for active listing routes on the listings feature flag read from /api/config.

New Features:
- Conditionally run Advent Dr Lot API and page smoke checks based on the listingsEnabled flag from the config endpoint.

Enhancements:
- Ensure core production smoke checks still cover health, home page, and Advent route while skipping listing routes when public listings are disabled.