### PR TITLE
Add document claim admin review page

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -271,6 +271,6 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 - **Phase 0**: OpenHands executor validation — still awaiting developer action
 - **Phase 1**: Document Registry skeleton — spec and API/database skeleton merged in #118/#120; deploy pending
-- **Phase 2** (current): AI Review Queue — backend queue API added; admin UI and audited apply workflow remain next
+- **Phase 2** (current): AI Review Queue — backend queue API and read-only admin page added; audited apply workflow remains next
 - **Phase 3**: Drive event automation
 - **Phase 4**: Gmail intake (Pub/Sub)

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,7 +25,7 @@
 
 ## Low Priority
 
-- [ ] **Phase 2: AI Review Queue admin UI + apply workflow** — review-queue API is complete; next slice is admin UI for reviewing extracted claims and an audited apply workflow for approved facts
+- [ ] **Phase 2: AI Review Queue apply workflow** — review-queue API and read-only admin UI are complete; next slice is an audited apply workflow for approved facts
 - [ ] **Phase 3: Drive event automation** — depends on Phase 2 — **Gemini leads**
 - [ ] **Phase 4: Gmail intake** — depends on Phase 3 — **Gemini leads**
 
@@ -34,6 +34,7 @@
 ## Completed
 
 - [x] **Phase 2: AI Review Queue API** — added `GET /api/documents/review/claims` for status-filtered extracted-claim review queues with HTTP coverage in `tests/document-registry.test.js` — 2026-06-18
+- [x] **Phase 2: AI Review Queue admin UI** — added an authenticated read-only `/admin/document-claims` page with filters, safe rendered evidence, source/storage URI redaction, and HTTP coverage in `tests/admin-document-review.test.js` — 2026-06-19
 - [x] **Add integration/E2E tests** — `tests/http-smoke.test.js` starts the real Express app against a temporary SQLite database and is enforced by `scripts/preflight.sh`; covers health/config/listings-off/contact-origin/chat-fallback behavior over HTTP — 2026-06-18
 - [x] **Remove disabled Twilio path** — deleted the unused dynamic Twilio sender, removed lead-route SMS calls, and updated docs so lead notifications are email/local persistence only until a future SMS provider is intentionally specified — 2026-06-18
 - [x] **CORS origin restriction review** — existing `CORS_ORIGIN` allowlist behavior verified and regression-covered in `tests/http-smoke.test.js`; trusted origins receive CORS headers and can submit guarded leads, untrusted origins do not receive CORS access and are rejected by same-origin lead guards — 2026-06-18

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -1059,3 +1059,24 @@ Start Phase 2 with a backend review-queue slice for extracted claims, without bu
 ### Remaining Risks
 - This does not yet render the queue in `/admin`, mutate property/listing facts, or mark approved claims as `applied`.
 - The existing Phase 1 schema validates AI `value_type` but does not persist it; that should be a separate schema decision if the admin UI needs it.
+
+---
+
+## 2026-06-19 — Codex — Document Registry Phase 2 read-only admin review page
+
+### Objective
+Add the first admin-facing review surface for extracted document claims without approving, rejecting, applying facts to listing records, enabling Drive/Gmail automation, or deploying to production.
+
+### Changes Made
+- `api/routes/admin.js` — added authenticated `GET /admin/document-claims` with status/property/claim/document filters, effective-property fallback, rejected/superseded version exclusion, escaped read-only claim rendering, and deliberate omission of source/storage URIs.
+- `api/views/admin.js` — added a sidebar link and small table/filter styles for the document-claim review page.
+- `tests/admin-document-review.test.js` — added real HTTP coverage with a temporary SQLite DB for auth redirect, admin login, rendered claim data, filter behavior, rejected-version exclusion, and source/storage URI redaction.
+- `scripts/preflight.sh` — added the admin document review smoke test to the standard preflight gate.
+- `TASKS.md`, `docs/DOCUMENT_REGISTRY_SPEC.md`, `PROJECT_STATE.md` — recorded the read-only admin review page as complete while leaving audited apply workflow open.
+
+### Verification
+- Required validation before PR: `node --check api/routes/admin.js`; `node --check api/views/admin.js`; `node --check tests/admin-document-review.test.js`; `node tests/admin-document-review.test.js`; `bash scripts/preflight.sh`; `node tests/verify-security-fixes.test.js`; `git diff --check`.
+
+### Remaining Risks
+- This is review-only. The audited workflow that applies approved claims into listing/property facts is still the next Phase 2 slice.
+- Merge still does not deploy this admin page to the VPS; production remains on the last manually deployed runtime until Phil approves a VPS deploy.

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -46,6 +46,81 @@ const upload = multer({
 });
 
 const router = express.Router();
