### PR TITLE
fix(deps): bump multer 2.1.1 → 2.2.0 — clear high-sev DoS advisory (GHSA-72gw-mp4g-v24j, GHSA-3p4h-7m6x-2hcm)

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -122,13 +122,13 @@ Recent PRs #98, #100, #101, and #102 are merged. Open issue/PR counts must still
 | Health endpoint | **`GET /api/health`** — not `/health` (mounted in `api/routes/api.js`) |
 | Live config | ✅ `/api/config` → `listingsEnabled:false` (public listing API routes are intentionally gated off) |
 | 37 Advent live DB row | ✅ `status='sold'`, `price=170000`, `sold_at='2026-05-29'` |
-| npm audit | ✅ 0 vulnerabilities (verified on fix branch 2026-05-31) |
+| npm audit | ✅ 0 vulnerabilities — re-verified 2026-06-18 on `fix/multer-dos-advisory` (`npm audit` **and** `npm audit --omit=dev` both 0 high/critical). Supersedes the 2026-05-31 "0 vulns": a **high-sev `multer` DoS** advisory (GHSA-72gw-mp4g-v24j deeply-nested field names; GHSA-3p4h-7m6x-2hcm aborted-upload cleanup; affected ≤2.1.1) surfaced 2026-06-17 and was remediated by bumping `multer` 2.1.1→**2.2.0** (lockfile via `npm audit fix`) |
 | Security test suite | ✅ **57/57** locally on 2026-06-18 (`node tests/verify-security-fixes.test.js`) |
 | Preflight + route smoke | ✅ `scripts/preflight.sh` passed locally on 2026-06-04 |
 | CI gates | ✅ CodeQL, Semgrep, `preflight.yml` |
 | Branch protection | Required status checks enabled (`CodeQL`, `verify`, `check`, `CodeScan`, `semgrep-cloud-platform/scan`); required conversation resolution enabled; PR review protection and admin enforcement intentionally off per `DECISIONS.md` 2026-05-31 |
 | Governance files | ✅ `README.md`, `CONTRIBUTING.md`, `.github/CODEOWNERS`, issue templates, and PR template present |
-| GitHub security queues | ✅ Open code-scanning alerts: 0; Dependabot alerts: 0; secret-scanning alerts: 0 (2026-05-31 API audit) |
+| GitHub security queues | ✅ Open code-scanning alerts: 0; Dependabot alerts: 0; secret-scanning alerts: 0 (2026-05-31 API audit) — ⚠️ predates the 2026-06-17 high-sev `multer` DoS advisory (Dependabot/npm-audit class), remediated on `fix/multer-dos-advisory` (multer 2.1.1→2.2.0); re-query queues after that PR merges |
 | Remote branches | ✅ Only protected `main` remains on `origin` after stale branch cleanup (2026-05-31) |
 | Railway twin | ✅ Not live; auto-deploy disabled; all deployments removed. `railway deployment list` shows all recent deployments `REMOVED`. Retain service/volume until hard-delete after the 30-90 day backup window |
 | GitHub environments | Legacy Railway deployment statuses (`alert-laughter / production`) and the `production`/`copilot` environments are **not** gating and no longer reflect the live target (prod is the Hostinger VPS) — remove after Railway retention hard-delete |

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -827,3 +827,36 @@ Remove the repo-side blocker that made admin-uploaded listing photos depend on t
 
 ### Recommended Next Task
 Open PR for review. After merge, schedule a controlled VPS deploy/migration only with explicit Phil approval.
