### PR TITLE
Add Document Registry Phase 1 skeleton

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -27,7 +27,6 @@
 
 ## Low Priority
 
-- [ ] **Phase 1: Document Registry implementation** — new SQLite tables: `documents`, `document_versions`, `audit_events`, `integration_events`, `extracted_claims` (placeholder); API skeleton `/api/documents`; tests — depends on `docs/DOCUMENT_REGISTRY_SPEC.md` — **OpenHands or Claude Code**
 - [ ] **Phase 2: AI Review Queue** — depends on Phase 1 complete + ChatGPT spec
 - [ ] **Phase 3: Drive event automation** — depends on Phase 2 — **Gemini leads**
 - [ ] **Phase 4: Gmail intake** — depends on Phase 3 — **Gemini leads**
@@ -38,6 +37,7 @@
 ## Completed
 
 - [x] **CORS origin restriction review** — existing `CORS_ORIGIN` allowlist behavior verified and regression-covered in `tests/http-smoke.test.js`; trusted origins receive CORS headers and can submit guarded leads, untrusted origins do not receive CORS access and are rejected by same-origin lead guards — 2026-06-18
+- [x] **Phase 1: Document Registry implementation** — SQLite tables (`documents`, `document_versions`, `audit_events`, `integration_events`, `extracted_claims`), API-key protected `/api/documents` skeleton, state-transition validation, audit writes, AI claim validation, and `tests/document-registry.test.js` coverage — 2026-06-18
 - [x] **Phase 1: Document Registry spec** — schema, approval state machine, AI extraction JSON contract, API skeleton, and implementation acceptance criteria captured in `docs/DOCUMENT_REGISTRY_SPEC.md` — 2026-06-18
 - [x] **HTTP integration smoke test** — `tests/http-smoke.test.js` starts the real Express app on a temp SQLite DB and is enforced by `scripts/preflight.sh`; covers health/config/listings-off/contact-origin/chat-fallback behavior — 2026-06-18
 - [x] **Repo support for persistent listing uploads** — `LISTINGS_ROOT` now controls listing/photo storage and `/images` serving; default remains local repo `listings/`, VPS target is `/data/listings` on the existing persistent volume — 2026-06-18

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -997,3 +997,27 @@ Close the open `TASKS.md` item asking whether `cors()` without an origin list is
 
 ### Recommended Next Task
 Continue with either the Twilio-path cleanup or the Document Registry implementation skeleton, depending on whether the next chunk should be low-risk cleanup or feature foundation.
+
+---
+
+## 2026-06-18 — Codex — Document Registry Phase 1 implementation skeleton
+
+### Objective
+Implement the Phase 1 Document Registry skeleton described in `docs/DOCUMENT_REGISTRY_SPEC.md` without enabling Drive sync, Gmail intake, AI review UI, public document access, or production deployment.
+
+### Changes Made
+- `api/db.js`, `database/schema.sql` — added `documents`, `document_versions`, `extracted_claims`, `integration_events`, and `audit_events` tables plus supporting indexes.
+- `api/routes/documents.js` — added an API-key protected `/api/documents` router with document metadata CRUD, version registration/approval/rejection, extracted-claim insertion/approval/rejection, state-transition guards, AI extraction payload validation, and audit-event writes.
+- `api/routes/api.js` — mounted the registry router under `/api/documents` behind `apiWriteRateLimit` and `requireApiKey`.
+- `tests/document-registry.test.js` — added real HTTP coverage using a temporary SQLite DB for auth, schema creation, document/version creation, invalid transitions, AI claim validation, claim approval/rejection, version approval, and audit rows.
+- `scripts/preflight.sh` — added route syntax checking and the registry smoke test to the standard preflight gate.
+- `TASKS.md` — moved the Phase 1 implementation skeleton to Completed.
+
+### Verification
+- Required validation before opening PR: `node --check api/routes/documents.js`; `node --check tests/document-registry.test.js`; `node tests/document-registry.test.js`; `bash scripts/preflight.sh`; `node tests/verify-security-fixes.test.js`.
+
+### Remaining Risks
+- This is metadata/API skeleton only. It does not upload binaries, sync Google Drive, ingest Gmail, render an admin review UI, apply approved claims to listings, or deploy to production.
+
+### Recommended Next Task
+After this PR merges, start Phase 2 only from a fresh spec: AI Review Queue/admin UI for reviewing extracted claims and deciding whether to apply approved facts.

