### PR TITLE
feat(chat): add PUBLIC_ASSISTANT_ENABLED cost-control flag

### DIFF
--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -838,7 +838,7 @@ Land the `PUBLIC_ASSISTANT_ENABLED` flag as a focused PR off current `origin/mai
 ### Changes Made (5 files, feature only)
 - `api/featureFlags.js` — add `publicAssistantEnabled()` (default ON; `PUBLIC_ASSISTANT_ENABLED=false` → canned reply, zero LLM spend on anonymous visitors). Admin AI generator unaffected.
 - `api/routes/chat.js` — early-return the canned `FALLBACK_REPLY` when the flag is off, before any provider call; safe-by-default header comment now includes the direct Anthropic path.
-- `api/routes/admin.js` — admin AI disabled-state copy/tooltip/error mention `ANTHROPIC_API_KEY` (recommended) alongside `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY`.
+- `api/routes/admin.js` — admin AI disabled-state copy/tooltip/error mentions `ANTHROPIC_API_KEY` (recommended) alongside `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY`.
 - `scripts/preflight.sh` — wire `tests/public-assistant-flag.test.js` into the preflight gate.
 - `tests/public-assistant-flag.test.js` (new) — stubs the AI provider; asserts disabled → 0 calls + canned reply; enabled/default/true → provider called.
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -865,3 +865,26 @@ Land the `PUBLIC_ASSISTANT_ENABLED` flag as a focused PR off current `origin/mai
 
 ### Recommended Next Task
 Codex verifies the PR via GitHub; on READY, Phil merges. Optional follow-ups: small docs PR for the AGENTS.md gatekeeper-format update; gitignore the two local strays.
+
+---
+
+## 2026-06-18 — Claude (Opus 4.8) — #112 follow-up: listings-aware fallback (Codex P2)
+
+### Objective
+Resolve Codex P2 on PR #112 (`api/routes/chat.js:50`): when the public assistant is disabled (or no AI key / upstream failure) AND public listings are off (the current default), the canned `FALLBACK_REPLY` still told visitors to "browse current WV listings" — a dead end, since `/listings`, `/search`, `/listing/*`, `/wv/*` redirect/empty when `publicListingsEnabled()` is false.
+
+### Changes Made
+- `api/utils/chatAssistant.js` — added `buildFallbackReply(listingsEnabled)` that appends the "browse listings" pointer only when listings are live; `FALLBACK_REPLY` is now `buildFallbackReply(true)` (unchanged default copy / client parity). Exported `buildFallbackReply`.
+- `api/routes/chat.js` — all four fallback returns (assistant-disabled, no-AI-key, empty reply, upstream error) now use `buildFallbackReply(publicListingsEnabled())`, so none point to hidden inventory. Imported `publicListingsEnabled`.
+- `tests/public-assistant-flag.test.js` — disabled-case assertions are now listings-aware; added a dedicated case proving disabled + `PUBLIC_LISTINGS_ENABLED=false` omits the listings pointer while keeping the contact path and zero provider calls.
+
+### Verification (Truthfulness Rule applies — worktree off origin/main @ 345d509, after `cd api && npm ci`)
+- `node --check` routes/chat.js, utils/chatAssistant.js → PASSED.
+- `node tests/public-assistant-flag.test.js` → 7/7.
+- `node tests/chat-assistant.test.js` → 14/14.
+- `node tests/ai-generator-routing.test.js` → 18/18.
+- `node tests/verify-security-fixes.test.js` → 57/57.
+- `bash scripts/preflight.sh` → PRE-FLIGHT PASSED.
+
+### Note
+- `publicListingsEnabled()` currently defaults **OFF** (inventory cleanup), so this fixes the DEFAULT prod path, not just an edge case.

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -827,3 +827,41 @@ Remove the repo-side blocker that made admin-uploaded listing photos depend on t
 
 ### Recommended Next Task
 Open PR for review. After merge, schedule a controlled VPS deploy/migration only with explicit Phil approval.
