### PR TITLE
feat(funnel): /start buyer's-guide landing page + lead magnet

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -51,7 +51,8 @@ Agents must use `PROJECT_STATE.md`, GitHub PR state, and live production checks 
 
 | Gate | Owner | Needed evidence / action | Notes |
 |------|-------|--------------------------|-------|
-| Funnel packet publish | Phil | Publish `/start` to Squarespace, upload the PDF lead-magnet, load the welcome emails | Pack is finalized and publish-ready: license #, brokerage disclosure, and Equal Housing all verified |
+| Funnel `/start` deploy + activation | Phil | Approve deploy of PR #109 to the VPS, then approve (a) exposing the PDF publicly, (b) activating the form for real traffic | Built on the **live VPS site** (Phil's chosen path, not Squarespace). PR #109 = `app/start.html` + Buyer's Guide PDF, posts to `/api/contacts` (`source=buyers-guide`). Local-verified (preflight + live smoke: `/start` 200 with listings off, PDF 200, contacts 201, cross-origin 403). **Merge-candidate only — not deployed.** Awaiting Codex READY verdict |
+| Welcome / nurture emails (funnel phase 2) | Phil | Approve enabling and sending the welcome sequence | Gated separately; emails are a hard pause-point. Not in PR #109 |
 | Optional alternate footer wording from Sheila | Sheila | Sheila-approved exact wording only if she wants something different from the current live-aligned block | Not blocking; the default form is already in the pack. The live fee/brokerage wording is closed |
 | Railway hard-delete after retention | Phil | Explicit approval after 30-90 day retention window | Service/volume retained for rollback window; deployments are removed |
 | Remove `railway.json` and legacy GitHub deployment environments | Phil / repo maintainer | Decision after retention-window hard-delete | Keep until the Railway twin is fully deleted |
@@ -108,6 +109,7 @@ Recent PRs #98, #100, #101, and #102 are merged. Open issue/PR counts must still
 | **#102** (production smoke respects listings feature flag) | ✅ Merged — `b6eaefa` on `origin/main`; no deploy needed |
 | **#104** (agent state ledger framework) | ✅ Merged — `f821774` on `origin/main`; no deploy needed |
 | **#106** (WV license verified + ledger cleanup) | ✅ Merged — `09bd364` on `origin/main`; no deploy needed |
+| **#109** (/start funnel landing page + Buyer's Guide lead magnet) | 🟡 Open — additive (`app/start.html` + PDF); local-verified; awaiting Codex READY; **do not deploy** until Phil approves publish/activation |
 
 ---
 

