### PR TITLE
docs: add agent triage protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,26 @@ Before asking a user-facing question, an agent must be able to answer:
 
 If the answer is "I am not sure," inspect `PROJECT_STATE.md`, `DECISIONS.md`, GitHub, and the relevant live system first. Do not ask Phil to re-answer closed gates because the chat context is long or confusing.
 
+### Agent Triage Protocol
+
+Before asking Phil to relay status between Claude, Codex, Gemini, GitHub, Squarespace, Railway, or the VPS, run:
+
+```bash
+bash scripts/agent-triage.sh
+```
+
+Use the script output plus `PROJECT_STATE.md` as the shared message bus:
+
+- Pull current PR state from GitHub instead of asking Phil to copy/paste another agent's PR summary.
+- Pull closed facts and open gates from `PROJECT_STATE.md` instead of asking Phil to restate them.
+- Pull live health from `https://malickland.net/api/health` and `/api/config` instead of asking whether production is correct.
+- Treat another agent's chat output as **CLAIMED** until verified by repository files, GitHub, live endpoints, VPS, Railway, or an official source.
+- If the triage output already answers the question, act on it; do not ask Phil to mediate.
+
+Manual chat relay is a last resort, not the operating model. Use it only when the needed source is unavailable to the current agent or requires a human-owned authentication step such as Squarespace login.
+
+Detailed rules live in `docs/AGENT_TRIAGE_PROTOCOL.md`.
+
 ---
 
 ## Architectural Stability Rule

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE.md — Malickland 2.0
 