--- a/api/db.js
+++ b/api/db.js
@@ -123,6 +123,77 @@ db.exec(`
     created_at    TEXT NOT NULL DEFAULT (datetime('now')),
     sent_at       TEXT
   );
+  CREATE TABLE IF NOT EXISTS documents (
+    id                 TEXT PRIMARY KEY,
+    property_id        TEXT REFERENCES properties(id) ON DELETE SET NULL,
+    title              TEXT NOT NULL,
+    document_type      TEXT NOT NULL,
+    source_provider    TEXT NOT NULL DEFAULT 'manual',
+    source_uri         TEXT,
+    source_external_id TEXT,
+    status             TEXT NOT NULL DEFAULT 'draft',
+    current_version_id TEXT REFERENCES document_versions(id) ON DELETE SET NULL,
+    created_by         TEXT,
+    created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS document_versions (
+    id                  TEXT PRIMARY KEY,
+    document_id         TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    version_number      INTEGER NOT NULL,
+    file_name           TEXT NOT NULL,
+    mime_type           TEXT,
+    file_size_bytes     INTEGER,
+    sha256              TEXT,
+    storage_uri         TEXT NOT NULL,
+    storage_external_id TEXT,
+    ocr_text            TEXT,
+    ocr_status          TEXT NOT NULL DEFAULT 'not_started',
+    approval_status     TEXT NOT NULL DEFAULT 'pending_review',
+    approved_by         TEXT,
+    approved_at         TEXT,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(document_id, version_number)
+  );
+  CREATE TABLE IF NOT EXISTS extracted_claims (
+    id                   TEXT PRIMARY KEY,
+    document_id          TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    document_version_id  TEXT NOT NULL REFERENCES document_versions(id) ON DELETE CASCADE,
+    property_id          TEXT REFERENCES properties(id) ON DELETE SET NULL,
+    claim_type           TEXT NOT NULL,
+    claim_value_json     TEXT NOT NULL,
+    source_quote         TEXT,
+    source_location_json TEXT,
+    confidence           REAL,
+    status               TEXT NOT NULL DEFAULT 'pending_review',
+    reviewed_by          TEXT,
+    reviewed_at          TEXT,
+    review_note          TEXT,
+    created_at           TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS integration_events (
+    id                  TEXT PRIMARY KEY,
+    provider            TEXT NOT NULL,
+    event_type          TEXT NOT NULL,
+    document_id         TEXT REFERENCES documents(id) ON DELETE SET NULL,
+    document_version_id TEXT REFERENCES document_versions(id) ON DELETE SET NULL,
+    external_id         TEXT,
+    status              TEXT NOT NULL DEFAULT 'recorded',
+    payload_json        TEXT,
+    error_message       TEXT,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE IF NOT EXISTS audit_events (
+    id          TEXT PRIMARY KEY,
+    actor       TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id   TEXT NOT NULL,
+    before_json TEXT,
+    after_json  TEXT,
+    reason      TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+  );
   CREATE INDEX IF NOT EXISTS idx_properties_county ON properties(county_id);
   CREATE INDEX IF NOT EXISTS idx_properties_status ON properties(status);
   CREATE INDEX IF NOT EXISTS idx_properties_type   ON properties(property_type);
@@ -130,6 +201,27 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_leads_status ON leads(status);
   CREATE INDEX IF NOT EXISTS idx_lead_followups_lead_due ON lead_followups(lead_id, due_at);
   CREATE INDEX IF NOT EXISTS idx_lead_followups_due ON lead_followups(status, due_at);
+  CREATE INDEX IF NOT EXISTS idx_documents_property_id ON documents(property_id);
+  CREATE INDEX IF NOT EXISTS idx_documents_status ON documents(status);
+  CREATE INDEX IF NOT EXISTS idx_documents_type ON documents(document_type);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_source_external_id
+    ON documents(source_provider, source_external_id)
+    WHERE source_external_id IS NOT NULL;
+  CREATE INDEX IF NOT EXISTS idx_document_versions_document_id ON document_versions(document_id);
+  CREATE INDEX IF NOT EXISTS idx_document_versions_approval_status ON document_versions(approval_status);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_document_versions_sha256
+    ON document_versions(sha256)
+    WHERE sha256 IS NOT NULL;
+  CREATE INDEX IF NOT EXISTS idx_extracted_claims_document_id ON extracted_claims(document_id);
+  CREATE INDEX IF NOT EXISTS idx_extracted_claims_property_id ON extracted_claims(property_id);
+  CREATE INDEX IF NOT EXISTS idx_extracted_claims_status ON extracted_claims(status);
+  CREATE INDEX IF NOT EXISTS idx_extracted_claims_type ON extracted_claims(claim_type);
+  CREATE INDEX IF NOT EXISTS idx_integration_events_provider_type ON integration_events(provider, event_type);
+  CREATE INDEX IF NOT EXISTS idx_integration_events_document_id ON integration_events(document_id);
+  CREATE INDEX IF NOT EXISTS idx_integration_events_external_id ON integration_events(external_id);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_entity ON audit_events(entity_type, entity_id);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_actor ON audit_events(actor);
+  CREATE INDEX IF NOT EXISTS idx_audit_events_created_at ON audit_events(created_at);
 `);
 
 // Seed counties

--- a/api/routes/api.js
+++ b/api/routes/api.js
@@ -5,6 +5,7 @@ const crypto  = require('crypto');
 
 const { db }              = require('../db');
 const { requireApiKey }   = require('../middleware/auth');
+const createDocumentsRouter = require('./documents');
 const { contactsRateLimit, publicReadRateLimit, generateDescRateLimit, apiWriteRateLimit } = require('../middleware/rate-limits');
 const { sendLeadNotification } = require('../services/email');
 const { isValidEmail, normalizeAcreage, slugify, VALID_PROP_TYPES, VALID_PROP_STATUSES } = require('../helpers');
@@ -79,6 +80,9 @@ router.get('/properties',     publicReadRateLimit, sendPropertyList);
 router.get('/listings',       publicReadRateLimit, sendPropertyList);
 router.get('/properties/:id', publicReadRateLimit, sendPropertyDetail);
 router.get('/listings/:id',   publicReadRateLimit, sendPropertyDetail);