+
+---
+
+## 2026-06-18 — Claude (Opus 4.8) — Public assistant cost-control flag (clean extraction)
+
+### Objective
+Land the `PUBLIC_ASSISTANT_ENABLED` flag as a focused PR off current `origin/main`. The flag was developed earlier (Codex, 2026-06-14) but sat as uncommitted WIP on the stale `feat/listings-feature-flag` branch (10 commits behind main, tangled with already-merged route aliases and local strays). This extracts the feature cleanly and drops the redundant/stale pieces.
+
+### Changes Made (5 files, feature only)
+- `api/featureFlags.js` — add `publicAssistantEnabled()` (default ON; `PUBLIC_ASSISTANT_ENABLED=false` → canned reply, zero LLM spend on anonymous visitors). Admin AI generator unaffected.
+- `api/routes/chat.js` — early-return the canned `FALLBACK_REPLY` when the flag is off, before any provider call; safe-by-default header comment now includes the direct Anthropic path.
+- `api/routes/admin.js` — admin AI disabled-state copy/tooltip/error mention `ANTHROPIC_API_KEY` (recommended) alongside `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY`.
+- `scripts/preflight.sh` — wire `tests/public-assistant-flag.test.js` into the preflight gate.
+- `tests/public-assistant-flag.test.js` (new) — stubs the AI provider; asserts disabled → 0 calls + canned reply; enabled/default/true → provider called.
+
+### Deliberately excluded (kept the PR focused)
+- `api/routes/public.js` `/contact` `/about` `/search` aliases + their `verify-security-fixes.test.js` assertion — already on `origin/main` (verified present).
+- `AGENTS.md` Codex-gatekeeper handoff-format doc update — net-new but process-doc churn; deferred to a separate docs PR.
+- Local strays `compose.override.yml`, root `package-lock.json` — not part of the feature; left on the WIP branch.
+
+### Verification (Truthfulness Rule applies — clean worktree off origin/main @ 345d509, after `cd api && npm ci`)
+- `node --check` server.js / routes/chat.js / routes/admin.js / featureFlags.js → PASSED.
+- `node tests/public-assistant-flag.test.js` → 3/3 PASSED.
+- `node tests/chat-assistant.test.js` → 14/14 PASSED.
+- `node tests/ai-generator-routing.test.js` → 18/18 PASSED.
+- `node tests/verify-security-fixes.test.js` → 57/57 PASSED (matches main baseline — no regression from dropping the redundant alias hunk).
+- `bash scripts/preflight.sh` → PRE-FLIGHT PASSED (incl. new flag regression + safe-by-default `/api/chat` no-key smoke).
+
+### Security Notes
+- No secrets read, printed, committed, or changed. No production/VPS/DB mutation.
+- `npm ci` on this base reports the pending high-sev multer advisory — that is main's state, remediated separately by PR #111 (out of scope here).
+
+### Remaining Risks / Requires Human Decision
+1. Merge — gated on Codex VERDICT (gatekeeper protocol) + Phil approval.
+2. Deploy — Phil's manual VPS gate; merge ≠ deploy. To actually cut anonymous-visitor AI spend in prod, set `PUBLIC_ASSISTANT_ENABLED=false` in the VPS env after deploy.
+
+### Recommended Next Task
+Codex verifies the PR via GitHub; on READY, Phil merges. Optional follow-ups: small docs PR for the AGENTS.md gatekeeper-format update; gitignore the two local strays.

--- a/api/featureFlags.js
+++ b/api/featureFlags.js
@@ -18,4 +18,19 @@ function publicListingsEnabled() {
   return v !== 'false';
 }
 
-module.exports = { publicListingsEnabled };
+// ─────────────────────────────────────────────────────────────
+// Public homepage AI assistant ("MalickLand Assistant" chat widget).
+// Default ON to preserve current behavior. Turn OFF to stop the
+// public bot from making any paid AI calls — the widget then returns
+// its built-in canned reply (no LLM spend on anonymous visitors).
+// The admin AI listing generator is unaffected either way.
+//
+//   • set env  PUBLIC_ASSISTANT_ENABLED=false   to disable (no code change)
+// ─────────────────────────────────────────────────────────────
+function publicAssistantEnabled() {
+  const v = process.env.PUBLIC_ASSISTANT_ENABLED;
+  if (v === undefined || v === '') return true; // default: ON
+  return v !== 'false';
+}
+
+module.exports = { publicListingsEnabled, publicAssistantEnabled };