-> **Last verified:** 2026-06-18 (GitHub `origin/main` @ `f821774` after #104; live prod = Hostinger VPS, src @ `e7c2114`, container healthy; Railway twin deployments removed; WV license `WV0029577` verified vs WV REC roster)
+> **Last verified:** 2026-06-18 (GitHub `origin/main` @ `09bd364` after #106; live prod = Hostinger VPS, src @ `e7c2114`, container healthy; Railway twin deployments removed; WV license `WV0029577` verified vs WV REC roster)
 > **Authority:** Product completeness, repo workspace truth, resolved facts, and open gates. Use `docs/CANONICAL_MAP.md` for repo/domain/stack disambiguation. Deployment runbooks and guardrails remain in `docs/agent-handoff.md`.
 
 ---
@@ -8,6 +8,16 @@
 ## Agent State Ledger
 
 This section is the anti-loop ledger. Agents must read it before asking Phil for status or approval.
+
+### Triage entrypoint
+
+Before asking Phil to relay another agent's status, run:
+
+```bash
+bash scripts/agent-triage.sh
+```
+
+Agents must use `PROJECT_STATE.md`, GitHub PR state, and live production checks as the shared message bus. Chat screenshots and another agent's summaries are only CLAIMED until verified. Manual copy/paste relay is reserved for human-owned authentication boundaries such as Squarespace login.
 
 ### Resolved facts — do not ask again
 
@@ -19,7 +29,7 @@ This section is the anti-loop ledger. Agents must read it before asking Phil for
 | $299 broker admin fee wording | ✅ Approved and live | Homepage and `/37-advent` disclose the fee; broker approval was confirmed before deploy |
 | Brokerage disclosure | ✅ Live | Footer / public pages show `WV Real Estate Agency, LLC | Sheila Judy, Broker` |
 | Production deploy | ✅ Live and verified | Hostinger VPS `31.97.58.203`, src @ `e7c2114`, container `wv-property-intelligence` healthy |
-| PRs #98, #100, #101, #102 | ✅ Merged | `origin/main` includes #102 squash `b6eaefa` |
+| PRs #98, #100, #101, #102, #104, #106 | ✅ Merged | `origin/main` includes #106 squash `09bd364` |
 | `scripts/smoke-prod.sh` | ✅ Fixed | #102 merged; script respects `PUBLIC_LISTINGS_ENABLED` via `/api/config` |
 | Railway twin auto-deploy | ✅ Disabled | Dashboard action confirmed; #102 merge did not create a new Railway deployment |
 | Railway twin deployments | ✅ Removed | `railway deployment list` shows all recent deployments `REMOVED`, including `5927bce6` |
@@ -58,11 +68,11 @@ Before asking Phil anything, identify the open gate in the table above. If no op
 |------|--------|
 | **Active repo** | `/Users/yhyh7/Projects/wv-property-intelligence` |
 | **Remote** | `https://github.com/malickland-304/wv-property-intelligence.git` |
-| **Production branch** | `origin/main` @ `b6eaefa` (#102 merged 2026-06-17) |
-| **Last merged PR** | #102 `fix(smoke): respect PUBLIC_LISTINGS_ENABLED in smoke-prod.sh` |
+| **Production branch** | `origin/main` @ `09bd364` (#106 merged 2026-06-18) |
+| **Last merged PR** | #106 `docs(ledger): record WV license WV0029577 as verified; close that gate` |
 | **Live deploy target** | **Hostinger VPS** `srv1716268` / `31.97.58.203` (Docker + Traefik); deploy is **manual** — merge ≠ deploy. Not Railway. See `docs/CANONICAL_MAP.md` |
 
-`origin/main` is ahead of live production by #102 only. This is expected: #102 changes a smoke script, not runtime app behavior, and does not require deploy. Compare future work against `origin/main`, not a stale local `main`.
+`origin/main` is ahead of live production by docs/governance and smoke-script changes only (#102, #104, #106). This is expected: none of those changes require runtime deploy. Compare future work against `origin/main`, not a stale local `main`.
 
 ### Do not use as source of truth
 
@@ -96,6 +106,8 @@ Recent PRs #98, #100, #101, and #102 are merged. Open issue/PR counts must still
 | **#100** (docs follow-up + Railway decommission record) | ✅ Merged — `9e3db78` on `origin/main` |
 | **#101** (37 Advent closed sale + $299 admin fee disclosure) | ✅ Merged — `e7c2114` on `origin/main`; deployed live |
 | **#102** (production smoke respects listings feature flag) | ✅ Merged — `b6eaefa` on `origin/main`; no deploy needed |
+| **#104** (agent state ledger framework) | ✅ Merged — `f821774` on `origin/main`; no deploy needed |
+| **#106** (WV license verified + ledger cleanup) | ✅ Merged — `09bd364` on `origin/main`; no deploy needed |
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -41,6 +41,7 @@
 
 ## Completed
 
+- [x] **Agent triage protocol** — added `scripts/agent-triage.sh` and `docs/AGENT_TRIAGE_PROTOCOL.md`; agents must run/read durable state before asking Phil to relay Claude/Codex/GitHub/production status — 2026-06-18
 - [x] **Broken county links** — resolved: `/wv/:slug` county-page route exists (`api/routes/public.js:161`); serves county pages when `PUBLIC_LISTINGS_ENABLED=true`, gracefully `302`→`/` when off; homepage `/wv/<county>-county` links are hidden by the listings-off CSS — no 404s (verified live 2026-06-18: `/wv/hampshire-county` → 302)
 - [x] csurf → csrf-csrf migration — PR #63 merged 2026-05-27 — Codex verified, smoke PASSED
 - [x] AI control plane bootstrap (AGENTS.md, OpenHands hooks, issue templates) — PR #64 merged 2026-05-27

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -764,3 +764,31 @@ Apply the State Ledger Rule (#104): verify the one actionable open gate — the 
 1. Funnel packet publish (Squarespace `/start`, PDF lead-magnet, welcome emails) — owner Phil.
 2. Optional alternate marketing/footer wording from Sheila — only if different from the current live-aligned block (not blocking).
 3. Railway hard-delete + `railway.json` removal after the 30-90 day retention window — owner Phil.
+
+---
+
+## 2026-06-18 — Codex (GPT-5) — Agent triage protocol
+
+### Objective
+Turn the anti-loop framework into an executable triage path so Phil does not have to copy/paste status between agents.
+
+### Changes Made
+- `scripts/agent-triage.sh` — added a read-only command that prints resolved facts, open gates, local git state, open GitHub PRs, live production health, and the question rule.
+- `docs/AGENT_TRIAGE_PROTOCOL.md` — added the durable cross-agent triage protocol and Squarespace authentication boundary.
+- `AGENTS.md` — made the triage command mandatory before asking Phil to relay another agent's status.
+- `PROJECT_STATE.md` — added the triage entrypoint to the state ledger.
+- `TASKS.md` — marked the agent triage protocol complete.
+
+### Verification (Truthfulness Rule applies)
+- Command: `git diff --check` → Result: PASSED.
+- Command: `bash -n scripts/agent-triage.sh` → Result: PASSED.
+- Command: `bash scripts/agent-triage.sh` → Result: PASSED; printed resolved facts/open gates, local git state, GitHub open PRs (0 after #106 merged), and live production `/api/health` + `/api/config`.
+
+### Security Notes
+- The triage script is read-only and uses public GitHub API reads plus public production health/config endpoints. It does not read secrets, mutate GitHub, mutate production, or deploy.
+
+### Remaining Risks
+- This protocol cannot make Claude and Codex share private chat state directly. It prevents relay loops by forcing agents to read durable repo/GitHub/live state first.
+
+### Recommended Next Task
+Open a small PR against current `origin/main` so every future agent has the executable triage entrypoint.

--- a/docs/AGENT_TRIAGE_PROTOCOL.md
+++ b/docs/AGENT_TRIAGE_PROTOCOL.md
@@ -1,0 +1,110 @@
+# Agent Triage Protocol
+
+This protocol exists to keep agents from using Phil as a copy/paste bridge between Claude, Codex, GitHub, and production systems.
+
+## Rule
+
+Agents must use durable shared state before asking Phil for status.
+
+Durable state sources, in order:
+
+1. `PROJECT_STATE.md` — resolved facts, closed gates, open gates.
+2. GitHub PR state — checks, mergeability, review comments, head SHA, merged/closed state.
+3. Live production checks — `https://malickland.net/api/health`, `/api/config`, and VPS checks when production state matters.
+4. `WORK_LOG.md` — what an agent actually changed and verified.
+5. Chat transcript or screenshot — only a claim until verified.
+
+## Standard First Command
+
+Run this before asking Phil to relay anything:
+
+```bash
+bash scripts/agent-triage.sh
+```
+
+The command is read-only. It prints:
+
+- resolved facts,
+- open gates,
+- local git state,
+- open GitHub PRs,
+- live production health,
+- the user-question rule.
+
+## Closed-Gate Behavior
+
+If a fact appears under `PROJECT_STATE.md` resolved facts or closed gates:
+
+- do not ask Phil to reconfirm it,
+- do not restate it as uncertain,
+- do not block work on it,
+- verify it directly only when live evidence may have changed.
+
+Examples of closed gates at the time this protocol was added:
+
+- 37 Advent sold for `$170,000`,
+- close date `2026-05-29`,
+- $299 broker admin fee approved and live,
+- broker disclosure live,
+- WV license `WV0029577` verified,
+- Railway twin auto-deploy disabled and deployments removed.
+
+## Open-Gate Behavior
+
+Only ask Phil when the needed item appears as an open gate in `PROJECT_STATE.md`, or when a source requires human-owned authentication.
+
+The question must name:
+
+- the exact open gate,
+- the owner,
+- the missing field or approval,
+- what evidence will close it.
+
+Bad:
+
+```text
+Is the price right?
+Are we ready?
+What should I do next?
+```
+
+Good:
+
+```text
+Open gate: Funnel packet publish. Owner: Phil. Please log into Squarespace in Browser 1; after that I can inspect the existing site and pause before publishing anything public.
+```
+
+## Cross-Agent Handoff
+
+Agents must not rely on human copy/paste when they can query the source directly.
+
+Use this pattern:
+
+```text
+CLAIMED: <what another agent said>
+VERIFIED: <GitHub/repo/live source checked in this run>
+ACTION: <next step based on verified state>
+BLOCKER: <only if a human-owned open gate remains>
+```
+
+## Squarespace Boundary
+
+Squarespace login is a human-owned authentication gate. Agents may open the login page and wait, but they must not enter credentials or use SSO for Phil.
+
+After Phil says `logged in`, agents may inspect the dashboard and must pause before:
+
+- publishing a public `/start` page,
+- uploading or exposing the PDF lead magnet,
+- activating forms,
+- enabling or sending welcome emails.
+
+## Merge / Deploy Boundary
+
+Merge and deploy are separate.
+
+- A clean PR does not imply deploy.
+- A merge does not imply deploy.
+- Production deploy is manual to the Hostinger VPS unless a recorded decision changes that.
+- Railway is not the production target.
+
+Before saying a PR is ready, use the Codex Gatekeeper Protocol in `AGENTS.md`.

--- a/scripts/agent-triage.sh
+++ b/scripts/agent-triage.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="malickland-304/wv-property-intelligence"
+API="https://api.github.com/repos/$REPO"
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+print_state_section() {
+  local heading="$1"
+  awk -v heading="$heading" '
+    $0 ~ "^### " heading { print; in_section=1; next }
+    in_section && /^### / { exit }
+    in_section { print }
+  ' "$ROOT/PROJECT_STATE.md"
+}
+
+section "Agent triage protocol"
+cat <<'TEXT'
+Use this output before asking Phil or relaying between agents.
+- Closed facts/gates in PROJECT_STATE.md are not questions.
+- Open gates are the only valid user prompts.
+- PR and production claims below are CLAIMED until verified live in this run.
+- If this script gives enough evidence, act from it instead of asking Phil to copy/paste.
+TEXT
+
+section "Resolved facts"
+print_state_section "Resolved facts"
+
+section "Open gates"
+print_state_section "Open gates"
+
+section "Git"
+if git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  printf 'worktree: %s\n' "$ROOT"
+  printf 'branch: %s\n' "$(git -C "$ROOT" rev-parse --abbrev-ref HEAD)"
+  printf 'HEAD: %s\n' "$(git -C "$ROOT" rev-parse HEAD)"
+  printf 'dirty files:\n'
+  git -C "$ROOT" status --short --untracked-files
+else
+  printf 'not a git worktree: %s\n' "$ROOT"
+fi
+
+section "GitHub open PRs"
+if need curl; then
+  if need jq; then
+    curl -fsS "$API/pulls?state=open&per_page=20" \
+      | jq -r '.[] | "#\(.number) \(.title) | head=\(.head.sha[0:8]) | base=\(.base.ref) | url=\(.html_url)"'
+  else
+    curl -fsS "$API/pulls?state=open&per_page=20"
+  fi
+else
+  printf 'curl unavailable; cannot verify GitHub PRs\n'
+fi
+
+section "Production health"
+if need curl; then
+  printf 'GET /api/health: '
+  curl -fsS --max-time 10 https://malickland.net/api/health || printf 'FAILED'
+  printf '\nGET /api/config: '
+  curl -fsS --max-time 10 https://malickland.net/api/config || printf 'FAILED'
+  printf '\n'
+else
+  printf 'curl unavailable; cannot verify production health\n'
+fi
+
+section "Question rule"
+cat <<'TEXT'
+Before asking Phil, name the open gate from PROJECT_STATE.md.
+If no listed open gate matches, do not ask. Continue with repo-safe work or report the human-owned blocker.
+TEXT


### PR DESCRIPTION
## Summary
- add a read-only agent triage command that prints resolved facts, open gates, open PRs, local git state, and live production health
- document the no-copy-paste relay protocol and Squarespace login boundary
- wire the protocol into AGENTS.md, PROJECT_STATE.md, TASKS.md, and WORK_LOG.md

## Validation
- git diff --check
- bash -n scripts/agent-triage.sh
- bash scripts/agent-triage.sh

## Production
- No deploy. No production code changes. The script only reads public GitHub API and public malickland.net health/config endpoints.

## Summary by Sourcery

Document and enforce a cross-agent triage protocol and provide a scriptable entrypoint for agents to inspect shared project state before involving Phil.

Enhancements:
- Introduce a read-only agent-triage script that summarizes resolved facts, open gates, local git status, open GitHub PRs, and live production health for agents.

Documentation:
- Add AGENT_TRIAGE_PROTOCOL documentation covering durable state sources, closed/open gate behavior, cross-agent handoff rules, and Squarespace authentication boundaries.
- Update AGENTS, PROJECT_STATE, TASKS, and WORK_LOG docs to require running the triage command and using durable state instead of manual status relay.