### PR TITLE
Cover CORS origin allowlist behavior

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -31,13 +31,13 @@
 - [ ] **Phase 2: AI Review Queue** — depends on Phase 1 complete + ChatGPT spec
 - [ ] **Phase 3: Drive event automation** — depends on Phase 2 — **Gemini leads**
 - [ ] **Phase 4: Gmail intake** — depends on Phase 3 — **Gemini leads**
-- [ ] **CORS origin restriction review** — evaluate if `cors()` without origin list is appropriate as API scope grows
 - [ ] **Add integration/E2E tests** — currently only unit-style static-analysis tests; add real HTTP tests using supertest or similar
 
 ---
 
 ## Completed
 
+- [x] **CORS origin restriction review** — existing `CORS_ORIGIN` allowlist behavior verified and regression-covered in `tests/http-smoke.test.js`; trusted origins receive CORS headers and can submit guarded leads, untrusted origins do not receive CORS access and are rejected by same-origin lead guards — 2026-06-18
 - [x] **Phase 1: Document Registry spec** — schema, approval state machine, AI extraction JSON contract, API skeleton, and implementation acceptance criteria captured in `docs/DOCUMENT_REGISTRY_SPEC.md` — 2026-06-18
 - [x] **HTTP integration smoke test** — `tests/http-smoke.test.js` starts the real Express app on a temp SQLite DB and is enforced by `scripts/preflight.sh`; covers health/config/listings-off/contact-origin/chat-fallback behavior — 2026-06-18
 - [x] **Repo support for persistent listing uploads** — `LISTINGS_ROOT` now controls listing/photo storage and `/images` serving; default remains local repo `listings/`, VPS target is `/data/listings` on the existing persistent volume — 2026-06-18

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -975,3 +975,25 @@ Deliver the open Phase 1 Document Registry spec from `TASKS.md` so implementatio
 
 ### Recommended Next Task
 Implement the Phase 1 Document Registry skeleton from `docs/DOCUMENT_REGISTRY_SPEC.md` in a separate branch with focused tests.
+
+---
+
+## 2026-06-18 — Codex — CORS origin restriction review
+
+### Objective
+Close the open `TASKS.md` item asking whether `cors()` without an origin list is appropriate as API scope grows.
+
+### Changes Made
+- `tests/http-smoke.test.js` — extended the real HTTP smoke to start the app with `CORS_ORIGIN=https://trusted.example`; verified trusted origins receive `Access-Control-Allow-Origin`, untrusted origins do not, untrusted lead POSTs are rejected by `requireLeadSameOrigin`, and allowlisted cross-origin lead POSTs still work.
+- `TASKS.md` — moved CORS origin restriction review to Completed with the tested behavior.
+- `WORK_LOG.md` — this entry.
+
+### Verification
+- Required before PR: `node tests/http-smoke.test.js`, `bash scripts/preflight.sh`, `node tests/verify-security-fixes.test.js`, and `git diff --check`.
+
+### Security Notes
+- No runtime policy change was needed. Existing behavior is allowlist-based via `CORS_ORIGIN`; browser CORS access and lead/chat origin acceptance share that allowlist through `expectedLeadOrigins()`.
+- No secrets, production config, or VPS state changed.
+
+### Recommended Next Task
+Continue with either the Twilio-path cleanup or the Document Registry implementation skeleton, depending on whether the next chunk should be low-risk cleanup or feature foundation.

--- a/tests/http-smoke.test.js
+++ b/tests/http-smoke.test.js
@@ -12,6 +12,8 @@ const ROOT = path.join(__dirname, '..');
 const API_DIR = path.join(ROOT, 'api');
 const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'wv-http-smoke-'));
 const DB_PATH = path.join(TMP_DIR, 'smoke.db');
+const TRUSTED_ORIGIN = 'https://trusted.example';
+const UNTRUSTED_ORIGIN = 'https://untrusted.example';
 
 let server = null;
 let passed = 0;
