### PR TITLE
Add document claim review queue API

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -269,6 +269,6 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 - **Phase 0**: OpenHands executor validation — still awaiting developer action
 - **Phase 1**: Document Registry skeleton — spec and API/database skeleton merged in #118/#120; deploy pending
-- **Phase 2** (next): AI Review Queue
+- **Phase 2** (current): AI Review Queue — backend queue API added; admin UI and audited apply workflow remain next
 - **Phase 3**: Drive event automation
 - **Phase 4**: Gmail intake (Pub/Sub)

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,7 +25,7 @@
 
 ## Low Priority
 
-- [ ] **Phase 2: AI Review Queue** — depends on Phase 1 complete + ChatGPT spec
+- [ ] **Phase 2: AI Review Queue admin UI + apply workflow** — review-queue API is complete; next slice is admin UI for reviewing extracted claims and an audited apply workflow for approved facts
 - [ ] **Phase 3: Drive event automation** — depends on Phase 2 — **Gemini leads**
 - [ ] **Phase 4: Gmail intake** — depends on Phase 3 — **Gemini leads**
 
@@ -33,6 +33,7 @@
 
 ## Completed
 
+- [x] **Phase 2: AI Review Queue API** — added `GET /api/documents/review/claims` for status-filtered extracted-claim review queues with HTTP coverage in `tests/document-registry.test.js` — 2026-06-18
 - [x] **Add integration/E2E tests** — `tests/http-smoke.test.js` starts the real Express app against a temporary SQLite database and is enforced by `scripts/preflight.sh`; covers health/config/listings-off/contact-origin/chat-fallback behavior over HTTP — 2026-06-18
 - [x] **Remove disabled Twilio path** — deleted the unused dynamic Twilio sender, removed lead-route SMS calls, and updated docs so lead notifications are email/local persistence only until a future SMS provider is intentionally specified — 2026-06-18
 - [x] **CORS origin restriction review** — existing `CORS_ORIGIN` allowlist behavior verified and regression-covered in `tests/http-smoke.test.js`; trusted origins receive CORS headers and can submit guarded leads, untrusted origins do not receive CORS access and are rejected by same-origin lead guards — 2026-06-18

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -1040,3 +1040,22 @@ Close the backlog choice to either add the missing `twilio` dependency or remove
 
 ### Remaining Risks
 - SMS alerts are not implemented. Future SMS support should start from a fresh provider decision and package/env review.
+
+---
+
+## 2026-06-18 — Codex — Document Registry Phase 2 review queue API
+
+### Objective
+Start Phase 2 with a backend review-queue slice for extracted claims, without building the admin UI, applying approved facts to listings, enabling Drive/Gmail automation, or deploying to production.
+
+### Changes Made
+- `api/routes/documents.js` — added `GET /api/documents/review/claims`, defaulting to `pending_review` claims and supporting `status`, effective `property_id`, `claim_type`, `document_type`, and bounded `limit` filters; rejected/superseded source versions are excluded from the queue.
+- `tests/document-registry.test.js` — added real HTTP coverage for the review queue, invalid status rejection, parsed claim values/source locations, safe omission of source storage URIs, document-property fallback filtering, rejected-version exclusion, and reviewed-claim filtering.
+- `docs/DOCUMENT_REGISTRY_SPEC.md`, `TASKS.md`, `PROJECT_STATE.md` — recorded the Phase 2 queue API as complete while leaving admin UI and audited apply workflow open.
+
+### Verification
+- Required validation before PR: `node --check api/routes/documents.js`; `node tests/document-registry.test.js`; `bash scripts/preflight.sh`; `node tests/verify-security-fixes.test.js`; `git diff --check`.
+
+### Remaining Risks
+- This does not yet render the queue in `/admin`, mutate property/listing facts, or mark approved claims as `applied`.
+- The existing Phase 1 schema validates AI `value_type` but does not persist it; that should be a separate schema decision if the admin UI needs it.

--- a/api/routes/documents.js
+++ b/api/routes/documents.js
@@ -222,6 +222,43 @@ function createDocumentsRouter({ db }) {
     };
   }
 