--- a/api/featureFlags.js
+++ b/api/featureFlags.js
@@ -26,11 +26,15 @@ function publicListingsEnabled() {
 // The admin AI listing generator is unaffected either way.
 //
 //   • set env  PUBLIC_ASSISTANT_ENABLED=false   to disable (no code change)
+//
+// The "false" check is normalized (trim + lowercase) so a config typo like
+// `FALSE` or ` false ` still disables the bot — for a cost-control flag, an
+// intended "off" must never silently fall through to paid LLM calls.
 // ─────────────────────────────────────────────────────────────
 function publicAssistantEnabled() {
   const v = process.env.PUBLIC_ASSISTANT_ENABLED;
-  if (v === undefined || v === '') return true; // default: ON
-  return v !== 'false';
+  if (v === undefined || v.trim() === '') return true; // default: ON
+  return v.trim().toLowerCase() !== 'false';
 }
 
 module.exports = { publicListingsEnabled, publicAssistantEnabled };

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -528,12 +528,12 @@ router.get('/ai/:id', requireAuth, adminActionRateLimit, (req, res) => {
       <a href="/admin" class="btn-outline">← Back</a>
     </div>
     ${!aiOk ? `<div style="background:#fff3cd;color:#856404;padding:1rem;border-radius:8px;margin-bottom:1.5rem">
-      ⚠️ <strong>AI is not configured.</strong> Set <code>AI_GATEWAY_API_KEY</code> (preferred) or <code>OPENAI_API_KEY</code> to enable AI generation.
+      ⚠️ <strong>AI is not configured.</strong> Set <code>ANTHROPIC_API_KEY</code> (recommended) — or <code>AI_GATEWAY_API_KEY</code> / <code>OPENAI_API_KEY</code> — to enable AI generation.
     </div>` : ''}
     <div style="display:flex;gap:1rem;align-items:center;margin-bottom:1.5rem;flex-wrap:wrap">
       <form method="POST" action="/admin/ai/${esc(p.id)}" style="margin:0">
         <input type="hidden" name="_csrf" value="${esc(csrfToken(req))}" />
-        <button type="submit" class="btn" ${!aiOk ? 'disabled title="Set AI_GATEWAY_API_KEY or OPENAI_API_KEY first"' : ''}>
+        <button type="submit" class="btn" ${!aiOk ? 'disabled title="Set ANTHROPIC_API_KEY, AI_GATEWAY_API_KEY, or OPENAI_API_KEY first"' : ''}>
           ${content ? '🔄 Regenerate' : '✨ Generate Now'}
         </button>
       </form>
@@ -571,7 +571,7 @@ router.post('/ai/:id', requireAuth, requireCsrf, adminActionRateLimit, async (re
   `).get(req.params.id);
   if (!p) return res.redirect('/admin');
   if (!aiConfigured())
-    return res.status(400).send('AI not configured (set AI_GATEWAY_API_KEY or OPENAI_API_KEY)');
+    return res.status(400).send('AI not configured (set ANTHROPIC_API_KEY, AI_GATEWAY_API_KEY, or OPENAI_API_KEY)');
 
   try {
     await generateListingContent(p, db);

--- a/api/routes/chat.js
+++ b/api/routes/chat.js
@@ -12,10 +12,10 @@
  *     turn count / length,
  *   - a server-injected brokerage-safe system prompt the client cannot override.
  *
- * Safe-by-default: if no AI provider is configured (no AI_GATEWAY_API_KEY /
- * OPENAI_API_KEY), or the upstream call fails, it returns a friendly canned
- * reply instead of crashing or 500-ing — main auto-deploys to Railway, so this
- * must never take the site down when the key is absent.
+ * Safe-by-default: if no AI provider is configured (AI_GATEWAY_API_KEY /
+ * ANTHROPIC_API_KEY / OPENAI_API_KEY), or the upstream call fails, it returns a
+ * friendly canned reply instead of crashing or 500-ing — main auto-deploys to
+ * Railway, so this must never take the site down when the key is absent.
  *
  * Contract (matches app/index.html sendChatMsg):
  *   Request:  { messages: [{ role: 'user'|'assistant', content: string }, ...] }
@@ -26,6 +26,7 @@ const express = require('express');
 
 const { chatRateLimit } = require('../middleware/rate-limits');
 const { generateChatReply, aiConfigured } = require('../ai-generator');
+const { publicAssistantEnabled } = require('../featureFlags');
 const {
   buildChatSystemPrompt,
   sanitizeChatMessages,
@@ -40,6 +41,13 @@ function createChatRouter() {
 
     if (!messages.length || !messages.some((m) => m.role === 'user')) {
       return res.status(400).json({ error: 'A user message is required.' });
+    }
+
+    // Public assistant disabled (PUBLIC_ASSISTANT_ENABLED=false) → return the
+    // canned reply without calling any AI provider. Zero LLM spend on anonymous
+    // visitors; the admin listing generator is unaffected.
+    if (!publicAssistantEnabled()) {
+      return res.json({ reply: FALLBACK_REPLY });
     }
 
     // No provider configured → degrade gracefully (steady state until the key

--- a/api/routes/chat.js
+++ b/api/routes/chat.js
@@ -26,11 +26,11 @@ const express = require('express');
 
 const { chatRateLimit } = require('../middleware/rate-limits');
 const { generateChatReply, aiConfigured } = require('../ai-generator');
-const { publicAssistantEnabled } = require('../featureFlags');
+const { publicAssistantEnabled, publicListingsEnabled } = require('../featureFlags');
 const {
   buildChatSystemPrompt,
   sanitizeChatMessages,
-  FALLBACK_REPLY,
+  buildFallbackReply,
 } = require('../utils/chatAssistant');
 
 function createChatRouter() {
@@ -47,25 +47,25 @@ function createChatRouter() {
     // canned reply without calling any AI provider. Zero LLM spend on anonymous
     // visitors; the admin listing generator is unaffected.
     if (!publicAssistantEnabled()) {
-      return res.json({ reply: FALLBACK_REPLY });
+      return res.json({ reply: buildFallbackReply(publicListingsEnabled()) });
     }
 
     // No provider configured → degrade gracefully (steady state until the key
     // is set in Railway), not an error.
     if (!aiConfigured()) {
-      return res.json({ reply: FALLBACK_REPLY });
+      return res.json({ reply: buildFallbackReply(publicListingsEnabled()) });
     }
 
     const payload = [{ role: 'system', content: buildChatSystemPrompt() }, ...messages];
 
     try {
       const reply = await generateChatReply(payload);
-      return res.json({ reply: reply || FALLBACK_REPLY });
+      return res.json({ reply: reply || buildFallbackReply(publicListingsEnabled()) });
     } catch (err) {
       console.error('[Chat] assistant call failed:', err.message);
       // Non-2xx for observability, but include a usable reply so the widget
       // still shows something helpful (its own client fallback also covers this).
-      return res.status(502).json({ error: 'assistant_unavailable', reply: FALLBACK_REPLY });
+      return res.status(502).json({ error: 'assistant_unavailable', reply: buildFallbackReply(publicListingsEnabled()) });
     }
   });
 

--- a/api/utils/chatAssistant.js
+++ b/api/utils/chatAssistant.js
@@ -25,11 +25,23 @@ const MAX_TOTAL_CHARS     = 6000;
 const ALLOWED_ROLES       = new Set(['user', 'assistant']);
 
 // Brokerage-safe canned reply used whenever the live assistant can't answer
-// (no AI key configured, or the upstream call fails). No claims, just a useful
-// next step. Kept in sync with the client-side fallback in app/index.html.
-const FALLBACK_REPLY =
-  "Thanks for reaching out! I can't chat live right now, but Phil Malick can help directly — " +
-  'call (540) 246-1421 or email phil@malickland.net. You can also browse current WV listings here on the site.';
+// (assistant disabled, no AI key configured, or the upstream call fails). No
+// claims, just a useful next step. The "browse listings" pointer is only added
+// when public listings are actually live — with listings off, /listings,
+// /search, /listing/*, /wv/* redirect or return empty, so pointing visitors
+// there would be a dead end.
+function buildFallbackReply(listingsEnabled = true) {
+  const base =
+    "Thanks for reaching out! I can't chat live right now, but Phil Malick can help directly — " +
+    'call (540) 246-1421 or email phil@malickland.net.';
+  return listingsEnabled
+    ? `${base} You can also browse current WV listings here on the site.`
+    : base;
+}
+
+// Default (listings-on) form — preserves the original copy and parity with the
+// client-side fallback in app/index.html.
+const FALLBACK_REPLY = buildFallbackReply(true);
 
 /**
  * The system prompt. Mirrors the brokerage-safe guardrails of the listing
@@ -122,6 +134,7 @@ module.exports = {
   buildChatSystemPrompt,
   sanitizeChatMessages,
   FALLBACK_REPLY,
+  buildFallbackReply,
   MAX_MESSAGES,
   MAX_CHARS_PER_MSG,
   MAX_TOTAL_CHARS,

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -44,6 +44,11 @@ node --check routes/admin.js
 echo "✓ Syntax OK"
 echo
 
+echo "== Public assistant flag regression =="
+node "$ROOT/tests/public-assistant-flag.test.js"
+echo "✓ Public assistant flag OK"
+echo
+
 echo "== Startup smoke =="
 PORT="$PORT_TO_USE" DATABASE_PATH="$TMP_DIR/preflight.db" NODE_ENV=test PUBLIC_LISTINGS_ENABLED=true API_KEY=preflight-api-key SESSION_SECRET=preflight-session-secret ADMIN_PASSWORD=preflight-admin-password node server.js > "$APP_LOG" 2>&1 &
 PID=$!

--- a/tests/public-assistant-flag.test.js
+++ b/tests/public-assistant-flag.test.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Regression tests for the PUBLIC_ASSISTANT_ENABLED cost-control flag.
+ *
+ * Proves the trust/cost boundary the unit helpers don't: when the public
+ * assistant is disabled, POST /api/chat returns the canned reply WITHOUT
+ * ever calling the paid AI provider. Also proves the enabled (default) path
+ * still calls the provider, so the flag isn't silently dead.
+ *
+ * No network, no real AI: ai-generator is stubbed before chat.js binds it.
+ *
+ * Run: node tests/public-assistant-flag.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function test(description, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passed++;
+      console.log(`✓ ${description}`);
+    })
+    .catch((error) => {
+      failed++;
+      failures.push({ description, error: error.message });
+      console.log(`✗ ${description}`);
+      console.log(`  Error: ${error.message}`);
+    });
+}
+
+const AIGEN_PATH = path.join(__dirname, '..', 'api', 'ai-generator.js');
+const CHAT_PATH = path.join(__dirname, '..', 'api', 'routes', 'chat.js');
+
+// Load a fresh copy of the chat router with generateChatReply / aiConfigured
+// stubbed. chat.js destructures these at require-time, so the stubs must be
+// installed on the cached ai-generator module BEFORE chat.js is required.
+function loadChatRouterWithSpy() {
+  delete require.cache[require.resolve(AIGEN_PATH)];
+  delete require.cache[require.resolve(CHAT_PATH)];
+
+  const aigen = require(AIGEN_PATH);
+  const spy = { calls: 0 };
+  aigen.generateChatReply = async () => {
+    spy.calls++;
+    return 'STUBBED_AI_REPLY';
+  };
+  aigen.aiConfigured = () => true; // isolate the flag from the no-provider branch
+
+  const createChatRouter = require(CHAT_PATH);
+  const router = createChatRouter();
+
+  // Pull the final POST '/' handler out of the express route stack (the layer
+  // after chatRateLimit). Call it directly with mock req/res.
+  const layer = router.stack.find((l) => l.route && l.route.path === '/');
+  const stack = layer.route.stack;
+  const handler = stack[stack.length - 1].handle;
+
+  return { handler, spy };
+}
+
+function mockRes() {
+  return {
+    _status: 200,
+    _json: null,
+    status(code) { this._status = code; return this; },
+    json(obj) { this._json = obj; return this; },
+  };
+}
+
+const userMessages = { body: { messages: [{ role: 'user', content: 'Got land in Hampshire County?' }] } };
+
+(async () => {
+  const { FALLBACK_REPLY } = require(path.join(__dirname, '..', 'api', 'utils', 'chatAssistant'));
+
+  await test('disabled (PUBLIC_ASSISTANT_ENABLED=false): canned reply, ZERO provider calls', async () => {
+    process.env.PUBLIC_ASSISTANT_ENABLED = 'false';
+    const { handler, spy } = loadChatRouterWithSpy();
+    const res = mockRes();
+    await handler(userMessages, res);
+
+    assert.strictEqual(spy.calls, 0, 'generateChatReply must NOT be called when disabled');
+    assert.strictEqual(res._status, 200, 'disabled bot should answer 200, not error');
+    assert.strictEqual(res._json && res._json.reply, FALLBACK_REPLY, 'should return the canned reply');
+  });
+
+  await test('enabled (default): provider IS called and its reply is returned', async () => {
+    delete process.env.PUBLIC_ASSISTANT_ENABLED; // default ON
+    const { handler, spy } = loadChatRouterWithSpy();
+    const res = mockRes();
+    await handler(userMessages, res);
+
+    assert.strictEqual(spy.calls, 1, 'generateChatReply must be called when enabled');
+    assert.strictEqual(res._json && res._json.reply, 'STUBBED_AI_REPLY', 'should return the provider reply');
+  });
+
+  await test('explicit enabled (PUBLIC_ASSISTANT_ENABLED=true): provider is called', async () => {
+    process.env.PUBLIC_ASSISTANT_ENABLED = 'true';
+    const { handler, spy } = loadChatRouterWithSpy();
+    const res = mockRes();
+    await handler(userMessages, res);
+
+    assert.strictEqual(spy.calls, 1, 'true should behave like enabled');
+  });
+
+  delete process.env.PUBLIC_ASSISTANT_ENABLED;
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failures.length) {
+    console.log('\nFailures:');
+    failures.forEach((f) => console.log(`  ✗ ${f.description}: ${f.error}`));
+  }
+  process.exit(failed ? 1 : 0);
+})();

--- a/tests/public-assistant-flag.test.js
+++ b/tests/public-assistant-flag.test.js
@@ -78,7 +78,8 @@ function mockRes() {
 const userMessages = { body: { messages: [{ role: 'user', content: 'Got land in Hampshire County?' }] } };
 
 (async () => {
-  const { FALLBACK_REPLY } = require(path.join(__dirname, '..', 'api', 'utils', 'chatAssistant'));
+  const { buildFallbackReply } = require(path.join(__dirname, '..', 'api', 'utils', 'chatAssistant'));
+  const { publicListingsEnabled } = require(path.join(__dirname, '..', 'api', 'featureFlags'));
 
   await test('disabled (PUBLIC_ASSISTANT_ENABLED=false): canned reply, ZERO provider calls', async () => {
     process.env.PUBLIC_ASSISTANT_ENABLED = 'false';
@@ -88,7 +89,7 @@ const userMessages = { body: { messages: [{ role: 'user', content: 'Got land in 
 
     assert.strictEqual(spy.calls, 0, 'generateChatReply must NOT be called when disabled');
     assert.strictEqual(res._status, 200, 'disabled bot should answer 200, not error');
-    assert.strictEqual(res._json && res._json.reply, FALLBACK_REPLY, 'should return the canned reply');
+    assert.strictEqual(res._json && res._json.reply, buildFallbackReply(publicListingsEnabled()), 'should return the canned reply');
   });
 
   await test('enabled (default): provider IS called and its reply is returned', async () => {
@@ -118,9 +119,25 @@ const userMessages = { body: { messages: [{ role: 'user', content: 'Got land in 
       await handler(userMessages, res);
 
       assert.strictEqual(spy.calls, 0, 'an intended "off" must disable regardless of case/whitespace');
-      assert.strictEqual(res._json && res._json.reply, FALLBACK_REPLY, 'should return the canned reply');
+      assert.strictEqual(res._json && res._json.reply, buildFallbackReply(publicListingsEnabled()), 'should return the canned reply');
     });
   }
+
+  await test('disabled + listings OFF: fallback omits the listings pointer (no dead end), ZERO calls', async () => {
+    process.env.PUBLIC_ASSISTANT_ENABLED = 'false';
+    process.env.PUBLIC_LISTINGS_ENABLED = 'false';
+    const { handler, spy } = loadChatRouterWithSpy();
+    const res = mockRes();
+    await handler(userMessages, res);
+
+    assert.strictEqual(spy.calls, 0, 'still zero provider calls when disabled');
+    assert.ok(
+      res._json && !/browse current WV listings/i.test(res._json.reply),
+      'must NOT point users to listings when PUBLIC_LISTINGS_ENABLED=false',
+    );
+    assert.ok(/246-1421/.test(res._json.reply), 'should still give the direct contact path');
+    delete process.env.PUBLIC_LISTINGS_ENABLED;
+  });
 
   delete process.env.PUBLIC_ASSISTANT_ENABLED;
 

--- a/tests/public-assistant-flag.test.js
+++ b/tests/public-assistant-flag.test.js
@@ -110,6 +110,18 @@ const userMessages = { body: { messages: [{ role: 'user', content: 'Got land in 
     assert.strictEqual(spy.calls, 1, 'true should behave like enabled');
   });
 
+  for (const raw of ['FALSE', ' false ', 'False']) {
+    await test(`normalized disable (PUBLIC_ASSISTANT_ENABLED=${JSON.stringify(raw)}): canned reply, ZERO provider calls`, async () => {
+      process.env.PUBLIC_ASSISTANT_ENABLED = raw;
+      const { handler, spy } = loadChatRouterWithSpy();
+      const res = mockRes();
+      await handler(userMessages, res);
+
+      assert.strictEqual(spy.calls, 0, 'an intended "off" must disable regardless of case/whitespace');
+      assert.strictEqual(res._json && res._json.reply, FALLBACK_REPLY, 'should return the canned reply');
+    });
+  }
+
   delete process.env.PUBLIC_ASSISTANT_ENABLED;
 
   console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## What & why
Adds a `PUBLIC_ASSISTANT_ENABLED` env flag (default **ON**) gating the public homepage AI assistant. When `false`, `POST /api/chat` returns the built-in canned reply **without calling any AI provider** — so anonymous-visitor traffic can't run up LLM spend. The admin AI listing generator is unaffected either way. A one-env-var cost lever, no code change to toggle.

## Changes (5 files, feature only)
- `api/featureFlags.js` — `publicAssistantEnabled()` (default ON)
- `api/routes/chat.js` — early canned-reply return when disabled, before any provider call; note direct-Anthropic path in the safe-by-default comment
- `api/routes/admin.js` — disabled-state copy/tooltip/error mention `ANTHROPIC_API_KEY`
- `scripts/preflight.sh` — wire the flag regression into the preflight gate
- `tests/public-assistant-flag.test.js` (new) — stubs the provider; proves disabled ⇒ **0** provider calls + canned reply, enabled/default/true ⇒ provider called

## Verification (clean worktree off `origin/main`, after `cd api && npm ci`)
- `bash scripts/preflight.sh` → **PRE-FLIGHT PASSED** (incl. new flag regression + safe-by-default `/api/chat` no-key smoke)
- `node tests/verify-security-fixes.test.js` → **57/57** (matches main baseline — no regression)
- flag regression **3/3** · chat-assistant **14/14** · ai-generator-routing **18/18**
- `node --check` server.js / routes/chat.js / routes/admin.js / featureFlags.js

## Notes
- **Provenance:** extracted from earlier WIP (Codex, 2026-06-14) that sat on the stale `feat/listings-feature-flag` branch. Already-merged `/contact /about /search` aliases, the `AGENTS.md` gatekeeper-doc churn, and local strays were intentionally left out to keep this focused.
- **Deploy is a separate manual gate.** To disable the public bot in prod, set `PUBLIC_ASSISTANT_ENABLED=false` in the VPS env after merge + deploy.

## Summary by Sourcery

Introduce an environment flag to gate the public chat assistant and ensure it can be disabled without code changes, while keeping admin AI tools unaffected.

New Features:
- Add PUBLIC_ASSISTANT_ENABLED feature flag to control whether the public homepage chat assistant uses an AI provider or returns a canned reply.

Enhancements:
- Update chat route to short-circuit to the canned reply when the public assistant flag is disabled, preventing any AI provider calls for anonymous users.
- Clarify admin AI configuration messaging to reference ANTHROPIC_API_KEY alongside existing AI provider keys.
- Integrate the new public assistant flag regression test into the preflight script to enforce the cost-control behavior in CI.

Tests:
- Add a regression test suite verifying that disabling the public assistant prevents AI provider calls and returns the fallback reply, and that the default/enabled states still invoke the provider.