+
+// ── Document Registry (API-key protected) ────────────────
+router.use('/documents', apiWriteRateLimit, requireApiKey, createDocumentsRouter({ db }));
 
 // ── Analytics ─────────────────────────────────────────────
 router.get('/analytics', publicReadRateLimit, (_req, res) => {

--- a/api/routes/documents.js
+++ b/api/routes/documents.js
@@ -1,0 +1,603 @@
+'use strict';
+
+const express = require('express');
+const crypto = require('crypto');
+
+const DOCUMENT_TYPES = new Set([
+  'deed', 'plat', 'survey', 'tax_card', 'disclosure', 'contract',
+  'listing_agreement', 'inspection', 'photo_release', 'utility',
+  'hoa_or_restrictions', 'seller_note', 'buyer_note', 'marketing_source',
+  'other',
+]);
+
+const SOURCE_PROVIDERS = new Set(['manual', 'google_drive', 'gmail', 'api', 'system']);
+const DOCUMENT_STATUSES = new Set(['draft', 'active', 'superseded', 'archived', 'rejected']);
+const VERSION_APPROVAL_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded']);
+const CLAIM_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded', 'applied']);
+const CLAIM_VALUE_TYPES = new Set(['string', 'number', 'boolean', 'date', 'money', 'area', 'list', 'object']);
+const CLAIM_TYPES = new Set([
+  'address', 'parcel_id', 'acreage', 'annual_tax', 'tax_assessed', 'owner_name',
+  'road_access', 'utility', 'water_source', 'septic', 'flood_zone', 'zoning',
+  'restriction', 'easement', 'mineral_rights', 'school_district', 'listing_price',
+  'sale_price', 'close_date', 'disclosure_item', 'marketing_claim',
+]);
+
+const DOCUMENT_TRANSITIONS = {
+  draft: new Set(['active', 'rejected']),
+  active: new Set(['superseded', 'archived']),
+  superseded: new Set(['archived']),
+  archived: new Set([]),
+  rejected: new Set(['archived']),
+};
+
+function createDocumentsRouter({ db }) {
+  const router = express.Router();
+
+  const insertAudit = db.prepare(`
+    INSERT INTO audit_events (id,actor,action,entity_type,entity_id,before_json,after_json,reason)
+    VALUES (?,?,?,?,?,?,?,?)
+  `);
+  const selectDocument = db.prepare('SELECT * FROM documents WHERE id=?');
+  const selectVersion = db.prepare('SELECT * FROM document_versions WHERE id=?');
+  const selectClaim = db.prepare('SELECT * FROM extracted_claims WHERE id=?');
+
+  function makeId(prefix) {
+    return `${prefix}_${crypto.randomBytes(12).toString('hex')}`;
+  }
+
+  function cleanString(value, max = 500) {
+    if (value == null) return null;
+    const text = String(value).trim();
+    if (!text) return null;
+    return text.slice(0, max);
+  }
+
+  function actorFrom(req) {
+    return cleanString(req.body && (req.body.actor || req.body.reviewed_by || req.body.approved_by), 80)
+      || cleanString(req.get('x-actor'), 80)
+      || 'api';
+  }
+
+  function auditSafe(row) {
+    if (!row) return null;
+    const copy = { ...row };
+    for (const key of [
+      'source_uri',
+      'source_external_id',
+      'storage_uri',
+      'storage_external_id',
+      'ocr_text',
+      'claim_value_json',
+      'source_quote',
+      'source_location_json',
+      'review_note',
+    ]) {
+      if (copy[key] != null) copy[key] = '[redacted]';
+    }
+    return copy;
+  }
+
+  function writeAudit({ actor, action, entityType, entityId, before, after, reason }) {
+    insertAudit.run(
+      makeId('audit'),
+      actor,
+      action,
+      entityType,
+      entityId,
+      before ? JSON.stringify(auditSafe(before)) : null,
+      after ? JSON.stringify(auditSafe(after)) : null,
+      cleanString(reason, 500)
+    );
+  }
+
+  function getDocument(id) {
+    return selectDocument.get(id);
+  }
+
+  function getVersion(id) {
+    return selectVersion.get(id);
+  }
+
+  function getClaim(id) {
+    return selectClaim.get(id);
+  }
+
+  function requireDocument(req, res) {
+    const document = getDocument(req.params.id);
+    if (!document) {
+      res.status(404).json({ error: 'Document not found' });
+      return null;
+    }
+    return document;
+  }
+
+  function ensureKnown(value, allowed, label) {
+    if (!value || !allowed.has(value)) return `${label} is invalid`;
+    return null;
+  }
+
+  function ensureDocumentTransition(document, nextStatus) {
+    if (document.status === nextStatus) return null;
+    if (!DOCUMENT_STATUSES.has(nextStatus)) return 'status is invalid';
+    if (!DOCUMENT_TRANSITIONS[document.status] || !DOCUMENT_TRANSITIONS[document.status].has(nextStatus)) {
+      return `Invalid document status transition: ${document.status} -> ${nextStatus}`;
+    }
+    if (document.status === 'draft' && nextStatus === 'active') {
+      const versionCount = db.prepare('SELECT COUNT(*) AS c FROM document_versions WHERE document_id=?').get(document.id).c;
+      if (versionCount === 0) return 'Document needs at least one version before it can become active.';
+    }
+    return null;
+  }
+
+  function ensureVersionTransition(version, nextStatus) {
+    if (!VERSION_APPROVAL_STATUSES.has(nextStatus)) return 'approval_status is invalid';
+    if (version.approval_status === nextStatus) return null;
+    if (version.approval_status === 'pending_review' && ['approved', 'rejected'].includes(nextStatus)) return null;
+    if (version.approval_status === 'approved' && nextStatus === 'superseded') return null;
+    if (version.approval_status === 'rejected' && nextStatus === 'pending_review') return null;
+    return `Invalid version approval transition: ${version.approval_status} -> ${nextStatus}`;
+  }
+
+  function ensureClaimTransition(claim, nextStatus) {
+    if (!CLAIM_STATUSES.has(nextStatus)) return 'status is invalid';
+    if (claim.status === nextStatus) return null;
+    if (claim.status === 'pending_review' && ['approved', 'rejected'].includes(nextStatus)) return null;
+    if (claim.status === 'approved' && ['applied', 'superseded'].includes(nextStatus)) return null;
+    if (claim.status === 'applied' && nextStatus === 'superseded') return null;
+    return `Invalid claim status transition: ${claim.status} -> ${nextStatus}`;
+  }
+
+  function validateDocumentInput(body, partial = false) {
+    const title = cleanString(body.title, 200);
+    const documentType = cleanString(body.document_type, 80);
+    const sourceProvider = cleanString(body.source_provider, 40) || 'manual';
+    const status = cleanString(body.status, 40) || 'draft';
+
+    if (!partial || body.title != null) {
+      if (!title) return { error: 'title is required' };
+    }
+    if (!partial || body.document_type != null) {
+      const err = ensureKnown(documentType, DOCUMENT_TYPES, 'document_type');
+      if (err) return { error: err };
+    }
+    if (body.source_provider != null || !partial) {
+      const err = ensureKnown(sourceProvider, SOURCE_PROVIDERS, 'source_provider');
+      if (err) return { error: err };
+    }
+    if (body.status != null || !partial) {
+      const err = ensureKnown(status, DOCUMENT_STATUSES, 'status');
+      if (err) return { error: err };
+    }
+
+    return {
+      values: {
+        title,
+        document_type: documentType,
+        source_provider: sourceProvider,
+        source_uri: cleanString(body.source_uri, 2048),
+        source_external_id: cleanString(body.source_external_id, 300),
+        status,
+        property_id: cleanString(body.property_id, 80),
+        created_by: cleanString(body.created_by, 80),
+      },
+    };
+  }
+
+  function validateClaimInput(raw) {
+    const claimType = cleanString(raw.claim_type, 120);
+    const valueType = cleanString(raw.value_type, 40);
+    const confidence = Number(raw.confidence);
+    const quote = cleanString(raw.source_quote, 500);
+
+    if (!claimType) return { error: 'claim_type is required' };
+    if (!CLAIM_TYPES.has(claimType) && !claimType.startsWith('other:')) {
+      return { error: 'Unknown claim_type values must use other:<name>.' };
+    }
+    if (!valueType || !CLAIM_VALUE_TYPES.has(valueType)) return { error: 'value_type is invalid' };
+    if (!Object.prototype.hasOwnProperty.call(raw, 'value')) return { error: 'value is required' };
+    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+      return { error: 'confidence must be between 0 and 1' };
+    }
+    if (raw.source_quote && String(raw.source_quote).length > 500) {
+      return { error: 'source_quote must be 500 characters or fewer' };
+    }
+
+    let sourceLocationJson = null;
+    if (raw.source_location != null) {
+      try {
+        sourceLocationJson = JSON.stringify(raw.source_location);
+      } catch (_) {
+        return { error: 'source_location must be JSON serializable' };
+      }
+    }
+
+    return {
+      values: {
+        claim_type: claimType,
+        claim_value_json: JSON.stringify(raw.value),
+        source_quote: quote,
+        source_location_json: sourceLocationJson,
+        confidence,
+      },
+    };
+  }
+
+  router.get('/', (req, res) => {
+    const conditions = [];
+    const values = [];
+    for (const [key, column] of [
+      ['property_id', 'property_id'],
+      ['status', 'status'],
+      ['document_type', 'document_type'],
+    ]) {
+      if (req.query[key]) {
+        conditions.push(`${column}=?`);
+        values.push(String(req.query[key]));
+      }
+    }
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const documents = db.prepare(`
+      SELECT id, property_id, title, document_type, source_provider, status,
+             current_version_id, created_by, created_at, updated_at
+      FROM documents
+      ${where}
+      ORDER BY updated_at DESC, created_at DESC
+    `).all(...values);
+    res.json({ documents });
+  });
+
+  router.post('/', (req, res) => {
+    const validated = validateDocumentInput(req.body || {});
+    if (validated.error) return res.status(400).json({ error: validated.error });
+    const f = validated.values;
+    if (f.status !== 'draft') return res.status(400).json({ error: 'New documents must start in draft status.' });
+    const id = makeId('doc');
+    try {
+      db.prepare(`
+        INSERT INTO documents (
+          id, property_id, title, document_type, source_provider, source_uri,
+          source_external_id, status, created_by
+        ) VALUES (?,?,?,?,?,?,?,?,?)
+      `).run(
+        id,
+        f.property_id,
+        f.title,
+        f.document_type,
+        f.source_provider,
+        f.source_uri,
+        f.source_external_id,
+        f.status,
+        f.created_by
+      );
+      const row = getDocument(id);
+      writeAudit({
+        actor: actorFrom(req),
+        action: 'document.created',
+        entityType: 'document',
+        entityId: id,
+        after: row,
+        reason: req.body.reason,
+      });
+      res.status(201).json(row);
+    } catch (err) {
+      if (err && err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        return res.status(409).json({ error: 'Document source_external_id already exists for provider.' });
+      }
+      if (err && err.code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+        return res.status(400).json({ error: 'property_id does not exist.' });
+      }
+      console.error(err);
+      res.status(500).json({ error: 'Failed to create document' });
+    }
+  });
+
+  router.get('/:id', (req, res) => {
+    const document = requireDocument(req, res);
+    if (!document) return;
+    const versions = db.prepare(`
+      SELECT id, document_id, version_number, file_name, mime_type, file_size_bytes,
+             sha256, storage_uri, storage_external_id, ocr_status, approval_status,
+             approved_by, approved_at, created_at
+      FROM document_versions
+      WHERE document_id=?
+      ORDER BY version_number DESC
+    `).all(document.id);
+    const claims = db.prepare(`
+      SELECT id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+             source_quote, source_location_json, confidence, status, reviewed_by,
+             reviewed_at, review_note, created_at
+      FROM extracted_claims
+      WHERE document_id=?
+      ORDER BY created_at DESC
+    `).all(document.id);
+    const currentVersion = document.current_version_id ? getVersion(document.current_version_id) : null;
+    res.json({ document, current_version: currentVersion, versions, claims });
+  });
+
+  router.patch('/:id', (req, res) => {
+    const before = requireDocument(req, res);
+    if (!before) return;
+    const validated = validateDocumentInput(req.body || {}, true);
+    if (validated.error) return res.status(400).json({ error: validated.error });
+
+    const fields = {};
+    for (const key of ['title', 'document_type', 'source_provider', 'source_uri', 'source_external_id', 'status']) {
+      if (Object.prototype.hasOwnProperty.call(req.body, key)) fields[key] = validated.values[key];
+    }
+    if (Object.prototype.hasOwnProperty.call(req.body, 'property_id')) {
+      fields.property_id = validated.values.property_id;
+    }
+    if (fields.status) {
+      const err = ensureDocumentTransition(before, fields.status);
+      if (err) return res.status(400).json({ error: err });
+    }
+    if (Object.keys(fields).length === 0) return res.status(400).json({ error: 'No document fields provided' });
+
+    const assignments = Object.keys(fields).map((key) => `${key}=?`);
+    try {
+      db.prepare(`
+        UPDATE documents SET ${assignments.join(', ')}, updated_at=datetime('now') WHERE id=?
+      `).run(...Object.values(fields), before.id);
+    } catch (err) {
+      if (err && err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        return res.status(409).json({ error: 'Document source_external_id already exists for provider.' });
+      }
+      if (err && err.code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+        return res.status(400).json({ error: 'property_id does not exist.' });
+      }
+      console.error(err);
+      return res.status(500).json({ error: 'Failed to update document' });
+    }
+    const after = getDocument(before.id);
+    writeAudit({
+      actor: actorFrom(req),
+      action: 'document.updated',
+      entityType: 'document',
+      entityId: before.id,
+      before,
+      after,
+      reason: req.body.reason,
+    });
+    res.json(after);
+  });
+
+  router.post('/:id/versions', (req, res) => {
+    const document = requireDocument(req, res);
+    if (!document) return;
+    const fileName = cleanString(req.body.file_name, 300);
+    const storageUri = cleanString(req.body.storage_uri, 2048);
+    if (!fileName) return res.status(400).json({ error: 'file_name is required' });
+    if (!storageUri) return res.status(400).json({ error: 'storage_uri is required' });
+    const size = req.body.file_size_bytes == null ? null : Number(req.body.file_size_bytes);
+    if (size != null && (!Number.isFinite(size) || size < 0)) {
+      return res.status(400).json({ error: 'file_size_bytes must be a non-negative number' });
+    }
+
+    const versionNumber = db.prepare(`
+      SELECT COALESCE(MAX(version_number), 0) + 1 AS n FROM document_versions WHERE document_id=?
+    `).get(document.id).n;
+    const id = makeId('ver');
+    try {
+      db.prepare(`
+        INSERT INTO document_versions (
+          id, document_id, version_number, file_name, mime_type, file_size_bytes, sha256,
+          storage_uri, storage_external_id, ocr_text, ocr_status
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+      `).run(
+        id,
+        document.id,
+        versionNumber,
+        fileName,
+        cleanString(req.body.mime_type, 120),
+        size,
+        cleanString(req.body.sha256, 128),
+        storageUri,
+        cleanString(req.body.storage_external_id, 300),
+        null,
+        cleanString(req.body.ocr_status, 40) || 'not_started'
+      );
+      const row = getVersion(id);
+      writeAudit({
+        actor: actorFrom(req),
+        action: 'document_version.created',
+        entityType: 'document_version',
+        entityId: id,
+        after: row,
+        reason: req.body.reason,
+      });
+      res.status(201).json(row);
+    } catch (err) {
+      if (err && err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        return res.status(409).json({ error: 'Document version file hash already exists.' });
+      }
+      console.error(err);
+      res.status(500).json({ error: 'Failed to create document version' });
+    }
+  });
+
+  router.post('/:id/versions/:versionId/approve', (req, res) => {
+    const document = requireDocument(req, res);
+    if (!document) return;
+    const version = getVersion(req.params.versionId);
+    if (!version || version.document_id !== document.id) return res.status(404).json({ error: 'Version not found' });
+    if (!['draft', 'active'].includes(document.status)) {
+      return res.status(400).json({ error: `Cannot approve a version while document status is ${document.status}.` });
+    }
+    const err = ensureVersionTransition(version, 'approved');
+    if (err) return res.status(400).json({ error: err });
+    const actor = actorFrom(req);
+
+    const tx = db.transaction(() => {
+      const approvedVersions = db.prepare(`
+        SELECT * FROM document_versions
+        WHERE document_id=? AND approval_status='approved' AND id<>?
+      `).all(document.id, version.id);
+      for (const approved of approvedVersions) {
+        db.prepare("UPDATE document_versions SET approval_status='superseded' WHERE id=?").run(approved.id);
+        writeAudit({
+          actor,
+          action: 'document_version.superseded',
+          entityType: 'document_version',
+          entityId: approved.id,
+          before: approved,
+          after: getVersion(approved.id),
+          reason: `Replaced by ${version.id}`,
+        });
+      }
+      db.prepare(`
+        UPDATE document_versions
+        SET approval_status='approved', approved_by=?, approved_at=datetime('now')
+        WHERE id=?
+      `).run(actor, version.id);
+      db.prepare(`
+        UPDATE documents
+        SET status='active', current_version_id=?, updated_at=datetime('now')
+        WHERE id=?
+      `).run(version.id, document.id);
+      writeAudit({
+        actor,
+        action: 'document_version.approved',
+        entityType: 'document_version',
+        entityId: version.id,
+        before: version,
+        after: getVersion(version.id),
+        reason: req.body.reason,
+      });
+    });
+    tx();
+    res.json({ document: getDocument(document.id), version: getVersion(version.id) });
+  });
+
+  router.post('/:id/versions/:versionId/reject', (req, res) => {
+    const document = requireDocument(req, res);
+    if (!document) return;
+    const version = getVersion(req.params.versionId);
+    if (!version || version.document_id !== document.id) return res.status(404).json({ error: 'Version not found' });
+    const err = ensureVersionTransition(version, 'rejected');
+    if (err) return res.status(400).json({ error: err });
+    db.prepare("UPDATE document_versions SET approval_status='rejected' WHERE id=?").run(version.id);
+    writeAudit({
+      actor: actorFrom(req),
+      action: 'document_version.rejected',
+      entityType: 'document_version',
+      entityId: version.id,
+      before: version,
+      after: getVersion(version.id),
+      reason: req.body.reason,
+    });
+    res.json(getVersion(version.id));
+  });
+
+  router.post('/:id/claims', (req, res) => {
+    const document = requireDocument(req, res);
+    if (!document) return;
+    const versionId = cleanString(req.body.document_version_id, 120);
+    const version = versionId ? getVersion(versionId) : null;
+    if (!version || version.document_id !== document.id) {
+      return res.status(400).json({ error: 'document_version_id must reference this document' });
+    }
+    if (!Array.isArray(req.body.claims)) return res.status(400).json({ error: 'claims must be an array' });
+    if (req.body.claims.length === 0) return res.status(400).json({ error: 'claims must not be empty' });
+
+    const prepared = [];
+    for (const claim of req.body.claims) {
+      const validated = validateClaimInput(claim || {});
+      if (validated.error) return res.status(400).json({ error: validated.error });
+      prepared.push(validated.values);
+    }
+
+    const actor = actorFrom(req);
+    const rows = [];
+    const tx = db.transaction(() => {
+      for (const claim of prepared) {
+        const id = makeId('claim');
+        db.prepare(`
+          INSERT INTO extracted_claims (
+            id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+            source_quote, source_location_json, confidence
+          ) VALUES (?,?,?,?,?,?,?,?,?)
+        `).run(
+          id,
+          document.id,
+          version.id,
+          document.property_id,
+          claim.claim_type,
+          claim.claim_value_json,
+          claim.source_quote,
+          claim.source_location_json,
+          claim.confidence
+        );
+        const row = getClaim(id);
+        writeAudit({
+          actor,
+          action: 'extracted_claim.created',
+          entityType: 'extracted_claim',
+          entityId: id,
+          after: row,
+          reason: req.body.reason,
+        });
+        rows.push(row);
+      }
+    });
+    tx();
+    res.status(201).json({ claims: rows });
+  });
+
+  router.post('/:id/claims/:claimId/approve', (req, res) => {
+    return reviewClaim(req, res, 'approved');
+  });
+
+  router.post('/:id/claims/:claimId/reject', (req, res) => {
+    return reviewClaim(req, res, 'rejected');
+  });
+
+  function reviewClaim(req, res, status) {
+    const document = requireDocument(req, res);
+    if (!document) return;
+    const claim = getClaim(req.params.claimId);
+    if (!claim || claim.document_id !== document.id) return res.status(404).json({ error: 'Claim not found' });
+    const err = ensureClaimTransition(claim, status);
+    if (err) return res.status(400).json({ error: err });
+    const actor = actorFrom(req);
+    db.prepare(`
+      UPDATE extracted_claims
+      SET status=?, reviewed_by=?, reviewed_at=datetime('now'), review_note=?
+      WHERE id=?
+    `).run(status, actor, cleanString(req.body.review_note || req.body.reason, 500), claim.id);
+    const after = getClaim(claim.id);
+    writeAudit({
+      actor,
+      action: `extracted_claim.${status}`,
+      entityType: 'extracted_claim',
+      entityId: claim.id,
+      before: claim,
+      after,
+      reason: req.body.reason,
+    });
+    res.json(after);
+  }
+
+  router.get('/:id/audit', (req, res) => {
+    const document = requireDocument(req, res);
+    if (!document) return;
+    const entityIds = [document.id];
+    for (const version of db.prepare('SELECT id FROM document_versions WHERE document_id=?').all(document.id)) {
+      entityIds.push(version.id);
+    }
+    for (const claim of db.prepare('SELECT id FROM extracted_claims WHERE document_id=?').all(document.id)) {
+      entityIds.push(claim.id);
+    }
+    const placeholders = entityIds.map(() => '?').join(',');
+    const events = db.prepare(`
+      SELECT id, actor, action, entity_type, entity_id, before_json, after_json, reason, created_at
+      FROM audit_events
+      WHERE entity_id IN (${placeholders})
+      ORDER BY created_at ASC, id ASC
+    `).all(...entityIds);
+    res.json({ events });
+  });
+
+  return router;
+}
+
+module.exports = createDocumentsRouter;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -118,6 +118,82 @@ CREATE TABLE IF NOT EXISTS lead_followups (
   sent_at       TEXT
 );
 
+CREATE TABLE IF NOT EXISTS documents (
+  id                 TEXT PRIMARY KEY,
+  property_id        TEXT REFERENCES properties(id) ON DELETE SET NULL,
+  title              TEXT NOT NULL,
+  document_type      TEXT NOT NULL,
+  source_provider    TEXT NOT NULL DEFAULT 'manual',
+  source_uri         TEXT,
+  source_external_id TEXT,
+  status             TEXT NOT NULL DEFAULT 'draft',
+  current_version_id TEXT REFERENCES document_versions(id) ON DELETE SET NULL,
+  created_by         TEXT,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS document_versions (
+  id                  TEXT PRIMARY KEY,
+  document_id         TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  version_number      INTEGER NOT NULL,
+  file_name           TEXT NOT NULL,
+  mime_type           TEXT,
+  file_size_bytes     INTEGER,
+  sha256              TEXT,
+  storage_uri         TEXT NOT NULL,
+  storage_external_id TEXT,
+  ocr_text            TEXT,
+  ocr_status          TEXT NOT NULL DEFAULT 'not_started',
+  approval_status     TEXT NOT NULL DEFAULT 'pending_review',
+  approved_by         TEXT,
+  approved_at         TEXT,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(document_id, version_number)
+);
+
+CREATE TABLE IF NOT EXISTS extracted_claims (
+  id                   TEXT PRIMARY KEY,
+  document_id          TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  document_version_id  TEXT NOT NULL REFERENCES document_versions(id) ON DELETE CASCADE,
+  property_id          TEXT REFERENCES properties(id) ON DELETE SET NULL,
+  claim_type           TEXT NOT NULL,
+  claim_value_json     TEXT NOT NULL,
+  source_quote         TEXT,
+  source_location_json TEXT,
+  confidence           REAL,
+  status               TEXT NOT NULL DEFAULT 'pending_review',
+  reviewed_by          TEXT,
+  reviewed_at          TEXT,
+  review_note          TEXT,
+  created_at           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS integration_events (
+  id                  TEXT PRIMARY KEY,
+  provider            TEXT NOT NULL,
+  event_type          TEXT NOT NULL,
+  document_id         TEXT REFERENCES documents(id) ON DELETE SET NULL,
+  document_version_id TEXT REFERENCES document_versions(id) ON DELETE SET NULL,
+  external_id         TEXT,
+  status              TEXT NOT NULL DEFAULT 'recorded',
+  payload_json        TEXT,
+  error_message       TEXT,
+  created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS audit_events (
+  id          TEXT PRIMARY KEY,
+  actor       TEXT NOT NULL,
+  action      TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id   TEXT NOT NULL,
+  before_json TEXT,
+  after_json  TEXT,
+  reason      TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE TABLE IF NOT EXISTS sessions (
   sid    TEXT NOT NULL PRIMARY KEY,
   sess   JSON NOT NULL,
@@ -131,3 +207,24 @@ CREATE INDEX IF NOT EXISTS idx_properties_price  ON properties(price);
 CREATE INDEX IF NOT EXISTS idx_leads_status ON leads(status);
 CREATE INDEX IF NOT EXISTS idx_lead_followups_lead_due ON lead_followups(lead_id, due_at);
 CREATE INDEX IF NOT EXISTS idx_lead_followups_due ON lead_followups(status, due_at);
+CREATE INDEX IF NOT EXISTS idx_documents_property_id ON documents(property_id);
+CREATE INDEX IF NOT EXISTS idx_documents_status ON documents(status);
+CREATE INDEX IF NOT EXISTS idx_documents_type ON documents(document_type);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_source_external_id
+  ON documents(source_provider, source_external_id)
+  WHERE source_external_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_document_versions_document_id ON document_versions(document_id);
+CREATE INDEX IF NOT EXISTS idx_document_versions_approval_status ON document_versions(approval_status);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_document_versions_sha256
+  ON document_versions(sha256)
+  WHERE sha256 IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_extracted_claims_document_id ON extracted_claims(document_id);
+CREATE INDEX IF NOT EXISTS idx_extracted_claims_property_id ON extracted_claims(property_id);
+CREATE INDEX IF NOT EXISTS idx_extracted_claims_status ON extracted_claims(status);
+CREATE INDEX IF NOT EXISTS idx_extracted_claims_type ON extracted_claims(claim_type);
+CREATE INDEX IF NOT EXISTS idx_integration_events_provider_type ON integration_events(provider, event_type);
+CREATE INDEX IF NOT EXISTS idx_integration_events_document_id ON integration_events(document_id);
+CREATE INDEX IF NOT EXISTS idx_integration_events_external_id ON integration_events(external_id);
+CREATE INDEX IF NOT EXISTS idx_audit_events_entity ON audit_events(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_audit_events_actor ON audit_events(actor);
+CREATE INDEX IF NOT EXISTS idx_audit_events_created_at ON audit_events(created_at);

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -39,6 +39,7 @@ node --check server.js
 node --check db.js
 node --check middleware/auth.js
 node --check routes/api.js
+node --check routes/documents.js
 node --check routes/public.js
 node --check routes/admin.js
 echo "✓ Syntax OK"
@@ -52,6 +53,11 @@ echo
 echo "== HTTP integration smoke =="
 node "$ROOT/tests/http-smoke.test.js"
 echo "✓ HTTP integration smoke OK"
+echo
+
+echo "== Document registry smoke =="
+node "$ROOT/tests/document-registry.test.js"
+echo "✓ Document registry smoke OK"
 echo
 
 echo "== Startup smoke =="

--- a/tests/document-registry.test.js
+++ b/tests/document-registry.test.js
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const childProcess = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const API_DIR = path.join(ROOT, 'api');
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'wv-doc-registry-'));
+const DB_PATH = path.join(TMP_DIR, 'registry.db');
+const API_KEY = 'document-registry-test-key';
+
+let server = null;
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function test(name, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passed++;
+      console.log(`✓ ${name}`);
+    })
+    .catch((err) => {
+      failed++;
+      failures.push(`${name}: ${err.message}`);
+      console.log(`✗ ${name}`);
+      console.log(`  Error: ${err.message}`);
+    });
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const probe = http.createServer();
+    probe.on('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForHealth(baseUrl, getLog) {
+  const deadline = Date.now() + 15000;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    if (server.exitCode != null) {
+      throw new Error(`server exited early with code ${server.exitCode}\n${getLog()}`);
+    }
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await delay(250);
+  }
+  throw new Error(`server did not become healthy: ${lastError && lastError.message}\n${getLog()}`);
+}
+
+function api(baseUrl, pathName, options = {}) {
+  const headers = {
+    ...(options.auth === false ? {} : { Authorization: `Bearer ${API_KEY}` }),
+    ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+    ...(options.headers || {}),
+  };
+  return fetch(`${baseUrl}${pathName}`, {
+    ...options,
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+}
+
+async function json(res) {
+  return res.json();
+}
+
+function assertHasAction(events, action) {
+  assert(events.some((event) => event.action === action), `expected audit action ${action}`);
+}
+
+async function main() {
+  const port = await getFreePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let log = '';
+
+  server = childProcess.spawn(process.execPath, ['server.js'], {
+    cwd: API_DIR,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      DATABASE_PATH: DB_PATH,
+      NODE_ENV: 'test',
+      PUBLIC_LISTINGS_ENABLED: 'false',
+      PUBLIC_ASSISTANT_ENABLED: 'false',
+      API_KEY,
+      SESSION_SECRET: 'document-registry-session-secret',
+      ADMIN_PASSWORD: 'document-registry-admin-password',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const appendLog = (chunk) => {
+    log += chunk.toString();
+    if (log.length > 12000) log = log.slice(-12000);
+  };
+  server.stdout.on('data', appendLog);
+  server.stderr.on('data', appendLog);
+
+  try {
+    await waitForHealth(baseUrl, () => log);
+
+    let document = null;
+    let version = null;
+    let approvedClaim = null;
+    let rejectedClaim = null;
+
+    await test('GET /api/documents requires API key auth', async () => {
+      const res = await api(baseUrl, '/api/documents', { auth: false });
+      assert.strictEqual(res.status, 401);
+      assert.strictEqual((await json(res)).error, 'Unauthorized');
+    });
+
+    await test('POST /api/documents rejects non-draft creation', async () => {
+      const res = await api(baseUrl, '/api/documents', {
+        method: 'POST',
+        body: {
+          title: 'Premature Active Survey',
+          document_type: 'survey',
+          status: 'active',
+        },
+      });
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'New documents must start in draft status.');
+    });
+
+    await test('POST /api/documents creates a draft document', async () => {
+      const res = await api(baseUrl, '/api/documents', {
+        method: 'POST',
+        body: {
+          title: 'Advent Tax Card',
+          document_type: 'tax_card',
+          source_provider: 'manual',
+          source_uri: 'manual://advent-tax-card.pdf',
+          actor: 'test-suite',
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      document = await json(res);
+      assert(document.id.startsWith('doc_'));
+      assert.strictEqual(document.status, 'draft');
+      assert.strictEqual(document.document_type, 'tax_card');
+    });
+
+    await test('GET /api/documents lists documents with filters', async () => {
+      const res = await api(baseUrl, '/api/documents?status=draft&document_type=tax_card');
+      assert.strictEqual(res.status, 200);
+      const body = await json(res);
+      assert(Array.isArray(body.documents));
+      assert(body.documents.some((row) => row.id === document.id));
+    });
+
+    await test('PATCH /api/documents/:id rejects invalid draft to active transition without a version', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}`, {
+        method: 'PATCH',
+        body: { status: 'active', actor: 'test-suite' },
+      });
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'Document needs at least one version before it can become active.');
+    });
+
+    await test('PATCH /api/documents/:id reports invalid property references as 400', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}`, {
+        method: 'PATCH',
+        body: { property_id: 'missing-property-id', actor: 'test-suite' },
+      });
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'property_id does not exist.');
+    });
+
+    await test('POST /api/documents/:id/versions creates version metadata', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/versions`, {
+        method: 'POST',
+        body: {
+          file_name: 'advent-tax-card.pdf',
+          mime_type: 'application/pdf',
+          file_size_bytes: 12345,
+          sha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          storage_uri: 'manual://advent-tax-card.pdf',
+          actor: 'test-suite',
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      version = await json(res);
+      assert(version.id.startsWith('ver_'));
+      assert.strictEqual(version.version_number, 1);
+      assert.strictEqual(version.approval_status, 'pending_review');
+    });
+
+    await test('POST /api/documents/:id/versions returns 409 for duplicate file hashes', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/versions`, {
+        method: 'POST',
+        body: {
+          file_name: 'duplicate-tax-card.pdf',
+          sha256: version.sha256,
+          storage_uri: 'manual://duplicate-tax-card.pdf',
+          actor: 'test-suite',
+        },
+      });
+      assert.strictEqual(res.status, 409);
+      assert.strictEqual((await json(res)).error, 'Document version file hash already exists.');
+    });
+
+    await test('POST /api/documents/:id/claims rejects invalid AI extraction payloads', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/claims`, {
+        method: 'POST',
+        body: {
+          document_version_id: version.id,
+          claims: [{
+            claim_type: 'parcel_id',
+            value: '14-09-012B-0096-0000',
+            value_type: 'string',
+            confidence: 1.5,
+          }],
+        },
+      });
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'confidence must be between 0 and 1');
+    });
+
+    await test('POST /api/documents/:id/claims stores validated extracted claims', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/claims`, {
+        method: 'POST',
+        body: {
+          document_version_id: version.id,
+          actor: 'test-suite',
+          claims: [
+            {
+              claim_type: 'parcel_id',
+              value: '14-09-012B-0096-0000',
+              value_type: 'string',
+              source_quote: 'Parcel 14-09-012B-0096-0000',
+              source_location: { page: 1, section: 'Tax parcel' },
+              confidence: 0.92,
+            },
+            {
+              claim_type: 'other:registry_test',
+              value: 'Review required',
+              value_type: 'string',
+              confidence: 0.5,
+            },
+          ],
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      const body = await json(res);
+      assert.strictEqual(body.claims.length, 2);
+      approvedClaim = body.claims[0];
+      rejectedClaim = body.claims[1];
+      assert.strictEqual(approvedClaim.status, 'pending_review');
+    });
+
+    await test('POST /api/documents/:id/claims/:claimId/approve approves a pending claim', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/claims/${approvedClaim.id}/approve`, {
+        method: 'POST',
+        body: { actor: 'test-suite', review_note: 'Parcel value matches source.' },
+      });
+      assert.strictEqual(res.status, 200);
+      const body = await json(res);
+      assert.strictEqual(body.status, 'approved');
+      assert.strictEqual(body.reviewed_by, 'test-suite');
+      assert(body.reviewed_at && !body.reviewed_at.includes('T'), 'reviewed_at should use SQLite datetime format');
+    });
+
+    await test('POST /api/documents/:id/claims/:claimId/reject rejects a pending claim', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/claims/${rejectedClaim.id}/reject`, {
+        method: 'POST',
+        body: { actor: 'test-suite', review_note: 'Not a supported registry field.' },
+      });
+      assert.strictEqual(res.status, 200);
+      const body = await json(res);
+      assert.strictEqual(body.status, 'rejected');
+      assert.strictEqual(body.reviewed_by, 'test-suite');
+      assert(body.reviewed_at && !body.reviewed_at.includes('T'), 'reviewed_at should use SQLite datetime format');
+    });
+
+    await test('POST /api/documents/:id/versions/:versionId/approve activates the document', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/versions/${version.id}/approve`, {
+        method: 'POST',
+        body: { actor: 'test-suite', reason: 'Initial accepted source.' },
+      });
+      assert.strictEqual(res.status, 200);
+      const body = await json(res);
+      assert.strictEqual(body.version.approval_status, 'approved');
+      assert(body.version.approved_at && !body.version.approved_at.includes('T'), 'approved_at should use SQLite datetime format');
+      assert.strictEqual(body.document.status, 'active');
+      assert.strictEqual(body.document.current_version_id, version.id);
+    });
+
+    await test('POST /api/documents/:id/versions/:versionId/reject rejects invalid version transitions', async () => {
+      const res = await api(baseUrl, `/api/documents/${document.id}/versions/${version.id}/reject`, {
+        method: 'POST',
+        body: { actor: 'test-suite' },
+      });
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'Invalid version approval transition: approved -> rejected');
+    });
+
+    await test('GET /api/documents/:id returns registry detail and audit rows', async () => {
+      const detailRes = await api(baseUrl, `/api/documents/${document.id}`);
+      assert.strictEqual(detailRes.status, 200);
+      const detail = await json(detailRes);
+      assert.strictEqual(detail.document.status, 'active');
+      assert.strictEqual(detail.current_version.id, version.id);
+      assert.strictEqual(detail.versions.length, 1);
+      assert.strictEqual(detail.claims.length, 2);
+
+      const auditRes = await api(baseUrl, `/api/documents/${document.id}/audit`);
+      assert.strictEqual(auditRes.status, 200);
+      const audit = await json(auditRes);
+      assertHasAction(audit.events, 'document.created');
+      assertHasAction(audit.events, 'document_version.created');
+      assertHasAction(audit.events, 'extracted_claim.created');
+      assertHasAction(audit.events, 'extracted_claim.approved');
+      assertHasAction(audit.events, 'extracted_claim.rejected');
+      assertHasAction(audit.events, 'document_version.approved');
+      assert(audit.events.every((event) => !String(event.after_json || '').includes('manual://')));
+    });
+  } finally {
+    if (server && server.exitCode == null) {
+      server.kill();
+      await new Promise((resolve) => server.once('exit', resolve));
+    }
+    fs.rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+
+  if (failed) {
+    console.error(`\ndocument-registry.test.js: ${failed} failed, ${passed} passed`);
+    failures.forEach((failure) => console.error(`  - ${failure}`));
+    process.exit(1);
+  }
+
+  console.log(`\ndocument-registry.test.js: ${passed} passed, 0 failed`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Document Registry tables and indexes to runtime migrations and schema reference
- add API-key protected /api/documents skeleton with document/version/claim state transitions and audit writes
- add real HTTP registry smoke test and wire it into preflight

## Validation
- git diff --check
- node --check api/routes/documents.js
- node --check api/routes/api.js
- node --check api/db.js
- node tests/document-registry.test.js
- bash scripts/preflight.sh
- node tests/verify-security-fixes.test.js
- node tests/chat-assistant.test.js
- node tests/public-assistant-flag.test.js

## Production
No production deploy, DNS, Railway, Vercel, or VPS changes are included or implied.

## Summary by Sourcery

Introduce a Phase 1 Document Registry skeleton with database support, an API-key protected documents API, and integration into preflight checks.

New Features:
- Add SQLite tables and indexes for documents, document_versions, extracted_claims, integration_events, and audit_events to support the document registry domain model.
- Expose an API-key protected /api/documents router for managing document metadata, versions, extracted claims, status transitions, and audit retrieval.
- Add an end-to-end HTTP document registry smoke test that exercises the live server against a temporary SQLite database.

Enhancements:
- Wire the document registry router into the main API under /api/documents behind write rate limiting and API key auth.
- Update preflight script to include syntax checks for the new documents route and run the document registry smoke test.
- Mark the Phase 1 Document Registry implementation task as completed in the task tracker and log the work in the work log.

Tests:
- Add document-registry.test.js to validate document lifecycle, version approval/rejection rules, claim validation and review flows, and audit logging via real HTTP requests against a test server.