--- a/app/assets/MalickLand_WV_Buyers_Guide.pdf
+++ b/app/assets/MalickLand_WV_Buyers_Guide.pdf
@@ -1,0 +1,169 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 14 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/PageMode /UseNone /Pages 12 0 R /Type /Catalog
+>>
+endobj
+11 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260617232544-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617232544-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+12 0 obj
+<<
+/Count 6 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R ] /Type /Pages
+>>
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 995
+>>
+stream
+Gasan9lJc?%))O>&D1E.d:ncFceI.slS)jOf*:W=(XGqkYI9WUp4`SEnY9XJ9tN;#K#FN35!G-*$j2A/(4Pi^i-Yat5;?OcAd`!u#ae=p1.rZ$_?=@P!TAd21;tW)as^qh8KHS$3bcd2ENhDoLc.(YM^\V@-eD<91E>#h&?CBn:C.c`$R=[:cNG:/)$D"<R)fB]=emSd0`n_TKIN9gE:c"<Mu8$meam:<rIiiqFRTSS+p/H(r)G#Fr?_U%\nqg67C+Q1,(gL/:LUZ6h"DHO*NF6`[olSGVHIhBe*cqH*D/DUdMGl($J"X;9#;F1+9a,dienS@U^AB1Tjk7s6o%4_\)Y3,Q72@g5M1d_-\F\g0a<%qB4X)#@K;H)Je,\QrLVd-517`?(OF#P<k''UZ<paL8]iStP`kFGFF3U$jgr#o3;c7BoW@'\'7pS>'IcJOK^41T8j*9X8frPTi6rI>19c/_ihpgBk(:#+M4\uRf=]qV79@^h^C"Ib&==^F%8>D&Y(9]):[l5'/qn_9(UqQ=h+'Im<FpG[jB2eI_Nf1EqKT5H2t3Ts(%lU/@aO3[l<IOH'p%Wk>L^DAl,qQD-sU#0G3*+pD-PWAE1,6,4BaeOLHCe8"`2%Ed0/V48si5s\i7gNpDUdr/k?bbA10/J`AX+#ms.&$P=\>&pWeDN(^;]a0W)?E&S"6[O%c:)mO0a<lZbJOrs0B7)1@.j1FWQETG`;i%X\$6ai^[a^_e&'(6,YTO&FVG%F.,4P(ngJNO`:/-1lftrkP36Ak>4NRD6>:^uE=pr<U"sP(MO2!uL5C':^6@#"*g;63Jq^;S2X6p%2?CoeXNr*V/aEPg=CO)?p*I0r'.;qqDW_%])>A[TVqSD!C54G7)g`8%@SO_tD.eAHlMQ3Ner4l[.7U)q-!Tp""C+_peE$[LkHiJ2aqrPiB(!]&/r=F;XN=]%d))o51g:2f2V4m;?:lhshe+]KP$\),u20NYQFtneV<KWT*~>endstream
+endobj
+14 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2272
+>>
+stream
+Gatm<968iI'#+6EFOa\[;_j-sa.>2LST.P&D.`.>0=ekB,[j@J$jg+4Wr;Jb!?`[k[Uc:.8Qd=d@&*Vb2ZrX@5HqoORcs[8IesgU&CTs)K%Q"Gp6mUP:O\gY71a$=6=-7=;%hiF93BQ5^Rn&S;_P&In5?888J<b!%i*oj$lh(LZHU"(A-q+!*(SqEX.SKn7.&cG%gJFQdkJhgD,$p8=XBr+f1_M&5Phf"'tG&AI6UG8s8+G``p$V;LB3\ZD"peC2cP%@P?e,S[suloYNG%7VUW_P6&\+,h9uIMpAH$1a]V'!SS">>LH1^MeV(*/5LT9[c0/cU7E+I`?Xi]@<KFe8KPN=(ZK!5;8b]mHF=5eQOFfJJp^TCL?h\cY*u7G63R[#M*X?#N^(YN^s(r\)l<Xh2nm:VO'&,!$OuW*.4:4#<IUdFoi>.nI@,CSM&A,4jo)'=7@I,&R6'.r(KnJ4!+A)0Ha&YCCLA,VYE/nji$*>VR=)(<1d9k8iFs/pC]b_uEG4^^1dk!A6%#9U0>S(Eor",49r-NF*?id2X(59X-$A:m!1EVK"@1I";FF)fI%%8i.dIJT!bDmY?'lQ0;/emua`2trcVAGcbXhr6!hTpjcEXG8L)Te85_HK[7VS!!M5#X$lKG?(C!KUZ0eCh<_W7d-=SqTTP=QTf'@N@0W@8e`d]BOpbHUXh[,aC:;MU,E/+kT!mgrn-gTN^=fH>q^Zj]M<]Qh'"K30(]A=;[[e!eCRYBW[jc6(Ld#9u[-,F07H83IMGHS@'*kABCiA$Q`\kGcQC\cjLuS^k@0-"1Vs(S5uY.ahgMNe@^CIh5K@Jc1H*dH*ntmbFVW].Ug2Ydo*T7qr&r^?:gH$i$dO>+`^Ihg`6<"=Eo@O`!\"6*DiPRL-+%4p?RQR3B=`gm^2s8K^6iB*egHMk@,nJ]OVGO^c2!7.3$8mi^H^Q]W%^U)pMRRd!LMF?8XE'du'U%.pAm?:LKo'C5*"-\HZ1*/N1RjcAa'..&C6IjN."S]oZ#DDU#$Ok`Ps[,rpq+jICG+!?l"*E;6W"c?<,4[;kDmErbr-E^(LFG9CWah^#V9+H'*2E_##meee8_IH"hK*u4:ne6Hr%1I'!&;hX)ZbL&`N?mONr&gT'%j5TYfJ$Wi7n%AV>CB9YFa]8DTe!b&N]'r;B_3:DFB\q+H8O)j,l,DWFNSkWKgP6^__]VI?N=&UDcU&;Lc=mC@O5m+1E#%,FMGh+F2L,I`1AhS_LO,*&RD7l),e:&R]<=B\*JPL6@e9ILhHBV3CV,%'O,_2!IlsSV<B_,sM(BM497b*3H]8dghD*?f?SH>Sl@mr=@Z[&0m?gDHkd*b!V)>:4cEZh5J17KhFqf4R_cR.X"SXoSFo/,u9XM2Z\-UEKcmH*$CX85f$UXA8H+C]43-uWFXS]W1Mbb#_lfR3EK^S@(l0?/Ik<:%l,6s\nWgH1Y;,qC_OgrSLX%J2Nl]K7]@>ZSlX&f,j!49!AJ<+-Vn-p=kkf]"jeceR'6I@R-:I&%b;q[&+FXqcQRYpN-"!1C<9@b8R,kAWRRm[[EP,k]LH8E::k[Cmh2HA?l?:38OXensk<NIH%0'l7:021QL7nO$6@FJf@cae>^Hi"I,\e?^D/4/S-FhC"Y4B]S\:mfV2;Q?6LMoul!$h,u]n>9KLi)iJI@(KUoCnb^f,^NsfN>)>i5u0")M`e=odf\pSFOS2ae1];7pDnUZ%Wq1hB"B5+@!pUgEH"$a^E3ZRTnsl'eW%8\I%bDlL_)i30&@)Y@u=pQYd%?-DP?p,1e,u.AtLrg>J70T]&FZ9m/$F4Y?VFkR6ZEVeae5OLs>igTpZn/BQ>Z:^+sCd,>9V!5>[Ra6UeEQANSqcA\XuHo2u-BQj#hcCG8#3cAp#t51F?b_IS(-R\>\XetoUm@B5Pal703[#[3ZO&lIp,1L<EEGtjc:.bXi9b_qWm/9.5*4Z'8.BmUD2lat'Vp:bOelTADc5LS?9RV"YS29e=eBsp<7e*POSZX*>sZ4A2!p=gh25)_8"7GO$PS/PUp]A(\=*O$_PJ'X)FNWJJ"ISOjgeQ5.JpZti:.n>A.dsg`FaIrZYTkmUs8nh,CD2h%(X>!"goNBTWX.*uM=ubd^CX)T@aN.TG^L'u&B1P&G]RAkkQs.4CP<V,Tl/U.8@,67A)Y2I*QM*K!N:E>7jFe/qQjPWk&Cf?=*pdb@:bs7PQS+#Y]W1=$Y2!o(AO6o>pOf0=`^UKqh^Z!#,rVSp+XHliP3bA\@6:OVnVc4ZU6GTZ-$>Tt~>endstream
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2314
+>>
+stream
+Gatm<>BAQ-&q9SYfU4Wr[j*U-GTT/?j':BHj7YHhC;8g5VB?1&0+(!7eP(I?G6*kmA4s)f.%ZME/rSQap'M9<s1!Jh"i-T6]Y<C@"\`OD"##2H28#QOI6I1"m`-LS01gg=qY8's8E&%DB-d\CQ[k]S&JPdGTdSVc%\M'.MQpec-=52c7+trYpdc.W/5?6gl8^HZ*D`!"8FS>_i;>O%lg3S6Q;dPtDAG8<2hGCDcGP0\q%6"+NHlX+%P;\:Ig`k2a":VsRNGu/-VSu`UH>%ka&@q5F?Jr^cJ@/t\*uu2*8[/S2@;)"Wm'$=\A!D"?UPUGkCq?pKO<I_NkVKn#?ABmCRqHQW%$pCmZ_GD<nDCuC?_UXDRT\]]=VWJUgY7TWV9b(4Rb_g)I:YIJ'2D'2f5O`[J*X\Vn1]G,7K7g-baiTjGfZ[n2JF97!OLK!a!@rpK2qM6+HN:o/HeIFLV]"7S0t>'n_$M^V7R+(bm6d/*C!FP\&uFBQR5mQn2d#cnu9tBNH]g4?_XQMBe:gj%=tj$HQJp"MT9[pOjo32,dU'V+sT1RBW2e=0dKj?-R.f(s!JuS?!6`H)Y&potAXJfe?E!<DF!&,r>u5p[)/7,MKS*Fb=)b3(kL':JRgq1<)Zn'd>,CAbT_P?)r!"^N3%X4Hier$U%kTEJqh%;o)G&X>L2_\lg.IO@q_#)k)gL#4C$C6E5`eTY8d@[W#FC%Vm]T@RG3`nLS[8#g&4NH,kM9Ku_Ge6>H/E0C]-_=;9-2/b2g3@?+Zb-Ho6tPr&hW2GiOmM[R/O[V0_H`/17'-dV25,4%f:Dn7h"pWa]C8clL[?7pu:fBY.XYu;A6#jVllRGNq0]"OK-V`a;VULn?Q=&ls.4MbLqPXiH1((\/]NA<Sn1:t5$3'X?\k'JIspUf/jn#cj:r(n-.>*Z*G$b\ZY_^Tl@WHBA"SZcJ!CX\4]?)[.pYcFm3N-NL,ee.9DbhEMhcc0`HCLlQ\2'(;5fl@LYjoR;s4Yn%f'spVm9EUWOYuacH@+j*J1,6p'CJ8+P+L;JDT8d9Xf4"JQXp_N<$rn3e-dp`kWDL1Q5L'=;"<=SFe\KD@%F1Q_RUb&7L&$3re(+`t9UZ-a,g.^5?:$PXpcK.o4FDa^;-AT5M?!iS^u?(U?VJ;'I4kd.=fC;+/k1dS^f4g[KE9#3qYDq(S<HoQb0",c=tN\[f99FcL?RZ(H&np4')(T5j9X^Arj>g>L\G`;2dQC_IiNRqPb1RqT<LG^dLKG0.SS?jn?FUPl<*dE*Flic)_o?t/XZ(B[^oLmjTRX;cpS+5NL@hk'F8-QJodr)XD?8lW^H@M"dBbuH*+#mb]TTuI$t8?PP]JuKA"KbMF4=4nYq]+kBE9^F";$_`iQ%m5S&M-r9I0qH#G4O>X@2s=J[Zf>T]2L^-KrW"EhM@ZhoCC:-j.`<8*"2=`+'(m*S35B?pD\K,nAhD2+Wr6IAsbe`:IL4=k$>kq-KdBkmpmSlfQ,]0m.[\1:Y#futTa#Z$/om3TE"Wt4tF&9qEEhb\,?NFdPmj<r!Ee%H=*e$GIJ7?@$tXP7AKJ'eTuVLtA@,6<\mRKO_cmQkS4o+AS5;IVViIEJ3.U[fC-`>t2TD0%VC@\?*_S^DKYregaU4EM\'q&uhoDPH@;DYd'D!i6X1+(\YdCh$I0s4i(TJdaI/X.OH]7R-(ML,n!p%!2-CT1^4QP/gGS/+hlq_p,!;iH18n_0F#*qpj#?I'+jgPP!c)AD9DCn$0M%R;f(Ern([D[m4CD^GHJj`\i^=Wi^:?E0KM+N%RFli=0;,UFmW]JHE^ih4.:j1iB=u/VTjpAfKfimJn1$QU8U>V86PlQ:Tgh=mOR?CZ#!6PVW8a6%G&Di`#ulQ*009>CC299*N)G$8W-MJM*3WfSGkG2Y'RHA,N.$5=.[)2>NieP9VQ1W!]SFc`3ue>\fC(TgJ)lH$ll:$hOB"U2ug&^/6Ue=*!#[lm"1l8aNW7)UOgS2EF4h9M;T4qc2D+[lU.U!?!#bW)%B*TQ2_\'JBO*nTcTMI[Pc!'6==!1.XjL#d>8QJ9@r)$^ElJ=;s1Q>m;7AmPEOM86b4u#i!#"?^-elYDCi+-n5"kLqua+=j_"`.p@/U&5\CJm?L(h+n;a_?Q;\!M[Xi.3!9IU^ZkT\#`HWZK/fZ[4b`K#nh,-gKO0KF>#pX5Oc``TU'g"W55Jja6H`R1B)7=;k=9>2X:'AT7E'u^$pnWE$]4P+6\VI#JkUX7-Y&/[P-[QdrD1m8gg0P?oYS(n=dUHm]d-m,#q07E,mVgu*cZhE\Remm:[dXnE>m.%!B1J"rV~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2210
+>>
+stream
+Gatm<92jkA'#*rf11Cd;9OORgUG'59dqhN-`%p7f/q#1EZE6DFBrXcZNn>Gg?^2Zj)!lF!+[@Mg.5NKhI**ZM^RkCr08Vkgl28[Kc_p#d][-t!H;.bD-\%^IR27,t6r'3I5nr77MkADQ^J4ocZ'/(I3AE*7MBg11()>YtoGeObZ:pg6?jY[b(^AoUX.,nn5]UbNHbE1?WLr2-F@iAhX=Eh>CF0Db+5JQlMRk0;rA]d'pW"rJL[i:jI1MAWD#!2ADQ*&^,Im`,VLQtb=!P<..IM:MTLQ-6>NoHAqr'WmEE:I'V4$If1$9`fS^I-'-2m>nK^KYhX;HA$$U"A=lR+;H_KD8fTm/l"TEhVVI4s]p'IE(di7m^n^HHsg>sF71Ua(<`Z\?2uFfS+hVuJSJ/TiR9]lLR-Z#/6TF$u_j"DQet/U>P%SAG^n^B<>4]8p6S(H?:<LG65bU$!^V3I[%$mmV47^VS'hd-s66JfNAjj',MY^G)Lp'QhO:!]X/LY3VVBZ5.Pc-&aik]i&B6PrK6^4M<4n'P7K-1=sPm0L&d!"Kp5>i_e90#06893n"81D3[^^U=N9O:.lq+\9@(f*nqE+bj/iXUk.HY8R2\rfZO"-h:507%FuNR/&%bT`b\OcFLbebiejW+M`;Z9G5B!b!LTM&Wo@[`Dn]+SSrrPS%?4=;A_i6\LlneBmS%YuN*^;q76-iWab;Y!Q7^mr@G2\(68eXu)HkBY8B-N[a\$";NuE,\C$N9-c5qn!mY8]1%fB]7^J>i3[J"18W&a#]6c<<9>cZ]/UXV);HiW#3J5#P8hDZ6pQ[`'Ba]>>VP:Wk0J.1I&"/=BJWH?t3j<Ce]@LMY^g=`Rg<M;J#^,"A\WTX\T?9)Q/$JSY4VST0n#ut`O.$iepN3aJ,=8@FaD.V']'NQ>)@MF62?+RQ!'M8N6o"(*jT9SHDd>;R`?tt6s%9EKD>o7^C5taDPfdQm[k)<V=^">BuGaA)aEo3o&cXVQI"NVPmX(jVbR$D[u2j?GVeVYFDXHk2@SucP!gtk+?O3H[uVNkP`p`?%8K(*CcNkcT_#R<Y@1%f,;)k`nDlrW[4^V_BO72"fC"YoGW9hpEuj.YsQW>fC;W@SMmGNA.fr];dHip;BH>5SDkh9=Qq40bYBPdT>XK<m-BLeO;(4b#$H!rt(O0]QRbpJJS/,)tiJ1OA&LMLIBrT5@?8&G(d/.+/Y(UWRsl3a^6F<@_Ch4fE.'+&)+i1qDq(iDGQ\Q_</(pX8+6BqB/j5/PqV\0RC'>Tk>\FG_[TGG[L-C.nfP@!]'_R3O29N/PoG6_X4Y5f-JI/]uYq`#4I3A6GBQ3i[suSStU='TC.$o8t'tV/P-gDcM]Y0L[V2pdk,Rm;c\4L_6NgMG9'dP=BJ"cpC;FNR;Us#M(W[K-)sUQ_o"uTmPb<NOi$=@5b,DX6R8UD^tB9BSf]HiZpLIKVAa9mXib\NYM.F[@FROfO8#G.&;&)kA=^c:18m#AVKht[#<olb/Img0@:t#%:;W^8+7Nt_ZsLJk6_f=,-L68A^(Q="JsIM0Tg:PqIiE\)su$7BP$$tT_cfs%9b%QECmBJ--9SX]uq,I=k06>@QC1-ZqF%j"_!.,Zq>RRI!R%%eEFAbeAr-"A#a`-jCukaZ^qY1>ulcq/oN8KY+_b*9%X/D'HWPCG!I@34a$((Z7ag?.;U/h93ga_(Nh=]@C6=N1n=k_P+?k9H.[cTo'g8Y1r3Z_neY!=EZO3k^p`$djjGAr&iZ2;jGkM6!HL$#S7-jpJ-qfcAIj5ol[$ZnqHD/\As?2K'rRg@G2%eNR<a\(54qk!W"K'1_&-]Mq`VX,iU;h5T?NfJU6gjbB%_Cth9(+('3<`D\bkZ[qeG#mj*`!)-oBB=C7pu?B:tXhn[TZ\7Z(K21crg<1qOZ>G(:H$Ftlh[?ntRFU8,XM2At'4c)0X;+8;T!DGC$,%K)X1dSJ?b"IW\)oFhX*AoNFZ1[>\P]G/AAk/9qd\Edb'T5NHS-p-e=#UDk!`t?qYS+!A3ET"d^%?_&Z]g=46Otb%7HMU#?M]1&k<LM00UsZ^bS!fieV1(a2SYOo5M;rVSkBYf9TgooaA(=:?-V06sFYZSZbY81Qd_/+uKW&P7IuCX?LQE75&5=G(jZ`r5P6@bBgk!k]Rj\/>)Oh,;Ic<h2C>D#>]f\.>e<rIImGHa;\,JO.)TZjRmX0O[rXTiJT4J~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2056
+>>
+stream
+Gatm<gN)%,&:O:SlqCcVN6I@t7>cM-j4J(0E@-^JfIqN$85MWH!Xq@e;5YMn"7Y;Sbf!H5@oKmVZ$W^AZgu2VY@mk_"jujl?G6$Qo4a>L(H;FIcKK@inEn#J]kQQRaI1BQl"l5)*e$d!IiV&e6>''BfEnOM=ZCL#G*(275pnC-XN7pcp*([7$%aV%iorr(?qStlD"fu]XAFD,IuAmg5HnB<2ePg]oIlc=78E4Y7UHX<Jc"O4q*B8d"hobk&f^g$m"QL`30MlHB^q?'0?qn8:1:2%">r62*hMf-B4##n"_TidlC-7n?E^k4FqZnuHUD0<0VZ`J(HJ8b9o@Wa9&9!:>rWK(Q^Xft,[GIse!6k46429r6Z0AcI_3=7>sFoL;7grHXhfR<X%!K-U5rlbWk+=ehDpYaG`;#14(a'49]o@S(<LX+i\\7ljqFnAf^<6Nj@pXRJ4#]NpB&[!6?<"lhL0;XcGKm2j\fJs^NtfZ>bd6r<B7G\Ac=ll7b.u%S6)`O<P>/kL=;"#K`RCpe)lcV@2'X73dpp/&/3QN>p#-,q0AcqB/(hd4E1`>D"=]'pFjCn#:3'lOqXTj`E>pY#5>WDC9#mU2CsW\6CU%nj-7HA>W[&O1KAGKWJ30ok@QkY)bsU7YDFQe[,M`KfF94a?mB"GbrdP('[4ZZ?fCsS`Moq@;N&JR;aoFue1i=Ac;S?qV.o;R60ZKqPBb!+Y^LC/ilF'_5eHA/Um^+hb:IUe:"'[$g2:q?7&l$pNTVoh`%qfGpK"RYa4A;7h376NrT?iIJf.J/cQp-b[\#-5npb?=4jeG%A<.0h*u\6oo7t9;hbaYMA%_^J0+ORoiAYPDgcXg1nNN#F2BGsNHD>!tWoCjgXqf;fmu:K]d)*JpoK#RRet_BFX7qo5hJ#Ba3K_HrM2F&SOGXJS_$%<!V`^N3?F.d:=-tj4cEr`cT9-(-O=u^oC+^C0h%<#Gi<>Q=2%8U*O!edq.BX%Ap2Z?nXr9[PRn*@mm.@p:[AdD8Sc]0+`8kZ"$"eH/-QSAW2(BK.81M35C+DlVVFn?c$Y8K&].@#fRiY:(6kMgnjH<-3[92Shl+@:k_WdWniKBNubbOsXguitX0-R9<^oWn7.oA,]i"@FXn3N>;a?YT^;E_jOP)5(SKWIO^J1ahn@m#b$6HN*#r9/D\o-@5SW:_U?"<WV#&+oEqN]i-JAQ*G*MKUEohuKON'MI#sD@A>=0[)@_XdcW'Ub0sr;Z(m`P85N/##ssV"f2SdGU3uLg_`d`oK3@"KB_icY7ZHW,,?@a"&K%/>,t%n]-m63Ou?52)MI\fd948qi&s)#9b%^>[$VQcf8u-!U9q*<9K!d@$b/r(CK9k$'L=DG;[k@4*\E(s\$o7Sj>sF_)]l9:dc&qcWO0m3ecAjsGtC%%WrjV]Kh9JeC/HNVL>.SJ7JZ"M-%Q.NiIX\mZrc(k1>rk*7F6AN7T;tq/c:HW'3F4c$1>3n;Xq:%0s?'>^pC_N\f>^F:nSLOcdYIHDr[5i,5;s(#V'Ss&S@`>QsQ6hX@afoegMGh:KG,))cLoY'PP3l4+g]dT#uHLnb71-Z#up"g(&eHkh)O'CcYd7NU(65HZSVG?2aV\hJZQjY[U,?R\eHMRN;':L-bPak4:9F8b0)p8&LeW`l"5cokTinpIf\VY?7gZYLl.Q'"<V8\!DL>@8dfY^XAA%o9F%I8p4Q/bcI.YbVHQUQZ.JDYBGTUMbJ?jPF`%+3S7,-4/1'T["p0B_6iZ89edD57H9.qc)#/UCTElklB/NN@5<La/aAk8jeo@<"rB.%IO)"!4/SV0n&p_)"bKPqYG9-;BKnSQJ`pOmNOJ[:)^HuCZl1uI"XC?ZgXmjMOiMfOL3V4WUb!16RT(bhS\gKGT:4j:GJ7V_T-h7pCi;MEeS*Q/1,'[gN53qc@Mu0`REYSZ4jlogY,sFe,RUXm(l'<F20')Lo*r_73's=?<Bcl@q7`pk7oJCn$;::JF"n0D9EaFghhNb<;UK(&8^Fk-[nCbe>368r$ILXO/S]nQ.[Ko,+^$V3in\et/:V=U*W-/Ai"5h~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2590
+>>
+stream
+Gatm=flGh,(4GpYgo>X5GF-R9'LdnILE:)J1+B%\Z"<eY0/*]*BT[rLP1$:D5(:c\(WhT2G)qfD\,ZXAm^[[,Eq.bf^I_2mDF/7o4n<uh4HL@=!DUT+EH:XA`/2/nj:B?MNVpV3J1E7$9NRi]$49+47"a+u.ApT6FSt8EU[++e`Q5;WNh!=X&o0Qp0Yj]u]$VoCOI>Z]YJk#gogeeFjE15uA1F".7?Q#Jl.\mCe@`WHO4.OqrqMcV+?]B"hnuJu-N#C''/Fsp'XIS#-@aJ)2r;-b'K2=&^h>Gch;)l?^:U3l.5La%<hbb!0pP255,7ZC4oOlfLotAgAV.YG.GhcpH7hoJ0NO#]8sthlkY@EYh't3\KbDWaeno'H5ONDpf8k\ae-pd'=_#@q\h6u;V*>_'D5t0De_5:tNp!_(3l`rDS\]!tD^>-Q9I5BsbBsQ.rH'-f,&cDL!>L-2pB&[!6?<!iGMa?oU[SRk/d8o]RnN,.1)Sn83W40,`3FAd<&DTThpU=S<+'Sr9+lXODalCUWRc0hc280NB;iZqj:eu#r*^-M^r<I;bCKUT_rOtBjAnfk,:&f'\&duLZC6=lr6SD1eqt%W+;NQI4_/;I7[Ym+kERkac#f8C;(3.frL<%VSrkqLW^ZZVR%N&C(>W,*U81E1$:c:G:f6EMdU7@EQN'gq-D$NgJNcf[%Z"F^7Sr:U-l,q[T@c:-XAn?[*QIF](if8-.=h@#LWM(9L$u=H#1/<Zc@)";OnA,^f&OO4,]D1.)2.d%VDp:=eq4:L,Bj]OJiF/_[pRerL9U^@T06N6NLdhhG%=CZIqee/cQ$^\4qLhen9Zh?8M\5hUXuGJYY3<F>E3oj2I[/V[G+gL3F-C+F#SU4>/,6Nm4O].V,-f*m:VuK]tH0*R.+2^4mn9:2m:5g%g`0%&AIB*&mccMBq=dR1eY?&gnhCjpR1B1<O*0TM2c?oi[Pr+pD@^Pa]qnODJH#J)8$;c;^3_p!;B5FTF2'WIk4`.cOeM'#%,EhE$Z/B7A\q;;^5=^pi6]re0Wm3HnuJ:a!ME1#puQ-in6?+9%R$D.T;UqjWOhVU_lU1n>8`3.1GtQ4I%VkOos**QkXWX&19>+pWsb(8&95&&@nF6.!hHDm\B&1c<X8CWXRZ"\Icne'QHB=/;LR'W^Q"Xd>UCe!gg4$q9oA5NX>HWQkt'KYSPb\"m\ZRYsKEalkL;$8iV<FU0NNEA\CU%6KE0jo2WE?KWo/a[bLOY!X%n6HFm6&V.HI/UCu7QiYR]5&Sd6<LDo`HFC25Fb^2KN6ebIlJt-V:F<14AaNU)Rh3siJV;sa^+$\WGFhVR6d]c;"pG4Wg?M%K"0%be!1*tMk11_?h^"e>daC7l\(q&/ZY$6(0"n5t7[jnO($7XGebo\e\6E*\FH[lC&-ut]X(Z9_X^H_JCZd)rLX/uLbD_oMtM2U*)6LN^BO5@F.k&iId?A!=bDM7KUpGRHf8*j/=B!^WKbW^/Z2DsoWlpE^@PMg>s4u=JrJ'RQMbr.UI#k0tf20YOpmk9tIW&+H?g$sme6!#kNrJ"aUr$l&=mr""^R[&HhT`G);@@*bFJ_Gm;R,`kRo;5K(lRpaEA95g,Q@2_`o%,;D*pePbR(9:P&"2>D#=,l:<d"@jK@Cp]>aMYs24*"-oq'mib`8Gnj7(aAM`#4,3TjkYCeZ9]+$_t+5m`Q$g/L_`]V7f9KZAZ-b,W9,\6-q]7`E'X07p-/Z:E@>_3Wo<_Bi5bl>.ou6hjLo^TMp&#_/%lPSUEa5AOgA3UZ!]B)%8>-o;`jPGDLjgG!C<BN!&AG_9tYSrSAGV<][d!mDr<rT/47!nh([&X0P[1<rd@@uK#/qf/jV(;mHV#XpeD3,Cad=PGl!#a%MCn6Y:fCMN@R>T_s*r&T=ZSVFgNEVZ2qR(TZd4)krE0kZZtklfRXcgA5A$:K/Qi0*L(?5rSq\Ys+Y+'ZB8oeU><JMmh:bO(HF%%X(.FW5F*%dJ]U-Dlr,=gjS8RmThZdh:qm3p6"M5o_`I4:bUmgCXbfJu^!(_pQO0X\g%D!ZO,#d"Ch-['D?W7]Uu92uMb&(VRL(Gt7H!h"RR*Y!`GQD9(s@XjZ$>:UC!BI\dG.>?fa3JZ7gc$a_5>*e"DXEHsN\H@9PWam9K"Bik%QHEUc68bK#JD&]'PoD3=UXmU7q^2&^&?>*Obkk=gYq!(oINj,R",eYM[8u!FAo^YX\8BC0,Ol$]DU[V`:KAo^7hdpRCG%="CRC\A9gj]6A8Y89NW[DN')7O$72uUPB'Yh\P-lNcqWgBa\Kl.[If;GorkiV`Z"^Q,U73CSgApRn]\d#Quf9[[_#`W+crDS\"&]#&,jX%GN4Z-]tNSl\]2@iJp3KrA&7%1ONqG-NsW@GJMF"hMO\_K[LH?&VLhO1r'=%rQ0#1!/iRF[dR;lO#&lnf2kl@m&oUreLR/=rVPTe#rI4!S!+,o!he1-Tu\E`M'a'aY8XHgG^<NO50u[,DgcbX=1N%]fJZ13qJC_RG]72LNmN(J1@eU;GIW9X9q/Z/-0-]Is4S8#(%-\V3^,NL8FS;%t0hjpI:5]S2+q2;t8aIk!iIq&f4>]!)~>endstream
+endobj
+xref
+0 19
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000516 00000 n 
+0000000711 00000 n 
+0000000906 00000 n 
+0000001101 00000 n 
+0000001296 00000 n 
+0000001491 00000 n 
+0000001561 00000 n 
+0000001842 00000 n 
+0000001932 00000 n 
+0000003018 00000 n 
+0000005382 00000 n 
+0000007788 00000 n 
+0000010090 00000 n 
+0000012238 00000 n 
+trailer
+<<
+/ID 
+[<783166beedb587b031af7690a717a961><783166beedb587b031af7690a717a961>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 11 0 R
+/Root 10 0 R
+/Size 19
+>>
+startxref
+14920
+%%EOF

--- a/app/start.html
+++ b/app/start.html
@@ -100,6 +100,7 @@
   <section class="form-wrap" id="get-guide">
     <div class="shell">
       <div class="form-card">
+        <div id="leadCapture">
         <h2>Get the guide</h2>
         <p class="form-intro">Tell Phil a little about what you're looking for and the guide is yours. If you add a property type or county, he can follow up with specific local guidance.</p>
         <form id="startLeadForm">
@@ -136,10 +137,11 @@
           <button type="submit" id="startSubmitBtn" class="btn submit-btn">Send Me the Guide</button>
           <p id="startFormStatus" class="status" role="status" aria-live="polite"></p>
         </form>
+        </div>
         <div class="success-panel" id="successPanel">
           <p style="margin:0 0 4px;font-weight:700;color:var(--forest);">Thanks &mdash; your guide is ready.</p>
           <p style="margin:0;color:var(--muted);">If you included a property type or county, Phil will follow up with specific local guidance.</p>
-          <a href="/assets/MalickLand_WV_Buyers_Guide.pdf" class="btn btn-gold" download>Download the Buyer's Guide (PDF)</a>
+          <a href="/assets/MalickLand_WV_Buyers_Guide.pdf" class="btn btn-gold" download target="_blank" rel="noopener">Download the Buyer's Guide (PDF)</a>
         </div>
       </div>
     </div>
@@ -198,10 +200,11 @@
           });
           var data = await response.json().catch(function () { return {}; });
           if (!response.ok) throw new Error(data.error || 'There was a problem. Please try again.');
-          form.style.display = 'none';
+          var capture = document.getElementById('leadCapture');
+          if (capture) capture.style.display = 'none';
           status.textContent = '';
           successPanel.classList.add('show');
-          successPanel.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          successPanel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         } catch (error) {
           status.textContent = error.message || 'There was a problem. Please try again.';
           status.classList.add('error');

--- a/app/start.html
+++ b/app/start.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>West Virginia Buyer's Guide | MalickLand</title>
+  <meta name="description" content="Download a practical West Virginia buyer's guide for homes, land, cabins, and investment property in the Eastern Panhandle and Potomac Highlands." />
+  <meta property="og:title" content="West Virginia Buyer's Guide | MalickLand" />
+  <meta property="og:description" content="A practical guide for buyers comparing homes, acreage, cabins, and investment property across West Virginia." />
+  <meta property="og:type" content="website" />
+  <style>
+    :root {
+      --bg: #f4f0e7; --paper: #fcfbf7; --ink: #111111; --muted: #5f5a52;
+      --line: #cfc2aa; --gold: #af8242; --gold-dark: #8b632b; --forest: #162017;
+      --forest-soft: #223126; --white: #ffffff; --shadow: 0 14px 40px rgba(17,17,17,0.12);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0; font-family: "Avenir Next", "Segoe UI", sans-serif; color: var(--ink);
+      background: radial-gradient(circle at top left, rgba(175,130,66,0.12), transparent 28%),
+        linear-gradient(180deg, #f7f3eb 0%, #efe7da 100%);
+      line-height: 1.55;
+    }
+    a { color: inherit; }
+    .shell { max-width: 1020px; margin: 0 auto; padding: 0 22px; }
+    .hero { background: linear-gradient(160deg, var(--forest) 0%, var(--forest-soft) 100%); color: var(--white); }
+    .hero .shell { padding: 60px 22px 66px; }
+    .eyebrow { text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.78rem; color: var(--gold); font-weight: 700; margin: 0 0 14px; }
+    .hero h1 { font-size: 2.5rem; line-height: 1.12; margin: 0 0 16px; max-width: 16ch; }
+    .hero p { font-size: 1.12rem; color: #e9e1d2; max-width: 60ch; margin: 0 0 26px; }
+    .btn { display: inline-block; border: none; border-radius: 8px; padding: 14px 26px; font-size: 1rem; font-weight: 700; cursor: pointer; text-decoration: none; }
+    .btn-gold { background: var(--gold); color: var(--forest); }
+    .btn-gold:hover { background: var(--gold-dark); color: var(--white); }
+    .btn-ghost { background: transparent; color: var(--white); border: 1px solid rgba(255,255,255,0.5); margin-left: 12px; }
+    .section { padding: 54px 0; }
+    .section-title { font-size: 1.9rem; color: var(--forest); margin: 0 0 8px; }
+    .lead { color: var(--muted); max-width: 62ch; margin: 0 0 28px; }
+    .grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+    .card { background: var(--paper); border: 1px solid var(--line); border-radius: 12px; padding: 22px 24px; box-shadow: var(--shadow); }
+    .card h3 { margin: 0 0 6px; color: var(--gold-dark); font-size: 1.12rem; }
+    .card p { margin: 0; color: var(--muted); font-size: 0.98rem; }
+    .form-wrap { background: var(--forest); color: var(--white); }
+    .form-wrap .shell { padding: 52px 22px 60px; }
+    .form-card { background: var(--paper); color: var(--ink); border-radius: 14px; padding: 30px 30px 34px; box-shadow: var(--shadow); max-width: 640px; margin: 0 auto; }
+    .form-card h2 { color: var(--forest); margin: 0 0 6px; font-size: 1.7rem; }
+    .form-intro { color: var(--muted); margin: 0 0 22px; }
+    .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .row { display: flex; flex-direction: column; }
+    .row.full { grid-column: 1 / -1; }
+    label { font-size: 0.85rem; font-weight: 600; margin-bottom: 5px; color: var(--forest-soft); }
+    input, select, textarea { font: inherit; padding: 11px 12px; border: 1px solid var(--line); border-radius: 8px; background: var(--white); color: var(--ink); }
+    input:focus, select:focus, textarea:focus { outline: 2px solid var(--gold); border-color: var(--gold); }
+    .submit-btn { width: 100%; margin-top: 20px; background: var(--gold); color: var(--forest); }
+    .submit-btn:hover { background: var(--gold-dark); color: var(--white); }
+    .status { margin: 14px 0 0; font-weight: 600; min-height: 1.2em; }
+    .status.success { color: #1f7a44; }
+    .status.error { color: #b3261e; }
+    .success-panel { display: none; margin-top: 18px; padding: 20px; border: 1px solid var(--line); border-radius: 10px; background: #f3f7f1; text-align: center; }
+    .success-panel.show { display: block; }
+    .success-panel .btn-gold { margin-top: 12px; }
+    footer { background: #11160f; color: #cdbf9f; font-size: 0.82rem; }
+    footer .shell { padding: 30px 22px; }
+    footer .contact { color: #f7f4ec; font-weight: 600; margin: 0 0 8px; }
+    footer .legal { color: #9d937f; line-height: 1.6; margin: 0; }
+    @media (max-width: 680px) { .hero h1 { font-size: 1.95rem; } .grid, .form-grid { grid-template-columns: 1fr; } .btn-ghost { margin-left: 0; margin-top: 10px; } }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="shell">
+      <p class="eyebrow">Free West Virginia Buyer's Guide</p>
+      <h1>Buy WV homes, land, and mountain property with a clearer plan.</h1>
+      <p>A practical guide for buyers comparing homes, acreage, cabins, and investment property across the Eastern Panhandle and Potomac Highlands. Learn what to check before you write an offer &mdash; financing, commute, water, septic, access, restrictions, and resale logic.</p>
+      <a href="#get-guide" class="btn btn-gold">Download the Guide</a>
+      <a href="tel:+15402461421" class="btn btn-ghost">Talk with Phil</a>
+    </div>
+  </header>
+
+  <section class="section">
+    <div class="shell">
+      <h2 class="section-title">What the guide helps you avoid</h2>
+      <p class="lead">The most expensive mistakes in WV real estate are avoidable when you know what to check first.</p>
+      <div class="grid">
+        <div class="card"><h3>Financing surprises</h3><p>Know why the buyer, the property, and the address all matter to whether a loan closes.</p></div>
+        <div class="card"><h3>Land mistakes</h3><p>Check access, water, septic, utilities, restrictions, and survey issues before deadlines pass.</p></div>
+        <div class="card"><h3>Commute assumptions</h3><p>Compare counties and verify real door-to-door timing, including MARC access where relevant.</p></div>
+        <div class="card"><h3>Weak investment math</h3><p>Think through buyer pool, resale, rental demand, repair cost, and exit strategy.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" style="padding-top:0;">
+    <div class="shell">
+      <h2 class="section-title">Built for West Virginia buyers</h2>
+      <p class="lead">Phil Malick works with buyers across Berkeley, Morgan, Jefferson, Hampshire, Hardy, and Mineral Counties. Whether you are local, relocating, commuting, investing, or looking for land, the right first step is a practical conversation about the property type and county that actually fit.</p>
+    </div>
+  </section>
+
+  <section class="form-wrap" id="get-guide">
+    <div class="shell">
+      <div class="form-card">
+        <h2>Get the guide</h2>
+        <p class="form-intro">Tell Phil a little about what you're looking for and the guide is yours. If you add a property type or county, he can follow up with specific local guidance.</p>
+        <form id="startLeadForm">
+          <input type="hidden" name="source" value="buyers-guide" />
+          <input type="hidden" name="utm_source" id="utm_source" />
+          <input type="hidden" name="utm_medium" id="utm_medium" />
+          <input type="hidden" name="utm_campaign" id="utm_campaign" />
+          <div class="form-grid">
+            <div class="row"><label for="name">First name *</label><input id="name" name="name" type="text" required /></div>
+            <div class="row"><label for="email">Email *</label><input id="email" name="email" type="email" required /></div>
+            <div class="row"><label for="phone">Phone (optional)</label><input id="phone" name="phone" type="tel" /></div>
+            <div class="row">
+              <label for="lookingFor">What are you looking for?</label>
+              <select id="lookingFor" name="lookingFor">
+                <option value="">Select one</option>
+                <option value="Home">Home</option>
+                <option value="Land">Land</option>
+                <option value="Cabin">Cabin</option>
+                <option value="Investment">Investment</option>
+                <option value="Not sure">Not sure</option>
+              </select>
+            </div>
+            <div class="row"><label for="county">Target county (optional)</label><input id="county" name="county" type="text" placeholder="e.g. Hampshire" /></div>
+            <div class="row">
+              <label for="timeline">Timeline (optional)</label>
+              <select id="timeline" name="timeline">
+                <option value="">Select one</option>
+                <option value="Ready now">Ready now</option>
+                <option value="30-90 days">30-90 days</option>
+                <option value="Just looking">Just looking</option>
+              </select>
+            </div>
+          </div>
+          <button type="submit" id="startSubmitBtn" class="btn submit-btn">Send Me the Guide</button>
+          <p id="startFormStatus" class="status" role="status" aria-live="polite"></p>
+        </form>
+        <div class="success-panel" id="successPanel">
+          <p style="margin:0 0 4px;font-weight:700;color:var(--forest);">Thanks &mdash; your guide is ready.</p>
+          <p style="margin:0;color:var(--muted);">If you included a property type or county, Phil will follow up with specific local guidance.</p>
+          <a href="/assets/MalickLand_WV_Buyers_Guide.pdf" class="btn btn-gold" download>Download the Buyer's Guide (PDF)</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="shell">
+      <p class="contact">Phil Malick | MalickLand | (540) 246-1421 | phil@malickland.net</p>
+      <p class="legal">Real estate services by Phil Malick through WV Real Estate Agency, LLC &middot; Sheila Judy, Broker &middot; Licensed in West Virginia &middot; WV License #WV0029577 &middot; 501 E Main St, Romney, WV 26757 &middot; Equal Housing Opportunity.</p>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var params = new URLSearchParams(window.location.search);
+      var form = document.getElementById('startLeadForm');
+      var status = document.getElementById('startFormStatus');
+      var button = document.getElementById('startSubmitBtn');
+      var successPanel = document.getElementById('successPanel');
+      var utm = { utm_source: document.getElementById('utm_source'), utm_medium: document.getElementById('utm_medium'), utm_campaign: document.getElementById('utm_campaign') };
+      Object.keys(utm).forEach(function (k) { if (utm[k]) utm[k].value = params.get(k) || ''; });
+      if (!form) return;
+
+      form.addEventListener('submit', async function (event) {
+        event.preventDefault();
+        status.textContent = ''; status.className = 'status';
+        button.disabled = true; button.textContent = 'Sending...';
+
+        var parts = [];
+        if (form.county.value.trim()) parts.push('County: ' + form.county.value.trim());
+        if (form.timeline.value) parts.push('Timeline: ' + form.timeline.value);
+        parts.push('Buyer’s Guide download');
+        var utmBits = [];
+        if (form.utm_source.value) utmBits.push('src=' + form.utm_source.value);
+        if (form.utm_medium.value) utmBits.push('med=' + form.utm_medium.value);
+        if (form.utm_campaign.value) utmBits.push('camp=' + form.utm_campaign.value);
+        if (utmBits.length) parts.push('[' + utmBits.join(' ') + ']');
+
+        var payload = {
+          name: form.name.value.trim(),
+          email: form.email.value.trim(),
+          phone: form.phone.value.trim(),
+          interest: form.lookingFor.value,
+          message: parts.join(' · '),
+          source: 'buyers-guide',
+          utm_source: form.utm_source.value,
+          utm_medium: form.utm_medium.value,
+          utm_campaign: form.utm_campaign.value
+        };
+
+        try {
+          var response = await fetch('/api/contacts', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+          var data = await response.json().catch(function () { return {}; });
+          if (!response.ok) throw new Error(data.error || 'There was a problem. Please try again.');
+          form.style.display = 'none';
+          status.textContent = '';
+          successPanel.classList.add('show');
+          successPanel.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        } catch (error) {
+          status.textContent = error.message || 'There was a problem. Please try again.';
+          status.classList.add('error');
+          button.disabled = false; button.textContent = 'Send Me the Guide';
+        }
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What this is
The content-funnel landing page on the **live VPS site** (Phil's chosen path). Adds a `/start` page that captures a lead and delivers the WV Buyer's Guide PDF.

**Scope: 2 files, additive only.**
- `app/start.html` — self-contained landing page (brand-matched to `37-advent.html`, inline CSS, no new deps, no new routes — served by the existing static middleware).
- `app/assets/MalickLand_WV_Buyers_Guide.pdf` — the lead magnet (6 pages, 15.5 KB).

## How it works
- Lead form → same-origin JSON `POST /api/contacts` with `source=buyers-guide`.
- `interest` folds into the message (`[Interest: …]`); county/timeline/UTM captured in the message body (contacts table has no dedicated columns).
- On success the form is replaced by the **PDF download** (`/assets/MalickLand_WV_Buyers_Guide.pdf`) — gated behind the form as the capture step.
- Footer carries the **approved broker disclosure** (WV Real Estate Agency, LLC · Sheila Judy, Broker · WV License #WV0029577 · Equal Housing Opportunity).

## Verification (local, evidence)
- `scripts/preflight.sh` → **PRE-FLIGHT PASSED**.
- Live server, **`PUBLIC_LISTINGS_ENABLED=false` (prod config)**:
  - `GET /start` → **200** text/html (proves it is NOT gated by the listings-off flag).
  - `GET /assets/MalickLand_WV_Buyers_Guide.pdf` → **200** application/pdf, 15516 bytes.
  - `POST /api/contacts` (same-origin) → **201**; row stored with `source=buyers-guide` and `[Interest: Land]` folded.
  - `POST /api/contacts` cross-origin → **403** (same-origin guard intact).
- `/start` contains none of the `listings-off` hidden selectors, so it is unaffected even if the class is ever injected.

## ⛔ Deploy / activation gates (NOT in this PR)
Per Phil's standing instruction, this is **merge-candidate only — do not deploy**. Still pending Phil's explicit go on each of:
1. Publishing `/start` (deploy to VPS).
2. Exposing the PDF publicly.
3. Activating the form for real traffic.
4. Any welcome/nurture emails (phase 2).

## CLAUDE HANDOFF → Codex
Requesting a READY verdict. Evidence above; I am **not** self-declaring READY. Truth = GitHub checks + VPS. Branch head: see commit `98831b4`.

## Summary by Sourcery

Add a new /start content-funnel landing page that captures leads for the West Virginia Buyer's Guide and delivers the PDF via an existing static asset.

New Features:
- Introduce a dedicated /start landing page with marketing content tailored to West Virginia real estate buyers.
- Add a lead-capture form that posts contact details and buyer interest to the existing /api/contacts endpoint and gates access to the buyer's guide download.
- Serve the West Virginia Buyer's Guide as a new static PDF asset for download after successful form submission.

Enhancements:
- Capture basic UTM parameters with the lead form submission for simple source attribution.