+  function parseJsonField(raw, fallback = null) {
+    if (raw == null) return fallback;
+    try {
+      return JSON.parse(raw);
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function claimForReview(row) {
+    return {
+      id: row.id,
+      document_id: row.document_id,
+      document_version_id: row.document_version_id,
+      property_id: row.effective_property_id,
+      claim_property_id: row.claim_property_id,
+      document_property_id: row.document_property_id,
+      property_label: [row.property_address, row.property_city].filter(Boolean).join(', ') || null,
+      document_title: row.document_title,
+      document_type: row.document_type,
+      document_status: row.document_status,
+      version_number: row.version_number,
+      version_approval_status: row.version_approval_status,
+      file_name: row.file_name,
+      claim_type: row.claim_type,
+      value: parseJsonField(row.claim_value_json),
+      source_quote: row.source_quote,
+      source_location: parseJsonField(row.source_location_json),
+      confidence: row.confidence,
+      status: row.status,
+      reviewed_by: row.reviewed_by,
+      reviewed_at: row.reviewed_at,
+      review_note: row.review_note,
+      created_at: row.created_at,
+    };
+  }
+
   router.get('/', (req, res) => {
     const conditions = [];
     const values = [];
@@ -244,6 +281,63 @@ function createDocumentsRouter({ db }) {
       ORDER BY updated_at DESC, created_at DESC
     `).all(...values);
     res.json({ documents });
+  });
+
+  router.get('/review/claims', (req, res) => {
+    const status = cleanString(req.query.status, 40) || 'pending_review';
+    if (!CLAIM_STATUSES.has(status)) return res.status(400).json({ error: 'status is invalid' });
+
+    const conditions = ['c.status=?'];
+    const values = [status];
+    const filters = { status };
+    const propertyId = cleanString(req.query.property_id, 120);
+    if (propertyId) {
+      filters.property_id = propertyId;
+      conditions.push('COALESCE(c.property_id, d.property_id)=?');
+      values.push(propertyId);
+    }
+    const claimType = cleanString(req.query.claim_type, 120);
+    if (claimType) {
+      filters.claim_type = claimType;
+      conditions.push('c.claim_type=?');
+      values.push(claimType);
+    }
+    const documentType = cleanString(req.query.document_type, 120);
+    if (documentType) {
+      filters.document_type = documentType;
+      conditions.push('d.document_type=?');
+      values.push(documentType);
+    }
+
+    const requestedLimit = Number(req.query.limit || 50);
+    const limit = Number.isFinite(requestedLimit) && requestedLimit > 0
+      ? Math.min(Math.floor(requestedLimit), 100)
+      : 50;
+    filters.limit = limit;
+
+    const claims = db.prepare(`
+      SELECT
+        c.id, c.document_id, c.document_version_id,
+        c.property_id AS claim_property_id,
+        d.property_id AS document_property_id,
+        COALESCE(c.property_id, d.property_id) AS effective_property_id,
+        c.claim_type,
+        c.claim_value_json, c.source_quote, c.source_location_json,
+        c.confidence, c.status, c.reviewed_by, c.reviewed_at, c.review_note, c.created_at,
+        d.title AS document_title, d.document_type, d.status AS document_status,
+        v.version_number, v.file_name, v.approval_status AS version_approval_status,
+        p.address AS property_address, p.city AS property_city
+      FROM extracted_claims c
+      JOIN documents d ON d.id = c.document_id
+      JOIN document_versions v ON v.id = c.document_version_id
+      LEFT JOIN properties p ON p.id = COALESCE(c.property_id, d.property_id)
+      WHERE ${conditions.join(' AND ')}
+        AND v.approval_status NOT IN ('rejected', 'superseded')
+      ORDER BY c.created_at ASC, c.id ASC
+      LIMIT ?
+    `).all(...values, limit).map(claimForReview);
+
+    res.json({ claims, filters });
   });
 
   router.post('/', (req, res) => {

--- a/docs/DOCUMENT_REGISTRY_SPEC.md
+++ b/docs/DOCUMENT_REGISTRY_SPEC.md
@@ -205,6 +205,7 @@ Implementation should add a new router under `/api/documents`. Mutating routes r
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
 | `GET` | `/api/documents` | API key | List documents with filters: `property_id`, `status`, `document_type`. |
+| `GET` | `/api/documents/review/claims` | API key | List extracted claims by review status for the human review queue. Defaults to `pending_review`; supports `status`, `property_id`, `claim_type`, `document_type`, and `limit`; property filtering falls back to the document property when the claim was extracted before the document was linked; rejected/superseded source versions are excluded. |
 | `POST` | `/api/documents` | API key | Create a logical document. |
 | `GET` | `/api/documents/:id` | API key | Read document, current version, versions, and claims. |
 | `PATCH` | `/api/documents/:id` | API key | Update title/type/status metadata. |
@@ -301,6 +302,6 @@ A future implementation PR should satisfy all of these:
 |-------|-------|
 | Phase 1 spec | This document: schema, state machine, AI JSON contract, API skeleton. |
 | Phase 1 implementation | SQLite tables, helpers, API skeleton, tests. |
-| Phase 2 AI Review Queue | Admin UI for reviewing extracted claims and applying approved facts. |
+| Phase 2 AI Review Queue | Review-queue API for extracted claims, then admin UI for reviewing claims and applying approved facts. The queue API is implemented at `/api/documents/review/claims`; admin UI/apply workflow remains next. |
 | Phase 3 Drive event automation | Drive watch/import pipeline into `documents` and `document_versions`. |
 | Phase 4 Gmail intake | Email attachment/message ingestion into the registry. |

--- a/tests/document-registry.test.js
+++ b/tests/document-registry.test.js
@@ -13,8 +13,11 @@ const API_DIR = path.join(ROOT, 'api');
 const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'wv-doc-registry-'));
 const DB_PATH = path.join(TMP_DIR, 'registry.db');
 const API_KEY = 'document-registry-test-key';
+const REVIEW_PROPERTY_ID = 'review-property-1';
+const Database = require(path.join(API_DIR, 'node_modules', 'better-sqlite3'));
 
 let server = null;
+let testDb = null;
 let passed = 0;
 let failed = 0;
 const failures = [];
@@ -119,6 +122,12 @@ async function main() {
 
   try {
     await waitForHealth(baseUrl, () => log);
+    testDb = new Database(DB_PATH);
+    const county = testDb.prepare("SELECT id FROM counties WHERE name='Hampshire'").get();
+    testDb.prepare(`
+      INSERT INTO properties (id, county_id, address, city, property_type, status, listing_slug)
+      VALUES (?, ?, ?, ?, 'land', 'draft', ?)
+    `).run(REVIEW_PROPERTY_ID, county.id, 'Review Queue Road', 'Romney', 'review-queue-road');
 
     let document = null;
     let version = null;
@@ -150,6 +159,7 @@ async function main() {
         body: {
           title: 'Advent Tax Card',
           document_type: 'tax_card',
+          property_id: REVIEW_PROPERTY_ID,
           source_provider: 'manual',
           source_uri: 'manual://advent-tax-card.pdf',
           actor: 'test-suite',
@@ -270,6 +280,110 @@ async function main() {
       assert.strictEqual(approvedClaim.status, 'pending_review');
     });
 
+    await test('GET /api/documents/review/claims lists pending claims for human review', async () => {
+      const res = await api(baseUrl, '/api/documents/review/claims');
+      assert.strictEqual(res.status, 200);
+      const body = await json(res);
+      assert.strictEqual(body.filters.status, 'pending_review');
+      assert(Array.isArray(body.claims));
+      assert.strictEqual(body.claims.length, 2);
+      const parcelClaim = body.claims.find((claim) => claim.id === approvedClaim.id);
+      assert(parcelClaim, 'expected parcel claim in review queue');
+      assert.strictEqual(parcelClaim.document_title, 'Advent Tax Card');
+      assert.strictEqual(parcelClaim.document_type, 'tax_card');
+      assert.strictEqual(parcelClaim.property_id, REVIEW_PROPERTY_ID);
+      assert.strictEqual(parcelClaim.property_label, 'Review Queue Road, Romney');
+      assert.strictEqual(parcelClaim.version_number, 1);
+      assert.strictEqual(parcelClaim.file_name, 'advent-tax-card.pdf');
+      assert.deepStrictEqual(parcelClaim.value, '14-09-012B-0096-0000');
+      assert.deepStrictEqual(parcelClaim.source_location, { page: 1, section: 'Tax parcel' });
+      assert(!Object.prototype.hasOwnProperty.call(parcelClaim, 'source_uri'), 'review queue must not expose source_uri');
+    });
+
+    await test('GET /api/documents/review/claims rejects invalid status filters', async () => {
+      const res = await api(baseUrl, '/api/documents/review/claims?status=needs_human');
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'status is invalid');
+    });
+
+    await test('GET /api/documents/review/claims falls back to document property and excludes rejected versions', async () => {
+      const docRes = await api(baseUrl, '/api/documents', {
+        method: 'POST',
+        body: {
+          title: 'Late Linked Access Note',
+          document_type: 'seller_note',
+          source_provider: 'manual',
+          source_uri: 'manual://late-linked-access-note.txt',
+          actor: 'test-suite',
+        },
+      });
+      assert.strictEqual(docRes.status, 201);
+      const lateDocument = await json(docRes);
+
+      const versionRes = await api(baseUrl, `/api/documents/${lateDocument.id}/versions`, {
+        method: 'POST',
+        body: {
+          file_name: 'late-linked-access-note.txt',
+          sha256: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          storage_uri: 'manual://late-linked-access-note.txt',
+          actor: 'test-suite',
+        },
+      });
+      assert.strictEqual(versionRes.status, 201);
+      const lateVersion = await json(versionRes);
+
+      const claimRes = await api(baseUrl, `/api/documents/${lateDocument.id}/claims`, {
+        method: 'POST',
+        body: {
+          document_version_id: lateVersion.id,
+          actor: 'test-suite',
+          claims: [{
+            claim_type: 'road_access',
+            value: 'Deeded gravel access',
+            value_type: 'string',
+            confidence: 0.81,
+          }],
+        },
+      });
+      assert.strictEqual(claimRes.status, 201);
+      const lateClaim = (await json(claimRes)).claims[0];
+      assert.strictEqual(lateClaim.property_id, null);
+
+      const patchRes = await api(baseUrl, `/api/documents/${lateDocument.id}`, {
+        method: 'PATCH',
+        body: { property_id: REVIEW_PROPERTY_ID, actor: 'test-suite' },
+      });
+      assert.strictEqual(patchRes.status, 200);
+
+      const fallbackRes = await api(
+        baseUrl,
+        `/api/documents/review/claims?property_id=${encodeURIComponent(REVIEW_PROPERTY_ID)}&claim_type=road_access`
+      );
+      assert.strictEqual(fallbackRes.status, 200);
+      const fallback = await json(fallbackRes);
+      assert.strictEqual(fallback.filters.property_id, REVIEW_PROPERTY_ID);
+      const queuedLateClaim = fallback.claims.find((claim) => claim.id === lateClaim.id);
+      assert(queuedLateClaim, 'expected late-linked claim to use document property fallback');
+      assert.strictEqual(queuedLateClaim.property_id, REVIEW_PROPERTY_ID);
+      assert.strictEqual(queuedLateClaim.claim_property_id, null);
+      assert.strictEqual(queuedLateClaim.document_property_id, REVIEW_PROPERTY_ID);
+      assert.strictEqual(queuedLateClaim.version_approval_status, 'pending_review');
+
+      const rejectVersionRes = await api(baseUrl, `/api/documents/${lateDocument.id}/versions/${lateVersion.id}/reject`, {
+        method: 'POST',
+        body: { actor: 'test-suite', reason: 'Invalid source file.' },
+      });
+      assert.strictEqual(rejectVersionRes.status, 200);
+
+      const rejectedVersionQueueRes = await api(
+        baseUrl,
+        `/api/documents/review/claims?property_id=${encodeURIComponent(REVIEW_PROPERTY_ID)}&claim_type=road_access`
+      );
+      assert.strictEqual(rejectedVersionQueueRes.status, 200);
+      const rejectedVersionQueue = await json(rejectedVersionQueueRes);
+      assert(!rejectedVersionQueue.claims.some((claim) => claim.id === lateClaim.id));
+    });
+
     await test('POST /api/documents/:id/claims/:claimId/approve approves a pending claim', async () => {
       const res = await api(baseUrl, `/api/documents/${document.id}/claims/${approvedClaim.id}/approve`, {
         method: 'POST',
@@ -280,6 +394,41 @@ async function main() {
       assert.strictEqual(body.status, 'approved');
       assert.strictEqual(body.reviewed_by, 'test-suite');
       assert(body.reviewed_at && !body.reviewed_at.includes('T'), 'reviewed_at should use SQLite datetime format');
+    });
+
+    await test('GET /api/documents/review/claims filters reviewed claims by status and supported fields', async () => {
+      const pendingRes = await api(baseUrl, '/api/documents/review/claims?status=pending_review');
+      assert.strictEqual(pendingRes.status, 200);
+      const pending = await json(pendingRes);
+      assert(!pending.claims.some((claim) => claim.id === approvedClaim.id));
+
+      const approvedRes = await api(baseUrl, '/api/documents/review/claims?status=approved&claim_type=parcel_id');
+      assert.strictEqual(approvedRes.status, 200);
+      const approved = await json(approvedRes);
+      assert(approved.claims.some((claim) => claim.id === approvedClaim.id));
+      assert(!approved.claims.some((claim) => claim.id === rejectedClaim.id));
+      assert.strictEqual(approved.filters.status, 'approved');
+      assert.strictEqual(approved.filters.claim_type, 'parcel_id');
+
+      const propertyFilterRes = await api(
+        baseUrl,
+        `/api/documents/review/claims?status=approved&property_id=${encodeURIComponent(REVIEW_PROPERTY_ID)}`
+      );
+      assert.strictEqual(propertyFilterRes.status, 200);
+      const propertyFiltered = await json(propertyFilterRes);
+      assert.strictEqual(propertyFiltered.filters.property_id, REVIEW_PROPERTY_ID);
+      assert(propertyFiltered.claims.some((claim) => claim.id === approvedClaim.id));
+      assert(propertyFiltered.claims.every((claim) => claim.property_id === REVIEW_PROPERTY_ID));
+
+      const documentTypeFilterRes = await api(
+        baseUrl,
+        '/api/documents/review/claims?status=approved&document_type=tax_card'
+      );
+      assert.strictEqual(documentTypeFilterRes.status, 200);
+      const documentTypeFiltered = await json(documentTypeFilterRes);
+      assert.strictEqual(documentTypeFiltered.filters.document_type, 'tax_card');
+      assert(documentTypeFiltered.claims.some((claim) => claim.id === approvedClaim.id));
+      assert(documentTypeFiltered.claims.every((claim) => claim.document_type === 'tax_card'));
     });
 
     await test('POST /api/documents/:id/claims/:claimId/reject rejects a pending claim', async () => {
@@ -337,6 +486,10 @@ async function main() {
       assert(audit.events.every((event) => !String(event.after_json || '').includes('manual://')));
     });
   } finally {
+    if (testDb) {
+      testDb.close();
+      testDb = null;
+    }
     if (server && server.exitCode == null) {
       server.kill();
       await new Promise((resolve) => server.once('exit', resolve));


### PR DESCRIPTION
## Summary
- add `GET /api/documents/review/claims` as the Phase 2 backend review queue for extracted claims
- default the queue to `pending_review` and support `status`, `property_id`, `claim_type`, `document_type`, and bounded `limit` filters
- return reviewer-safe claim payloads with parsed values/source locations and without document storage URIs
- update Document Registry docs, backlog, project state, and work log while leaving admin UI/apply workflow open

## Validation
- `git diff --check`
- `node --check api/routes/documents.js`
- `node --check tests/document-registry.test.js`
- `node tests/document-registry.test.js`
- `bash scripts/preflight.sh`
- `node tests/verify-security-fixes.test.js`

## Boundaries
- No production deploy
- No VPS, DNS, Railway, Vercel, or env changes
- No changes to PR #116
- Does not apply approved claims to listing/property facts