+const CLAIM_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded', 'applied']);
+const DOCUMENT_TYPES = new Set([
+  'deed', 'plat', 'survey', 'tax_card', 'disclosure', 'contract',
+  'listing_agreement', 'inspection', 'photo_release', 'utility',
+  'hoa_or_restrictions', 'seller_note', 'buyer_note', 'marketing_source',
+  'other',
+]);
+
+function cleanQuery(value, max = 120) {
+  if (value == null) return '';
+  return String(value).trim().slice(0, max);
+}
+
+function parseJsonField(raw) {
+  if (raw == null || raw === '') return null;
+  try {
+    return JSON.parse(raw);
+  } catch (_) {
+    return raw;
+  }
+}
+
+function displayJsonValue(raw) {
+  const value = parseJsonField(raw);
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+function renderSelectOptions(values, selected) {
+  return values.map((value) =>
+    `<option value="${esc(value)}" ${selected === value ? 'selected' : ''}>${esc(value)}</option>`
+  ).join('');
+}
+
+function renderReviewFilters(filters) {
+  const statuses = ['pending_review', 'approved', 'rejected', 'superseded', 'applied'];
+  const documentTypes = ['', ...Array.from(DOCUMENT_TYPES).sort()];
+
+  return `
+    <div class="filter-panel">
+      <form method="GET" action="/admin/document-claims">
+        <div>
+          <label>Status</label>
+          <select name="status">
+            ${renderSelectOptions(statuses, filters.status)}
+          </select>
+        </div>
+        <div>
+          <label>Property ID</label>
+          <input type="text" name="property_id" value="${esc(filters.property_id)}" placeholder="Optional" />
+        </div>
+        <div>
+          <label>Claim Type</label>
+          <input type="text" name="claim_type" value="${esc(filters.claim_type)}" placeholder="parcel_id, acreage..." />
+        </div>
+        <div>
+          <label>Document Type</label>
+          <select name="document_type">
+            ${documentTypes.map((value) => {
+              const label = value || 'Any';
+              return `<option value="${esc(value)}" ${filters.document_type === value ? 'selected' : ''}>${esc(label)}</option>`;
+            }).join('')}
+          </select>
+        </div>
+        <button type="submit" class="btn">Filter</button>
+      </form>
+    </div>`;
+}
+
+function formatConfidence(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return '';
+  return `${Math.round(n * 100)}%`;
+}
 
 // ── Login ─────────────────────────────────────────────────
 router.get('/login', (_req, res) => res.send(loginPageHtml));
@@ -580,6 +655,128 @@ router.post('/ai/:id', requireAuth, requireCsrf, adminActionRateLimit, async (re
     return res.status(500).send('AI generation failed: ' + esc(err.message));
   }
   res.redirect(`/admin/ai/${p.id}`);
+});
+
+// ── Document Claim Review Queue ───────────────────────────
+router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => {
+  const filters = {
+    status: cleanQuery(req.query.status) || 'pending_review',
+    property_id: cleanQuery(req.query.property_id, 80),
+    claim_type: cleanQuery(req.query.claim_type, 120),
+    document_type: cleanQuery(req.query.document_type, 80),
+  };
+
+  if (!CLAIM_STATUSES.has(filters.status)) {
+    return res.status(400).send(adminShell('Document Claims', `
+      <div class="dash-header">
+        <h1>Document Claims</h1>
+        <a href="/admin" class="btn-outline">Back</a>
+      </div>
+      <div class="empty-state">Invalid status filter.</div>
+    `, csrfToken(req)));
+  }
+
+  if (filters.document_type && !DOCUMENT_TYPES.has(filters.document_type)) {
+    return res.status(400).send(adminShell('Document Claims', `
+      <div class="dash-header">
+        <h1>Document Claims</h1>
+        <a href="/admin" class="btn-outline">Back</a>
+      </div>
+      <div class="empty-state">Invalid document type filter.</div>
+    `, csrfToken(req)));
+  }
+
+  const conditions = ['c.status=?'];
+  const values = [filters.status];
+
+  if (filters.property_id) {
+    conditions.push('COALESCE(c.property_id, d.property_id)=?');
+    values.push(filters.property_id);
+  }
+  if (filters.claim_type) {
+    conditions.push('c.claim_type=?');
+    values.push(filters.claim_type);
+  }
+  if (filters.document_type) {
+    conditions.push('d.document_type=?');
+    values.push(filters.document_type);
+  }
+
+  const claims = db.prepare(`
+    SELECT
+      c.id, c.document_id, c.document_version_id,
+      c.property_id AS claim_property_id,
+      d.property_id AS document_property_id,
+      COALESCE(c.property_id, d.property_id) AS effective_property_id,
+      c.claim_type, c.claim_value_json, c.source_quote, c.source_location_json,
+      c.confidence, c.status, c.reviewed_by, c.reviewed_at, c.review_note, c.created_at,
+      d.title AS document_title, d.document_type, d.status AS document_status,
+      v.version_number, v.file_name, v.approval_status AS version_approval_status,
+      p.address AS property_address, p.city AS property_city
+    FROM extracted_claims c
+    JOIN documents d ON d.id = c.document_id
+    JOIN document_versions v ON v.id = c.document_version_id
+    LEFT JOIN properties p ON p.id = COALESCE(c.property_id, d.property_id)
+    WHERE ${conditions.join(' AND ')}
+      AND v.approval_status NOT IN ('rejected', 'superseded')
+    ORDER BY c.created_at ASC, c.id ASC
+    LIMIT 100
+  `).all(...values);
+
+  const rows = claims.map((claim) => {
+    const propertyLabel = [claim.property_address, claim.property_city].filter(Boolean).join(', ')
+      || claim.effective_property_id
+      || 'Unlinked';
+    const sourceLocation = displayJsonValue(claim.source_location_json);
+
+    return `
+      <tr>
+        <td>
+          <strong>${esc(propertyLabel)}</strong>
+          ${claim.effective_property_id ? `<div class="muted">${esc(claim.effective_property_id)}</div>` : ''}
+        </td>
+        <td>
+          <strong>${esc(claim.document_title)}</strong>
+          <div class="muted">${esc(claim.document_type)} · v${esc(claim.version_number)} · ${esc(claim.file_name || '')}</div>
+          <div class="muted">Document: ${esc(claim.document_status)} · Version: ${esc(claim.version_approval_status)}</div>
+        </td>
+        <td><span class="code-chip">${esc(claim.claim_type)}</span></td>
+        <td class="claim-value">${esc(displayJsonValue(claim.claim_value_json))}</td>
+        <td>${esc(formatConfidence(claim.confidence))}</td>
+        <td class="quote-cell">
+          ${claim.source_quote ? esc(claim.source_quote) : '<span class="muted">No quote</span>'}
+          ${sourceLocation ? `<div class="muted">${esc(sourceLocation)}</div>` : ''}
+        </td>
+        <td><span class="badge pending">${esc(claim.status)}</span></td>
+      </tr>`;
+  }).join('');
+
+  res.send(adminShell('Document Claims', `
+    <div class="dash-header">
+      <h1>Document Claims</h1>
+      <a href="/admin" class="btn-outline">Back</a>
+    </div>
+    ${renderReviewFilters(filters)}
+    <p class="queue-meta">
+      Showing ${claims.length} claim${claims.length === 1 ? '' : 's'} for review. Storage and source URIs are intentionally hidden.
+    </p>
+    ${claims.length ? `
+      <table class="listings-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Document</th>
+            <th>Claim</th>
+            <th>Value</th>
+            <th>Confidence</th>
+            <th>Source Evidence</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    ` : '<div class="empty-state">No document claims match these filters.</div>'}
+  `, csrfToken(req)));
 });
 
 // ── Integrations ──────────────────────────────────────────

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -13,6 +13,7 @@ const { adminShell, listingForm, loginPageHtml, loginErrorHtml } = require('../v
 const { esc, slugify, initListingFolder, isSafePathComponent, normalizeAcreage, safeListingPath } = require('../helpers');
 const { uploadPhotoToDrive } = require('../google');
 const { generateListingContent, aiConfigured } = require('../ai-generator');
+const { CLAIM_STATUSES, DOCUMENT_TYPES } = require('./documents');
 
 let sharp;
 try { sharp = require('sharp'); } catch (_) { sharp = null; }
@@ -46,13 +47,6 @@ const upload = multer({
 });
 
 const router = express.Router();
-const CLAIM_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded', 'applied']);
-const DOCUMENT_TYPES = new Set([
-  'deed', 'plat', 'survey', 'tax_card', 'disclosure', 'contract',
-  'listing_agreement', 'inspection', 'photo_release', 'utility',
-  'hoa_or_restrictions', 'seller_note', 'buyer_note', 'marketing_source',
-  'other',
-]);
 
 function cleanQuery(value, max = 120) {
   if (value == null) return '';
@@ -82,7 +76,7 @@ function renderSelectOptions(values, selected) {
 }
 
 function renderReviewFilters(filters) {
-  const statuses = ['pending_review', 'approved', 'rejected', 'superseded', 'applied'];
+  const statuses = Array.from(CLAIM_STATUSES);
   const documentTypes = ['', ...Array.from(DOCUMENT_TYPES).sort()];
 
   return `
@@ -117,9 +111,17 @@ function renderReviewFilters(filters) {
 }
 
 function formatConfidence(value) {
+  if (value == null || value === '') return '';
   const n = Number(value);
   if (!Number.isFinite(n)) return '';
   return `${Math.round(n * 100)}%`;
+}
+
+function statusBadgeClass(status) {
+  if (status === 'approved' || status === 'applied') return 'active';
+  if (status === 'rejected') return 'sold';
+  if (status === 'superseded') return 'draft';
+  return 'pending';
 }
 
 // ── Login ─────────────────────────────────────────────────
@@ -747,7 +749,7 @@ router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => 
           ${claim.source_quote ? esc(claim.source_quote) : '<span class="muted">No quote</span>'}
           ${sourceLocation ? `<div class="muted">${esc(sourceLocation)}</div>` : ''}
         </td>
-        <td><span class="badge pending">${esc(claim.status)}</span></td>
+        <td><span class="badge ${esc(statusBadgeClass(claim.status))}" data-status="${esc(claim.status)}">${esc(claim.status)}</span></td>
       </tr>`;
   }).join('');
 

--- a/api/routes/documents.js
+++ b/api/routes/documents.js
@@ -695,3 +695,5 @@ function createDocumentsRouter({ db }) {
 }
 
 module.exports = createDocumentsRouter;
+module.exports.DOCUMENT_TYPES = DOCUMENT_TYPES;
+module.exports.CLAIM_STATUSES = CLAIM_STATUSES;

--- a/api/views/admin.js
+++ b/api/views/admin.js
@@ -65,15 +65,24 @@ function adminShell(title, body, csrf) {
     .detail-table{width:100%;font-size:.875rem;border-collapse:collapse}
     .detail-table td{padding:.5rem;border-bottom:1px solid #f0f0f0}
     .detail-table td:first-child{font-weight:600;color:#555;width:40%}
+    .filter-panel{background:#fff;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,.06);padding:1rem;margin-bottom:1.25rem}
+    .filter-panel form{display:grid;grid-template-columns:repeat(4,minmax(160px,1fr)) auto;gap:.85rem;align-items:end}
+    .queue-meta{color:#555;font-size:.85rem;margin-bottom:1rem}
+    .muted{color:#666;font-size:.82rem}
+    .code-chip{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:#f6f4ee;border:1px solid #e5dfd0;border-radius:4px;padding:.15rem .35rem}
+    .claim-value{max-width:260px;white-space:normal;word-break:break-word}
+    .quote-cell{max-width:320px;white-space:normal;color:#444}
+    .empty-state{background:#fff;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,.06);padding:2rem;text-align:center;color:#555}
     @media(max-width:768px){
       .sidebar{display:none}.main{margin-left:0}
-      .form-grid,.report-grid{grid-template-columns:1fr}
+      .form-grid,.report-grid,.filter-panel form{grid-template-columns:1fr}
     }
   </style></head><body>
   <div class="sidebar">
     <span class="logo">🏡 WVREA Admin</span>
     <a href="/admin">📋 Listings</a>
     <a href="/admin/new">➕ New Listing</a>
+    <a href="/admin/document-claims">🧾 Document Claims</a>
     <a href="/admin/integrations">🔗 Integrations</a>
     <a href="/" target="_blank">🌐 Public Site</a>
     <a href="/admin/logout" class="logout" style="color:#ffaaaa">🚪 Logout</a>

--- a/docs/DOCUMENT_REGISTRY_SPEC.md
+++ b/docs/DOCUMENT_REGISTRY_SPEC.md
@@ -302,6 +302,6 @@ A future implementation PR should satisfy all of these:
 |-------|-------|
 | Phase 1 spec | This document: schema, state machine, AI JSON contract, API skeleton. |
 | Phase 1 implementation | SQLite tables, helpers, API skeleton, tests. |
-| Phase 2 AI Review Queue | Review-queue API for extracted claims, then admin UI for reviewing claims and applying approved facts. The queue API is implemented at `/api/documents/review/claims`; admin UI/apply workflow remains next. |
+| Phase 2 AI Review Queue | Review-queue API for extracted claims, read-only admin UI for reviewing claims, then audited application of approved facts. The queue API is implemented at `/api/documents/review/claims`; the read-only admin page is implemented at `/admin/document-claims`; audited apply workflow remains next. |
 | Phase 3 Drive event automation | Drive watch/import pipeline into `documents` and `document_versions`. |
 | Phase 4 Gmail intake | Email attachment/message ingestion into the registry. |

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -60,6 +60,11 @@ node "$ROOT/tests/document-registry.test.js"
 echo "✓ Document registry smoke OK"
 echo
 
+echo "== Admin document review smoke =="
+node "$ROOT/tests/admin-document-review.test.js"
+echo "✓ Admin document review smoke OK"
+echo
+
 echo "== Startup smoke =="
 PORT="$PORT_TO_USE" DATABASE_PATH="$TMP_DIR/preflight.db" NODE_ENV=test PUBLIC_LISTINGS_ENABLED=true API_KEY=preflight-api-key SESSION_SECRET=preflight-session-secret ADMIN_PASSWORD=preflight-admin-password node server.js > "$APP_LOG" 2>&1 &
 PID=$!

--- a/tests/admin-document-review.test.js
+++ b/tests/admin-document-review.test.js
@@ -130,6 +130,38 @@ function seedReviewData() {
   );
 
   testDb.prepare(`
+    INSERT INTO extracted_claims (
+      id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+      source_quote, source_location_json, confidence, status
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0.72, 'pending_review')
+  `).run(
+    'claim_admin_xss',
+    'doc_admin_review',
+    'ver_admin_review',
+    PROPERTY_ID,
+    '<script>alert("type")</script>&',
+    JSON.stringify({ foo: '<script>alert("value")</script>&"&' }),
+    '<script>alert("quote")</script>&',
+    JSON.stringify({ page: '<script>1</script>&' })
+  );
+
+  testDb.prepare(`
+    INSERT INTO extracted_claims (
+      id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+      source_quote, source_location_json, confidence, status, reviewed_by, reviewed_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 'approved', 'test-suite', datetime('now'))
+  `).run(
+    'claim_admin_approved',
+    'doc_admin_review',
+    'ver_admin_review',
+    PROPERTY_ID,
+    'acreage',
+    JSON.stringify('12.5 acres approved'),
+    'Approved acreage source',
+    JSON.stringify({ page: 4 })
+  );
+
+  testDb.prepare(`
     INSERT INTO document_versions (
       id, document_id, version_number, file_name, sha256, storage_uri, approval_status
     ) VALUES (?, ?, 2, ?, ?, ?, 'rejected')
@@ -211,9 +243,33 @@ async function main() {
       assert(html.includes('14-09-012B-0096-0000'));
       assert(html.includes('Parcel 14-09-012B-0096-0000'));
       assert(html.includes('&quot;page&quot;:2') || html.includes('{&quot;page&quot;:2'));
+      assert(html.includes('data-status="pending_review"'));
+      assert(!html.includes('<script>alert("type")</script>&'));
+      assert(!html.includes('<script>alert("value")</script>&"&'));
+      assert(!html.includes('<script>alert("quote")</script>&'));
+      assert(!html.includes('<script>1</script>&'));
+      assert(html.includes('&lt;script&gt;alert(&quot;type&quot;)&lt;/script&gt;&amp;'));
+      assert(html.includes('&lt;script&gt;alert(\\&quot;value\\&quot;)&lt;/script&gt;&amp;\\&quot;&amp;'));
+      assert(html.includes('&lt;script&gt;alert(&quot;quote&quot;)&lt;/script&gt;&amp;'));
+      assert(html.includes('&lt;script&gt;1&lt;/script&gt;&amp;'));
       assert(!html.includes('Rejected source claim'), 'claims from rejected versions must be excluded');
       assert(!html.includes('manual://hidden-tax-card.pdf'), 'source_uri must not render');
       assert(!html.includes('manual://hidden-storage-tax-card.pdf'), 'storage_uri must not render');
+    });
+
+    await test('GET /admin/document-claims with status=approved renders only approved claims', async () => {
+      const res = await fetch(`${baseUrl}/admin/document-claims?status=approved`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(res.status, 200);
+      const html = await res.text();
+      assert(html.includes('Document Claims'));
+      assert(html.includes('12.5 acres approved'));
+      assert(html.includes('Approved acreage source'));
+      assert(html.includes('data-status="approved"'));
+      assert(!html.includes('14-09-012B-0096-0000'));
+      assert(!html.includes('data-status="pending_review"'));
+      assert(!html.includes('<td>0%</td>'), 'null confidence should render blank, not 0%');
     });
 
     await test('GET /admin/document-claims supports effective property and document type filters', async () => {
@@ -235,6 +291,15 @@ async function main() {
       assert.strictEqual(res.status, 400);
       const html = await res.text();
       assert(html.includes('Invalid status filter.'));
+    });
+
+    await test('GET /admin/document-claims rejects invalid document type filters', async () => {
+      const res = await fetch(`${baseUrl}/admin/document-claims?document_type=not_a_real_type`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(res.status, 400);
+      const html = await res.text();
+      assert(html.includes('Invalid document type filter.'));
     });
   } finally {
     if (testDb) testDb.close();

--- a/tests/admin-document-review.test.js
+++ b/tests/admin-document-review.test.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const childProcess = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const API_DIR = path.join(ROOT, 'api');
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'wv-admin-doc-review-'));
+const DB_PATH = path.join(TMP_DIR, 'admin-review.db');
+const ADMIN_PASSWORD = 'admin-document-review-password';
+const PROPERTY_ID = 'admin-review-property';
+const Database = require(path.join(API_DIR, 'node_modules', 'better-sqlite3'));
+
+let server = null;
+let testDb = null;
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function test(name, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passed++;
+      console.log(`✓ ${name}`);
+    })
+    .catch((err) => {
+      failed++;
+      failures.push(`${name}: ${err.message}`);
+      console.log(`✗ ${name}`);
+      console.log(`  Error: ${err.message}`);
+    });
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const probe = http.createServer();
+    probe.on('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForHealth(baseUrl, getLog) {
+  const deadline = Date.now() + 15000;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    if (server.exitCode != null) {
+      throw new Error(`server exited early with code ${server.exitCode}\n${getLog()}`);
+    }
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await delay(250);
+  }
+  throw new Error(`server did not become healthy: ${lastError && lastError.message}\n${getLog()}`);
+}
+
+function cookieFrom(res) {
+  const raw = res.headers.get('set-cookie');
+  assert(raw, 'expected set-cookie header');
+  return raw.split(';')[0];
+}
+
+async function login(baseUrl) {
+  const res = await fetch(`${baseUrl}/admin/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ password: ADMIN_PASSWORD }),
+    redirect: 'manual',
+  });
+  assert.strictEqual(res.status, 302);
+  assert.strictEqual(res.headers.get('location'), '/admin');
+  return cookieFrom(res);
+}
+
+function seedReviewData() {
+  const county = testDb.prepare("SELECT id FROM counties WHERE name='Hampshire'").get();
+  testDb.prepare(`
+    INSERT INTO properties (id, county_id, address, city, property_type, status, listing_slug)
+    VALUES (?, ?, ?, ?, 'land', 'draft', ?)
+  `).run(PROPERTY_ID, county.id, 'Admin Review Road', 'Romney', 'admin-review-road');
+
+  testDb.prepare(`
+    INSERT INTO documents (
+      id, property_id, title, document_type, source_provider, source_uri, status, created_by
+    ) VALUES (?, ?, ?, ?, 'manual', ?, 'draft', 'test-suite')
+  `).run('doc_admin_review', PROPERTY_ID, 'Admin Review Tax Card', 'tax_card', 'manual://hidden-tax-card.pdf');
+
+  testDb.prepare(`
+    INSERT INTO document_versions (
+      id, document_id, version_number, file_name, sha256, storage_uri, approval_status
+    ) VALUES (?, ?, 1, ?, ?, ?, 'pending_review')
+  `).run(
+    'ver_admin_review',
+    'doc_admin_review',
+    'hidden-tax-card.pdf',
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    'manual://hidden-storage-tax-card.pdf'
+  );
+
+  testDb.prepare(`
+    INSERT INTO extracted_claims (
+      id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+      source_quote, source_location_json, confidence, status
+    ) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, 0.93, 'pending_review')
+  `).run(
+    'claim_admin_parcel',
+    'doc_admin_review',
+    'ver_admin_review',
+    'parcel_id',
+    JSON.stringify('14-09-012B-0096-0000'),
+    'Parcel 14-09-012B-0096-0000',
+    JSON.stringify({ page: 2, section: 'Tax parcel' })
+  );
+
+  testDb.prepare(`
+    INSERT INTO document_versions (
+      id, document_id, version_number, file_name, sha256, storage_uri, approval_status
+    ) VALUES (?, ?, 2, ?, ?, ?, 'rejected')
+  `).run(
+    'ver_admin_rejected',
+    'doc_admin_review',
+    'rejected-tax-card.pdf',
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+    'manual://rejected-storage-tax-card.pdf'
+  );
+
+  testDb.prepare(`
+    INSERT INTO extracted_claims (
+      id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+      confidence, status
+    ) VALUES (?, ?, ?, ?, ?, ?, 0.4, 'pending_review')
+  `).run(
+    'claim_admin_rejected_version',
+    'doc_admin_review',
+    'ver_admin_rejected',
+    PROPERTY_ID,
+    'road_access',
+    JSON.stringify('Rejected source claim')
+  );
+}
+
+async function main() {
+  const port = await getFreePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let log = '';
+
+  server = childProcess.spawn(process.execPath, ['server.js'], {
+    cwd: API_DIR,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      DATABASE_PATH: DB_PATH,
+      NODE_ENV: 'test',
+      PUBLIC_LISTINGS_ENABLED: 'false',
+      PUBLIC_ASSISTANT_ENABLED: 'false',
+      API_KEY: 'admin-document-review-api-key',
+      SESSION_SECRET: 'admin-document-review-session-secret',
+      ADMIN_PASSWORD,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const appendLog = (chunk) => {
+    log += chunk.toString();
+    if (log.length > 12000) log = log.slice(-12000);
+  };
+  server.stdout.on('data', appendLog);
+  server.stderr.on('data', appendLog);
+
+  try {
+    await waitForHealth(baseUrl, () => log);
+    testDb = new Database(DB_PATH);
+    seedReviewData();
+
+    await test('GET /admin/document-claims redirects anonymous users to login', async () => {
+      const res = await fetch(`${baseUrl}/admin/document-claims`, { redirect: 'manual' });
+      assert.strictEqual(res.status, 302);
+      assert.strictEqual(res.headers.get('location'), '/admin/login');
+    });
+
+    const cookie = await login(baseUrl);
+
+    await test('GET /admin/document-claims renders pending claim review rows safely', async () => {
+      const res = await fetch(`${baseUrl}/admin/document-claims`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(res.status, 200);
+      const html = await res.text();
+      assert(html.includes('Document Claims'));
+      assert(html.includes('Admin Review Road, Romney'));
+      assert(html.includes('Admin Review Tax Card'));
+      assert(html.includes('claim_admin_parcel') === false, 'internal claim ids should not be the main UI surface');
+      assert(html.includes('parcel_id'));
+      assert(html.includes('14-09-012B-0096-0000'));
+      assert(html.includes('Parcel 14-09-012B-0096-0000'));
+      assert(html.includes('&quot;page&quot;:2') || html.includes('{&quot;page&quot;:2'));
+      assert(!html.includes('Rejected source claim'), 'claims from rejected versions must be excluded');
+      assert(!html.includes('manual://hidden-tax-card.pdf'), 'source_uri must not render');
+      assert(!html.includes('manual://hidden-storage-tax-card.pdf'), 'storage_uri must not render');
+    });
+
+    await test('GET /admin/document-claims supports effective property and document type filters', async () => {
+      const res = await fetch(
+        `${baseUrl}/admin/document-claims?property_id=${encodeURIComponent(PROPERTY_ID)}&document_type=tax_card&claim_type=parcel_id`,
+        { headers: { Cookie: cookie } }
+      );
+      assert.strictEqual(res.status, 200);
+      const html = await res.text();
+      assert(html.includes('Admin Review Road, Romney'));
+      assert(html.includes('14-09-012B-0096-0000'));
+      assert(!html.includes('Rejected source claim'));
+    });
+
+    await test('GET /admin/document-claims rejects invalid filters', async () => {
+      const res = await fetch(`${baseUrl}/admin/document-claims?status=needs_human`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(res.status, 400);
+      const html = await res.text();
+      assert(html.includes('Invalid status filter.'));
+    });
+  } finally {
+    if (testDb) testDb.close();
+    if (server && server.exitCode == null) {
+      server.kill();
+      await new Promise((resolve) => server.once('exit', resolve));
+    }
+    fs.rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+
+  console.log(`\nAdmin document review tests: ${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    for (const failure of failures) console.log(`- ${failure}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  if (server && server.exitCode == null) server.kill();
+  if (testDb) testDb.close();
+  fs.rmSync(TMP_DIR, { recursive: true, force: true });
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds the first admin-facing Document Registry Phase 2 review surface:

- authenticated read-only `/admin/document-claims` page
- status, property, claim type, and document type filters
- effective-property fallback matching the review queue API
- rejected/superseded document-version exclusion
- escaped rendered claim evidence
- deliberate omission of `source_uri` and `storage_uri`
- sidebar navigation entry for Document Claims
- HTTP admin smoke test enforced by preflight

This does not approve, reject, or apply claims to listing facts. The audited apply workflow remains the next Phase 2 slice.

## Validation

- `node --check api/routes/admin.js`
- `node --check api/views/admin.js`
- `node --check tests/admin-document-review.test.js`
- `node tests/admin-document-review.test.js`
- `bash scripts/preflight.sh`
- `node tests/verify-security-fixes.test.js`
- `git diff --check`

## Production

No VPS, DNS, Railway, Vercel, or production environment changes. Merge does not deploy.

## Summary by Sourcery

Add an authenticated, read-only admin review page for document claims with filtering, safe rendering, and test coverage, and wire it into existing workflows and documentation.

New Features:
- Introduce an authenticated read-only /admin/document-claims admin page to review extracted document claims with filters for status, property, claim type, and document type.

Enhancements:
- Add UI elements and styles for document-claim filters and tables, including a new sidebar navigation entry in the admin shell.
- Update project task and state tracking documents to mark the Phase 2 admin review UI as complete and clarify that the audited apply workflow is still pending.
- Extend the document registry spec to document the new read-only admin review page as part of Phase 2.

Tests:
- Add an end-to-end admin document review test that boots the real server against a temporary SQLite database to cover auth redirects, login, claim rendering, filter behavior, and rejected-version exclusion.
- Include the new admin document review test in the preflight script so it runs as part of the standard validation pipeline.