@@ -85,6 +87,7 @@ async function main() {
       NODE_ENV: 'test',
       PUBLIC_LISTINGS_ENABLED: 'false',
       PUBLIC_ASSISTANT_ENABLED: 'false',
+      CORS_ORIGIN: TRUSTED_ORIGIN,
       API_KEY: 'http-smoke-api-key',
       SESSION_SECRET: 'http-smoke-session-secret',
       ADMIN_PASSWORD: 'http-smoke-admin-password',
@@ -126,6 +129,20 @@ async function main() {
       assert.deepStrictEqual(await json(res), { total: 0, page: 1, properties: [] });
     });
 
+    await test('CORS allows only configured cross-origin browser access', async () => {
+      const trusted = await fetch(`${baseUrl}/api/health`, {
+        headers: { Origin: TRUSTED_ORIGIN },
+      });
+      assert.strictEqual(trusted.status, 200);
+      assert.strictEqual(trusted.headers.get('access-control-allow-origin'), TRUSTED_ORIGIN);
+
+      const untrusted = await fetch(`${baseUrl}/api/health`, {
+        headers: { Origin: UNTRUSTED_ORIGIN },
+      });
+      assert.strictEqual(untrusted.status, 200);
+      assert.strictEqual(untrusted.headers.get('access-control-allow-origin'), null);
+    });
+
     await test('GET /listings redirects home when public listings are disabled', async () => {
       const res = await fetch(`${baseUrl}/listings`, { redirect: 'manual' });
       assert.strictEqual(res.status, 302);
@@ -153,6 +170,40 @@ async function main() {
       });
       assert.strictEqual(res.status, 403);
       assert.strictEqual((await json(res)).error, 'Lead request origin is required.');
+    });
+
+    await test('POST /api/contacts rejects untrusted cross-origin leads', async () => {
+      const res = await fetch(`${baseUrl}/api/contacts`, {
+        method: 'POST',
+        headers: {
+          Origin: UNTRUSTED_ORIGIN,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name: 'Bad Origin', email: 'bad@example.com' }),
+      });
+      assert.strictEqual(res.status, 403);
+      assert.strictEqual(res.headers.get('access-control-allow-origin'), null);
+      assert.strictEqual((await json(res)).error, 'Lead request origin is not allowed.');
+    });
+
+    await test('POST /api/contacts stores a CORS-allowlisted lead', async () => {
+      const res = await fetch(`${baseUrl}/api/contacts`, {
+        method: 'POST',
+        headers: {
+          Origin: TRUSTED_ORIGIN,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: 'Trusted Lead',
+          email: 'trusted@example.com',
+          message: 'Allowlisted origin contact',
+          source: 'http_smoke_cors',
+        }),
+      });
+      assert.strictEqual(res.status, 201);
+      assert.strictEqual(res.headers.get('access-control-allow-origin'), TRUSTED_ORIGIN);
+      const body = await json(res);
+      assert(Number.isInteger(body.id), 'response should include integer lead id');
     });
 
     await test('POST /api/contacts stores a same-origin lead', async () => {


### PR DESCRIPTION
## Summary
- extend the real HTTP smoke test to cover configured CORS allowlist behavior
- verify trusted origins receive Access-Control-Allow-Origin and can submit guarded leads
- verify untrusted origins receive no CORS browser access and are rejected by the lead origin guard
- close the CORS origin restriction review item in TASKS.md and record the result in WORK_LOG.md

## Guardrails
- test/backlog/log only
- no runtime policy change, new dependency, env var change, VPS, DNS, Railway, or Vercel change
- no production deploy implied

## Validation
- node tests/http-smoke.test.js
- bash scripts/preflight.sh
- node tests/verify-security-fixes.test.js
- node tests/chat-assistant.test.js
- node tests/public-assistant-flag.test.js
- npm test (from api/)
- git diff --check

## Summary by Sourcery

Extend HTTP smoke tests to verify existing CORS allowlist behavior and record completion of the CORS origin restriction review.

Documentation:
- Document the completed CORS origin restriction review and its verified behavior in WORK_LOG.md and TASKS.md.

Tests:
- Expand http-smoke integration test to cover CORS allowlist behavior for trusted and untrusted origins, including guarded lead submissions.

Chores:
- Mark the CORS origin restriction review task as completed in TASKS.md with a dated entry.