+
+---
+
+## 2026-06-18 — Claude Code (Opus 4.8) — fix/multer-dos-advisory
+
+### Objective
+Remediate the high-severity `multer` DoS advisory (production dependency powering admin photo upload). Two advisories: GHSA-72gw-mp4g-v24j (DoS via deeply nested field names) and GHSA-3p4h-7m6x-2hcm (DoS via incomplete cleanup of aborted uploads); affected `multer` 1.0.0–2.1.1. This postdated the 2026-05-31 "0 vulnerabilities" audit, so `PROJECT_STATE.md` was stale on that point.
+
+### Changes Made
+- `api/package-lock.json` — `npm audit fix` bumped `multer` 2.1.1 → **2.2.0** (lockfile-only; non-`--force`, no breaking major bump). `api/package.json` caret `^2.1.1` already admits 2.2.0; per AGENTS.md the lockfile is canonical and installs are `npm ci`-only, so the manifest floor was intentionally left unchanged rather than hand-editing the lockfile or running `npm install` to resync a floor bump.
+- `PROJECT_STATE.md` — updated the `npm audit` line and the GitHub-security-queues note to record the advisory + remediation.
+- `WORK_LOG.md` — this entry.
+- Done in an isolated git worktree branched off `origin/main` @ `0da3357`, then **rebased onto `origin/main` @ `345d509`** (after PRs #108/#109 merged) with the `PROJECT_STATE.md` / `WORK_LOG.md` coordination-file conflicts resolved by combining both sides; all gates re-run on the rebased base (below). Phil's uncommitted WIP on `feat/listings-feature-flag` was left untouched.
+
+### Verification (Truthfulness Rule applies)
+- Command: `npm ci` (api/) → PASSED — 178 pkgs; lock⇄package.json consistent; deterministically installs multer 2.2.0.
+- Command: `npm audit` (api/) → PASSED — found 0 vulnerabilities (JSON totals high 0 / critical 0).
+- Command: `npm audit --omit=dev` (api/) → PASSED — found 0 vulnerabilities (prod-only high 0 / critical 0).
+- Command: `node --check` on server.js, db.js, middleware/auth.js, routes/{api,public,admin}.js → PASSED (all parse; multer 2.2.0 resolves).
+- Command: `bash scripts/preflight.sh` → PASSED ("PRE-FLIGHT PASSED", exit 0).
+- Command: `node tests/verify-security-fixes.test.js` → PASSED — 57/57 (on rebased base; suite grew 54→57 via #108).
+- Live upload round-trip (server on temp DB + ephemeral port, multer 2.2.0): authed + CSRF + valid JPEG → HTTP 200 `{"ok":true,"filename":…}` with raw/compressed/mls files written; authed + no CSRF → 403; anonymous → 403.
+
+### Security Notes
+- Middleware order for `POST /admin/upload/:slug` (read from `api/server.js:153` + `api/routes/admin.js:318`): app-level `doubleCsrfProtection` (csrf-csrf) → `requireAuth` → `requireCsrf` → `uploadRateLimit` → `upload.single('photo')` (**multer LAST**). multer parses the body **after** auth + CSRF + rate-limiting — the DoS surface is unreachable without a valid admin session + CSRF token (empirically: anon and no-CSRF requests both 403 before any file is processed). No ordering regression — source is `origin/main`, unchanged by a lockfile bump.
+- multer 2.1.1 → 2.2.0 is a minor, API-compatible release (`diskStorage`, `single`, `limits`, `fileFilter` unchanged).
+
+### Remaining Risks
+- None identified for this change. Re-query GitHub code-scanning / Dependabot / secret-scanning queues after merge to confirm the Dependabot alert clears.
+- **Not deployed** — deploy to the Hostinger VPS is Phil's gate (merge ≠ deploy).
+
+### Recommended Next Task
+Per External Assistant / Codex Handoff Protocol: Codex independently verifies (gh pr view / gh pr checks / reviewThreads unresolved=0 / VPS SHA unchanged) and issues the READY/NOT READY verdict. Claude does not self-declare ready.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1705,9 +1705,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",


### PR DESCRIPTION
## What

Bump **multer** 2.1.1 → **2.2.0** (lockfile only) to clear a **high-severity** DoS advisory. `multer` is a production dependency powering admin photo upload.

Closes #110.

## Why

`npm audit` in `api/` flagged two high-severity advisories affecting multer 1.0.0–2.1.1:

- **GHSA-72gw-mp4g-v24j** — DoS via deeply nested field names
- **GHSA-3p4h-7m6x-2hcm** — DoS via incomplete cleanup of aborted uploads

This postdated the 2026-05-31 "0 vulnerabilities" audit, so `PROJECT_STATE.md` was stale on the npm-audit + security-queue lines.

## Change

- `api/package-lock.json` — `multer` 2.1.1 → 2.2.0 via `npm audit fix` (non-`--force`; minor, API-compatible; within the existing `^2.1.1` range).
- `api/package.json` — **unchanged on purpose.** The caret `^2.1.1` already admits 2.2.0; the lockfile is canonical and installs are `npm ci`-only per AGENTS.md, so the manifest floor was *not* hand-edited and the lockfile was *not* hand-edited / `npm install`-resynced.
- `PROJECT_STATE.md` — npm-audit line + GitHub-security-queues note updated to record the advisory + remediation.
- `WORK_LOG.md` — session entry.

## How to validate (all run on this branch @ HEAD)

| Check | Result |
|---|---|
| `cd api && npm ci` | 178 pkgs; lock⇄manifest consistent; installs multer 2.2.0 |
| `npm audit` | **found 0 vulnerabilities** (high 0 / critical 0) |
| `npm audit --omit=dev` | **found 0 vulnerabilities** (prod-only high 0 / critical 0) |
| `node --check` server.js, db.js, middleware/auth.js, routes/{api,public,admin}.js | all parse |
| `bash scripts/preflight.sh` | **PRE-FLIGHT PASSED** |
| `node tests/verify-security-fixes.test.js` | **54 / 54 passed** |
| Live `POST /admin/upload/:slug` (multer 2.2.0) | authed + CSRF + JPEG → **200 `{"ok":true}`**; authed no-CSRF → **403**; anon → **403** |

## Upload route / middleware ordering (no regression)

Effective order for `POST /admin/upload/:slug` (`api/server.js:152` + `api/routes/admin.js:318`):

`doubleCsrfProtection` (app-level csrf-csrf) → `requireAuth` → `requireCsrf` → `uploadRateLimit` → `upload.single('photo')` (**multer LAST**)

multer parses the request body **after** auth + CSRF + rate-limiting — the DoS surface is unreachable without a valid admin session **and** CSRF token (confirmed empirically: anonymous and no-CSRF requests both return 403 before any file is processed). A lockfile-only bump does not touch this source path.

## Deploy

**Not deployed.** Deploy to the Hostinger VPS is manual and is Phil's gate (merge ≠ deploy).

## Gatekeeper

Per AGENTS.md External Assistant / Codex Handoff Protocol: this PR is **evidence only**. Codex independently verifies (`gh pr view`, `gh pr checks`, unresolved review threads = 0, VPS SHA unchanged) and issues the READY / NOT READY verdict. Claude does **not** self-declare ready.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update API dependency lockfile to address a high-severity multer DoS advisory and document the remediation in project state and work log files.

Bug Fixes:
- Resolve high-severity DoS vulnerabilities in multer by upgrading the locked version from 2.1.1 to 2.2.0 in the API.

Build:
- Refresh api/package-lock.json so production installs use multer 2.2.0 within the existing caret range.

Documentation:
- Update PROJECT_STATE.md to record the new npm audit status and the multer DoS advisory and fix.

Chores:
- Add a WORK_LOG entry describing the multer advisory remediation work and verification steps.