### PR TITLE
Add document claim apply workflow

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -271,6 +271,6 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 
 - **Phase 0**: OpenHands executor validation — still awaiting developer action
 - **Phase 1**: Document Registry skeleton — spec and API/database skeleton merged in #118/#120; deploy pending
-- **Phase 2** (current): AI Review Queue — backend queue API and read-only admin page added; audited apply workflow remains next
-- **Phase 3**: Drive event automation
+- **Phase 2**: AI Review Queue — backend queue API, read-only admin page, and audited apply workflow added; deploy pending
+- **Phase 3** (current): Drive event automation
 - **Phase 4**: Gmail intake (Pub/Sub)

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,7 +25,6 @@
 
 ## Low Priority
 
-- [ ] **Phase 2: AI Review Queue apply workflow** — review-queue API and read-only admin UI are complete; next slice is an audited apply workflow for approved facts
 - [ ] **Phase 3: Drive event automation** — depends on Phase 2 — **Gemini leads**
 - [ ] **Phase 4: Gmail intake** — depends on Phase 3 — **Gemini leads**
 
@@ -35,6 +34,7 @@
 
 - [x] **Phase 2: AI Review Queue API** — added `GET /api/documents/review/claims` for status-filtered extracted-claim review queues with HTTP coverage in `tests/document-registry.test.js` — 2026-06-18
 - [x] **Phase 2: AI Review Queue admin UI** — added an authenticated read-only `/admin/document-claims` page with filters, safe rendered evidence, source/storage URI redaction, and HTTP coverage in `tests/admin-document-review.test.js` — 2026-06-19
+- [x] **Phase 2: AI Review Queue apply workflow** — added CSRF-protected `/admin/document-claims/:claimId/apply` for approved, explicitly mapped claims; updates listing fields in a transaction, marks claims applied, and writes property + claim audit rows with HTTP coverage — 2026-06-19
 - [x] **Add integration/E2E tests** — `tests/http-smoke.test.js` starts the real Express app against a temporary SQLite database and is enforced by `scripts/preflight.sh`; covers health/config/listings-off/contact-origin/chat-fallback behavior over HTTP — 2026-06-18
 - [x] **Remove disabled Twilio path** — deleted the unused dynamic Twilio sender, removed lead-route SMS calls, and updated docs so lead notifications are email/local persistence only until a future SMS provider is intentionally specified — 2026-06-18
 - [x] **CORS origin restriction review** — existing `CORS_ORIGIN` allowlist behavior verified and regression-covered in `tests/http-smoke.test.js`; trusted origins receive CORS headers and can submit guarded leads, untrusted origins do not receive CORS access and are rejected by same-origin lead guards — 2026-06-18

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -1080,3 +1080,23 @@ Add the first admin-facing review surface for extracted document claims without 
 ### Remaining Risks
 - This is review-only. The audited workflow that applies approved claims into listing/property facts is still the next Phase 2 slice.
 - Merge still does not deploy this admin page to the VPS; production remains on the last manually deployed runtime until Phil approves a VPS deploy.
+
+---
+
+## 2026-06-19 — Codex — Document Registry Phase 2 audited apply workflow
+
+### Objective
+Complete Phase 2 by allowing a human admin to apply approved extracted claims to mapped listing fields without letting AI claims mutate public facts directly.
+
+### Changes Made
+- `api/routes/admin.js` — added an explicit claim-type to property-field mapping and CSRF-protected `POST /admin/document-claims/:claimId/apply`; the route requires an approved claim, rejects rejected/superseded source versions, coerces mapped values, updates the property and claim status in one transaction, and writes `property.claim_applied` plus `extracted_claim.applied` audit rows.
+- `api/routes/admin.js` — added an apply button for approved, mapped claims in `/admin/document-claims`; unmapped or not-yet-approved claims stay read-only.
+- `tests/admin-document-review.test.js` — expanded real HTTP admin coverage to 8 tests, including authenticated CSRF apply, property mutation, claim `applied` status, audit rows, and rejection of non-approved claim application.
+- `TASKS.md`, `docs/DOCUMENT_REGISTRY_SPEC.md`, `PROJECT_STATE.md` — recorded Phase 2 as complete and moved the registry roadmap to Phase 3 Drive event automation.
+
+### Verification
+- Required validation before PR: `node --check api/routes/admin.js`; `node --check tests/admin-document-review.test.js`; `node tests/admin-document-review.test.js`; `bash scripts/preflight.sh`; `node tests/verify-security-fixes.test.js`; `git diff --check`.
+
+### Remaining Risks
+- Only explicitly mapped property fields can be applied. Document-summary/public-copy application remains out of scope.
+- Merge still does not deploy this admin workflow to the VPS; production changes require Phil's manual deploy approval.

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -47,10 +47,64 @@ const upload = multer({
 });
 
 const router = express.Router();
+const CLAIM_APPLY_FIELDS = new Map([
+  ['address', { column: 'address', type: 'text', label: 'Address' }],
+  ['parcel_id', { column: 'parcel_id', type: 'text', label: 'Parcel ID' }],
+  ['acreage', { column: 'acreage', type: 'number', label: 'Acreage' }],
+  ['annual_tax', { column: 'annual_tax', type: 'number', label: 'Annual Tax' }],
+  ['tax_assessed', { column: 'tax_assessed', type: 'number', label: 'Tax Assessed Value' }],
+  ['road_access', { column: 'road_access', type: 'text', label: 'Road Access' }],
+  ['flood_zone', { column: 'flood_zone', type: 'text', label: 'Flood Zone' }],
+  ['school_district', { column: 'school_district', type: 'text', label: 'School District' }],
+  ['listing_price', { column: 'price', type: 'number', label: 'List Price' }],
+  ['septic', { column: 'septic', type: 'boolean', label: 'Septic' }],
+]);
+const PROPERTY_UPDATE_COLUMNS = new Set(Array.from(CLAIM_APPLY_FIELDS.values()).map((field) => field.column));
+
+const insertAuditEvent = db.prepare(`
+  INSERT INTO audit_events (id,actor,action,entity_type,entity_id,before_json,after_json,reason)
+  VALUES (?,?,?,?,?,?,?,?)
+`);
 
 function cleanQuery(value, max = 120) {
   if (value == null) return '';
   return String(value).trim().slice(0, max);
+}
+
+function makeAuditId() {
+  return `audit_${crypto.randomBytes(12).toString('hex')}`;
+}
+
+function auditSafe(row) {
+  if (!row) return null;
+  const copy = { ...row };
+  for (const key of [
+    'source_uri',
+    'source_external_id',
+    'storage_uri',
+    'storage_external_id',
+    'ocr_text',
+    'claim_value_json',
+    'source_quote',
+    'source_location_json',
+    'review_note',
+  ]) {
+    if (copy[key] != null) copy[key] = '[redacted]';
+  }
+  return copy;
+}
+
+function writeAudit({ actor, action, entityType, entityId, before, after, reason }) {
+  insertAuditEvent.run(
+    makeAuditId(),
+    actor,
+    action,
+    entityType,
+    entityId,
+    before ? JSON.stringify(auditSafe(before)) : null,
+    after ? JSON.stringify(auditSafe(after)) : null,
+    cleanQuery(reason, 500) || null
+  );
 }
 
 function parseJsonField(raw) {
@@ -67,6 +121,28 @@ function displayJsonValue(raw) {
   if (value == null) return '';
   if (typeof value === 'string') return value;
   return JSON.stringify(value);
+}
+
+function claimValue(raw) {
+  return parseJsonField(raw);
+}
+
+function normalizeClaimValue(value, type) {
+  if (type === 'number') {
+    const raw = typeof value === 'string' ? value.replace(/[$,]/g, '').trim() : value;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return { error: 'Claim value is not a valid number.' };
+    return { value: n };
+  }
+  if (type === 'boolean') {
+    if (typeof value === 'boolean') return { value: value ? 1 : 0 };
+    if (typeof value === 'number' && (value === 0 || value === 1)) return { value };
+    const normalized = String(value ?? '').trim().toLowerCase();
+    if (['true', 'yes', 'y', '1'].includes(normalized)) return { value: 1 };
+    if (['false', 'no', 'n', '0'].includes(normalized)) return { value: 0 };
+    return { error: 'Claim value is not a valid boolean.' };
+  }
+  return { value: String(value ?? '').trim() };
 }
 
 function renderSelectOptions(values, selected) {
@@ -730,6 +806,12 @@ router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => 
       || claim.effective_property_id
       || 'Unlinked';
     const sourceLocation = displayJsonValue(claim.source_location_json);
+    const applyField = CLAIM_APPLY_FIELDS.get(claim.claim_type);
+    const applyCell = claim.status === 'approved' && claim.effective_property_id && applyField
+      ? `<form method="POST" action="/admin/document-claims/${esc(claim.id)}/apply">
+          <button type="submit" class="btn-sm">Apply to ${esc(applyField.label)}</button>
+        </form>`
+      : `<span class="muted">${claim.status === 'approved' ? 'No mapped field' : 'Review first'}</span>`;
 
     return `
       <tr>
@@ -750,6 +832,7 @@ router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => 
           ${sourceLocation ? `<div class="muted">${esc(sourceLocation)}</div>` : ''}
         </td>
         <td><span class="badge ${esc(statusBadgeClass(claim.status))}" data-status="${esc(claim.status)}">${esc(claim.status)}</span></td>
+        <td>${applyCell}</td>
       </tr>`;
   }).join('');
 
@@ -773,12 +856,103 @@ router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => 
             <th>Confidence</th>
             <th>Source Evidence</th>
             <th>Status</th>
+            <th>Action</th>
           </tr>
         </thead>
         <tbody>${rows}</tbody>
       </table>
     ` : '<div class="empty-state">No document claims match these filters.</div>'}
   `, csrfToken(req)));
+});
+
+router.post('/document-claims/:claimId/apply', requireAuth, requireCsrf, adminActionRateLimit, (req, res) => {
+  const claim = db.prepare(`
+    SELECT
+      c.*,
+      d.property_id AS document_property_id,
+      COALESCE(c.property_id, d.property_id) AS effective_property_id,
+      d.title AS document_title,
+      v.approval_status AS version_approval_status
+    FROM extracted_claims c
+    JOIN documents d ON d.id = c.document_id
+    JOIN document_versions v ON v.id = c.document_version_id
+    WHERE c.id=?
+  `).get(req.params.claimId);
+
+  function applyError(message, status = 400) {
+    return res.status(status).send(adminShell('Apply Document Claim', `
+      <div class="dash-header">
+        <h1>Apply Document Claim</h1>
+        <a href="/admin/document-claims?status=approved" class="btn-outline">Back</a>
+      </div>
+      <div class="empty-state">${esc(message)}</div>
+    `, csrfToken(req)));
+  }
+
+  if (!claim) return applyError('Claim not found.', 404);
+  if (claim.status !== 'approved') return applyError('Only approved claims can be applied.');
+  if (['rejected', 'superseded'].includes(claim.version_approval_status)) {
+    return applyError('Claims from rejected or superseded versions cannot be applied.');
+  }
+  if (!claim.effective_property_id) return applyError('Claim is not linked to a property.');
+
+  const applyField = CLAIM_APPLY_FIELDS.get(claim.claim_type);
+  if (!applyField || !PROPERTY_UPDATE_COLUMNS.has(applyField.column)) {
+    return applyError('Claim type is not mapped to a listing field.');
+  }
+
+  const normalized = normalizeClaimValue(claimValue(claim.claim_value_json), applyField.type);
+  if (normalized.error) return applyError(normalized.error);
+  if (applyField.type === 'text' && !normalized.value) return applyError('Claim value is empty.');
+
+  const property = db.prepare('SELECT * FROM properties WHERE id=?').get(claim.effective_property_id);
+  if (!property) return applyError('Linked property not found.', 404);
+
+  const actor = cleanQuery(req.body.actor || req.body.applied_by, 80) || 'admin';
+  const reason = cleanQuery(req.body.review_note || req.body.reason, 500)
+    || `Applied ${claim.claim_type} from ${claim.document_title || 'document claim'}.`;
+
+  const applyClaim = db.transaction(() => {
+    const beforeProperty = db.prepare('SELECT * FROM properties WHERE id=?').get(property.id);
+    const beforeClaim = db.prepare('SELECT * FROM extracted_claims WHERE id=?').get(claim.id);
+
+    db.prepare(`
+      UPDATE properties
+      SET ${applyField.column}=?, updated_at=datetime('now')
+      WHERE id=?
+    `).run(normalized.value, property.id);
+
+    db.prepare(`
+      UPDATE extracted_claims
+      SET status='applied', reviewed_by=?, reviewed_at=datetime('now'), review_note=?
+      WHERE id=? AND status='approved'
+    `).run(actor, reason, claim.id);
+
+    const afterProperty = db.prepare('SELECT * FROM properties WHERE id=?').get(property.id);
+    const afterClaim = db.prepare('SELECT * FROM extracted_claims WHERE id=?').get(claim.id);
+
+    writeAudit({
+      actor,
+      action: 'property.claim_applied',
+      entityType: 'property',
+      entityId: property.id,
+      before: beforeProperty,
+      after: afterProperty,
+      reason,
+    });
+    writeAudit({
+      actor,
+      action: 'extracted_claim.applied',
+      entityType: 'extracted_claim',
+      entityId: claim.id,
+      before: beforeClaim,
+      after: afterClaim,
+      reason,
+    });
+  });
+
+  applyClaim();
+  res.redirect(`/admin/document-claims?status=applied&property_id=${encodeURIComponent(property.id)}`);
 });
 
 // ── Integrations ──────────────────────────────────────────

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -65,6 +65,31 @@ const insertAuditEvent = db.prepare(`
   INSERT INTO audit_events (id,actor,action,entity_type,entity_id,before_json,after_json,reason)
   VALUES (?,?,?,?,?,?,?,?)
 `);
+const selectClaimForApply = db.prepare(`
+  SELECT
+    c.*,
+    d.property_id AS document_property_id,
+    COALESCE(c.property_id, d.property_id) AS effective_property_id,
+    d.title AS document_title,
+    v.approval_status AS version_approval_status
+  FROM extracted_claims c
+  JOIN documents d ON d.id = c.document_id
+  JOIN document_versions v ON v.id = c.document_version_id
+  WHERE c.id=?
+`);
+const selectPropertyById = db.prepare('SELECT * FROM properties WHERE id=?');
+const selectExtractedClaimById = db.prepare('SELECT * FROM extracted_claims WHERE id=?');
+const updateClaimApplied = db.prepare(`
+  UPDATE extracted_claims
+  SET status='applied', reviewed_by=?, reviewed_at=datetime('now'), review_note=?
+  WHERE id=? AND status='approved'
+`);
+const updatePropertyStatements = new Map(
+  Array.from(PROPERTY_UPDATE_COLUMNS).map((column) => [
+    column,
+    db.prepare(`UPDATE properties SET ${column}=?, updated_at=datetime('now') WHERE id=?`),
+  ])
+);
 
 function cleanQuery(value, max = 120) {
   if (value == null) return '';
@@ -129,7 +154,11 @@ function claimValue(raw) {
 
 function normalizeClaimValue(value, type) {
   if (type === 'number') {
+    if (value == null || Array.isArray(value) || typeof value === 'boolean' || typeof value === 'object') {
+      return { error: 'Claim value is not a valid number.' };
+    }
     const raw = typeof value === 'string' ? value.replace(/[$,]/g, '').trim() : value;
+    if (raw === '') return { error: 'Claim value is not a valid number.' };
     const n = Number(raw);
     if (!Number.isFinite(n)) return { error: 'Claim value is not a valid number.' };
     return { value: n };
@@ -141,6 +170,9 @@ function normalizeClaimValue(value, type) {
     if (['true', 'yes', 'y', '1'].includes(normalized)) return { value: 1 };
     if (['false', 'no', 'n', '0'].includes(normalized)) return { value: 0 };
     return { error: 'Claim value is not a valid boolean.' };
+  }
+  if (Array.isArray(value) || (value != null && typeof value === 'object')) {
+    return { error: 'Claim value is not valid text.' };
   }
   return { value: String(value ?? '').trim() };
 }
@@ -737,6 +769,7 @@ router.post('/ai/:id', requireAuth, requireCsrf, adminActionRateLimit, async (re
 
 // ── Document Claim Review Queue ───────────────────────────
 router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => {
+  const token = csrfToken(req);
   const filters = {
     status: cleanQuery(req.query.status) || 'pending_review',
     property_id: cleanQuery(req.query.property_id, 80),
@@ -809,6 +842,7 @@ router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => 
     const applyField = CLAIM_APPLY_FIELDS.get(claim.claim_type);
     const applyCell = claim.status === 'approved' && claim.effective_property_id && applyField
       ? `<form method="POST" action="/admin/document-claims/${esc(claim.id)}/apply">
+          <input type="hidden" name="_csrf" value="${esc(token)}" />
           <button type="submit" class="btn-sm">Apply to ${esc(applyField.label)}</button>
         </form>`
       : `<span class="muted">${claim.status === 'approved' ? 'No mapped field' : 'Review first'}</span>`;
@@ -862,22 +896,11 @@ router.get('/document-claims', requireAuth, adminActionRateLimit, (req, res) => 
         <tbody>${rows}</tbody>
       </table>
     ` : '<div class="empty-state">No document claims match these filters.</div>'}
-  `, csrfToken(req)));
+  `, token));
 });
 
 router.post('/document-claims/:claimId/apply', requireAuth, requireCsrf, adminActionRateLimit, (req, res) => {
-  const claim = db.prepare(`
-    SELECT
-      c.*,
-      d.property_id AS document_property_id,
-      COALESCE(c.property_id, d.property_id) AS effective_property_id,
-      d.title AS document_title,
-      v.approval_status AS version_approval_status
-    FROM extracted_claims c
-    JOIN documents d ON d.id = c.document_id
-    JOIN document_versions v ON v.id = c.document_version_id
-    WHERE c.id=?
-  `).get(req.params.claimId);
+  const claim = selectClaimForApply.get(req.params.claimId);
 
   function applyError(message, status = 400) {
     return res.status(status).send(adminShell('Apply Document Claim', `
@@ -905,7 +928,7 @@ router.post('/document-claims/:claimId/apply', requireAuth, requireCsrf, adminAc
   if (normalized.error) return applyError(normalized.error);
   if (applyField.type === 'text' && !normalized.value) return applyError('Claim value is empty.');
 
-  const property = db.prepare('SELECT * FROM properties WHERE id=?').get(claim.effective_property_id);
+  const property = selectPropertyById.get(claim.effective_property_id);
   if (!property) return applyError('Linked property not found.', 404);
 
   const actor = cleanQuery(req.body.actor || req.body.applied_by, 80) || 'admin';
@@ -913,23 +936,23 @@ router.post('/document-claims/:claimId/apply', requireAuth, requireCsrf, adminAc
     || `Applied ${claim.claim_type} from ${claim.document_title || 'document claim'}.`;
 
   const applyClaim = db.transaction(() => {
-    const beforeProperty = db.prepare('SELECT * FROM properties WHERE id=?').get(property.id);
-    const beforeClaim = db.prepare('SELECT * FROM extracted_claims WHERE id=?').get(claim.id);
+    const currentClaim = selectClaimForApply.get(claim.id);
+    if (!currentClaim || currentClaim.status !== 'approved') {
+      throw new Error('Only approved claims can be applied.');
+    }
+    if (['rejected', 'superseded'].includes(currentClaim.version_approval_status)) {
+      throw new Error('Claims from rejected or superseded versions cannot be applied.');
+    }
 
-    db.prepare(`
-      UPDATE properties
-      SET ${applyField.column}=?, updated_at=datetime('now')
-      WHERE id=?
-    `).run(normalized.value, property.id);
+    const beforeProperty = selectPropertyById.get(property.id);
+    const beforeClaim = selectExtractedClaimById.get(claim.id);
+    const claimUpdate = updateClaimApplied.run(actor, reason, claim.id);
+    if (claimUpdate.changes !== 1) throw new Error('Only approved claims can be applied.');
 
-    db.prepare(`
-      UPDATE extracted_claims
-      SET status='applied', reviewed_by=?, reviewed_at=datetime('now'), review_note=?
-      WHERE id=? AND status='approved'
-    `).run(actor, reason, claim.id);
+    updatePropertyStatements.get(applyField.column).run(normalized.value, property.id);
 
-    const afterProperty = db.prepare('SELECT * FROM properties WHERE id=?').get(property.id);
-    const afterClaim = db.prepare('SELECT * FROM extracted_claims WHERE id=?').get(claim.id);
+    const afterProperty = selectPropertyById.get(property.id);
+    const afterClaim = selectExtractedClaimById.get(claim.id);
 
     writeAudit({
       actor,
@@ -951,8 +974,12 @@ router.post('/document-claims/:claimId/apply', requireAuth, requireCsrf, adminAc
     });
   });
 
-  applyClaim();
-  res.redirect(`/admin/document-claims?status=applied&property_id=${encodeURIComponent(property.id)}`);
+  try {
+    applyClaim();
+  } catch (err) {
+    return applyError(err.message || 'Could not apply claim.');
+  }
+  return res.redirect(`/admin/document-claims?status=applied&property_id=${encodeURIComponent(property.id)}`);
 });
 
 // ── Integrations ──────────────────────────────────────────

--- a/docs/DOCUMENT_REGISTRY_SPEC.md
+++ b/docs/DOCUMENT_REGISTRY_SPEC.md
@@ -302,6 +302,6 @@ A future implementation PR should satisfy all of these:
 |-------|-------|
 | Phase 1 spec | This document: schema, state machine, AI JSON contract, API skeleton. |
 | Phase 1 implementation | SQLite tables, helpers, API skeleton, tests. |
-| Phase 2 AI Review Queue | Review-queue API for extracted claims, read-only admin UI for reviewing claims, then audited application of approved facts. The queue API is implemented at `/api/documents/review/claims`; the read-only admin page is implemented at `/admin/document-claims`; audited apply workflow remains next. |
+| Phase 2 AI Review Queue | Review-queue API for extracted claims, read-only admin UI for reviewing claims, and audited application of approved facts. The queue API is implemented at `/api/documents/review/claims`; the admin review page is implemented at `/admin/document-claims`; approved, mapped claims can be applied through `/admin/document-claims/:claimId/apply`. |
 | Phase 3 Drive event automation | Drive watch/import pipeline into `documents` and `document_versions`. |
 | Phase 4 Gmail intake | Email attachment/message ingestion into the registry. |

--- a/tests/admin-document-review.test.js
+++ b/tests/admin-document-review.test.js
@@ -77,6 +77,33 @@ function cookieFrom(res) {
   return raw.split(';')[0];
 }
 
+function mergeCookies(current, res) {
+  const raw = res.headers.get('set-cookie');
+  if (!raw) return current;
+  const cookies = new Map(
+    current
+      .split(';')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const index = part.indexOf('=');
+        return [part.slice(0, index), part.slice(index + 1)];
+      })
+  );
+  for (const header of raw.split(/,(?=[^;,]+=)/)) {
+    const pair = header.split(';')[0].trim();
+    const index = pair.indexOf('=');
+    if (index > 0) cookies.set(pair.slice(0, index), pair.slice(index + 1));
+  }
+  return Array.from(cookies.entries()).map(([key, value]) => `${key}=${value}`).join('; ');
+}
+
+function csrfFrom(html) {
+  const match = html.match(/<meta name="csrf-token" content="([^"]*)">/);
+  assert(match, 'expected csrf token meta tag');
+  return match[1];
+}
+
 async function login(baseUrl) {
   const res = await fetch(`${baseUrl}/admin/login`, {
     method: 'POST',
@@ -156,7 +183,7 @@ function seedReviewData() {
     'ver_admin_review',
     PROPERTY_ID,
     'acreage',
-    JSON.stringify('12.5 acres approved'),
+    JSON.stringify(12.5),
     'Approved acreage source',
     JSON.stringify({ page: 4 })
   );
@@ -264,12 +291,81 @@ async function main() {
       assert.strictEqual(res.status, 200);
       const html = await res.text();
       assert(html.includes('Document Claims'));
-      assert(html.includes('12.5 acres approved'));
+      assert(html.includes('12.5'));
       assert(html.includes('Approved acreage source'));
       assert(html.includes('data-status="approved"'));
+      assert(html.includes('Apply to Acreage'));
       assert(!html.includes('14-09-012B-0096-0000'));
       assert(!html.includes('data-status="pending_review"'));
       assert(!html.includes('<td>0%</td>'), 'null confidence should render blank, not 0%');
+    });
+
+    await test('POST /admin/document-claims/:id/apply applies approved mapped claims with audit rows', async () => {
+      const pageRes = await fetch(`${baseUrl}/admin/document-claims?status=approved`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(pageRes.status, 200);
+      const pageHtml = await pageRes.text();
+      const csrf = csrfFrom(pageHtml);
+      const postCookie = mergeCookies(cookie, pageRes);
+
+      const applyRes = await fetch(`${baseUrl}/admin/document-claims/claim_admin_approved/apply`, {
+        method: 'POST',
+        headers: {
+          Cookie: postCookie,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          _csrf: csrf,
+          actor: 'test-admin',
+          review_note: 'Apply acreage from reviewed tax card.',
+        }),
+        redirect: 'manual',
+      });
+      assert.strictEqual(applyRes.status, 302);
+      assert.strictEqual(
+        applyRes.headers.get('location'),
+        `/admin/document-claims?status=applied&property_id=${encodeURIComponent(PROPERTY_ID)}`
+      );
+
+      const property = testDb.prepare('SELECT acreage FROM properties WHERE id=?').get(PROPERTY_ID);
+      assert.strictEqual(property.acreage, 12.5);
+      const claim = testDb.prepare('SELECT status, reviewed_by, review_note FROM extracted_claims WHERE id=?').get('claim_admin_approved');
+      assert.strictEqual(claim.status, 'applied');
+      assert.strictEqual(claim.reviewed_by, 'test-admin');
+      assert.strictEqual(claim.review_note, 'Apply acreage from reviewed tax card.');
+
+      const audits = testDb.prepare(`
+        SELECT action, entity_type, entity_id, before_json, after_json, reason
+        FROM audit_events
+        WHERE entity_id IN (?, ?)
+        ORDER BY created_at ASC, id ASC
+      `).all(PROPERTY_ID, 'claim_admin_approved');
+      assert(audits.some((event) => event.action === 'property.claim_applied' && event.entity_id === PROPERTY_ID));
+      assert(audits.some((event) => event.action === 'extracted_claim.applied' && event.entity_id === 'claim_admin_approved'));
+      assert(audits.every((event) => event.reason === 'Apply acreage from reviewed tax card.'));
+    });
+
+    await test('POST /admin/document-claims/:id/apply rejects non-approved claims', async () => {
+      const pageRes = await fetch(`${baseUrl}/admin/document-claims`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(pageRes.status, 200);
+      const csrf = csrfFrom(await pageRes.text());
+      const postCookie = mergeCookies(cookie, pageRes);
+      const res = await fetch(`${baseUrl}/admin/document-claims/claim_admin_parcel/apply`, {
+        method: 'POST',
+        headers: {
+          Cookie: postCookie,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({ _csrf: csrf }),
+      });
+      assert.strictEqual(res.status, 400);
+      const html = await res.text();
+      assert(html.includes('Only approved claims can be applied.'));
+      const claim = testDb.prepare('SELECT status FROM extracted_claims WHERE id=?').get('claim_admin_parcel');
+      assert.strictEqual(claim.status, 'pending_review');
     });
 
     await test('GET /admin/document-claims supports effective property and document type filters', async () => {

--- a/tests/admin-document-review.test.js
+++ b/tests/admin-document-review.test.js
@@ -201,6 +201,18 @@ function seedReviewData() {
   );
 
   testDb.prepare(`
+    INSERT INTO document_versions (
+      id, document_id, version_number, file_name, sha256, storage_uri, approval_status
+    ) VALUES (?, ?, 3, ?, ?, ?, 'superseded')
+  `).run(
+    'ver_admin_superseded',
+    'doc_admin_review',
+    'superseded-tax-card.pdf',
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+    'manual://superseded-storage-tax-card.pdf'
+  );
+
+  testDb.prepare(`
     INSERT INTO extracted_claims (
       id, document_id, document_version_id, property_id, claim_type, claim_value_json,
       confidence, status
@@ -212,6 +224,34 @@ function seedReviewData() {
     PROPERTY_ID,
     'road_access',
     JSON.stringify('Rejected source claim')
+  );
+
+  testDb.prepare(`
+    INSERT INTO extracted_claims (
+      id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+      confidence, status
+    ) VALUES (?, ?, ?, ?, ?, ?, 0.8, 'approved')
+  `).run(
+    'claim_admin_rejected_source',
+    'doc_admin_review',
+    'ver_admin_rejected',
+    PROPERTY_ID,
+    'road_access',
+    JSON.stringify('Rejected source approved claim')
+  );
+
+  testDb.prepare(`
+    INSERT INTO extracted_claims (
+      id, document_id, document_version_id, property_id, claim_type, claim_value_json,
+      confidence, status
+    ) VALUES (?, ?, ?, ?, ?, ?, 0.8, 'approved')
+  `).run(
+    'claim_admin_superseded_source',
+    'doc_admin_review',
+    'ver_admin_superseded',
+    PROPERTY_ID,
+    'road_access',
+    JSON.stringify('Superseded source approved claim')
   );
 }
 
@@ -295,6 +335,7 @@ async function main() {
       assert(html.includes('Approved acreage source'));
       assert(html.includes('data-status="approved"'));
       assert(html.includes('Apply to Acreage'));
+      assert(html.includes('name="_csrf"'));
       assert(!html.includes('14-09-012B-0096-0000'));
       assert(!html.includes('data-status="pending_review"'));
       assert(!html.includes('<td>0%</td>'), 'null confidence should render blank, not 0%');
@@ -342,7 +383,12 @@ async function main() {
         ORDER BY created_at ASC, id ASC
       `).all(PROPERTY_ID, 'claim_admin_approved');
       assert(audits.some((event) => event.action === 'property.claim_applied' && event.entity_id === PROPERTY_ID));
-      assert(audits.some((event) => event.action === 'extracted_claim.applied' && event.entity_id === 'claim_admin_approved'));
+      const claimAudit = audits.find((event) => event.action === 'extracted_claim.applied' && event.entity_id === 'claim_admin_approved');
+      assert(claimAudit);
+      assert(claimAudit.before_json.includes('[redacted]'));
+      assert(claimAudit.after_json.includes('[redacted]'));
+      assert(!claimAudit.before_json.includes('Approved acreage source'));
+      assert(!claimAudit.after_json.includes('Approved acreage source'));
       assert(audits.every((event) => event.reason === 'Apply acreage from reviewed tax card.'));
     });
 
@@ -366,6 +412,39 @@ async function main() {
       assert(html.includes('Only approved claims can be applied.'));
       const claim = testDb.prepare('SELECT status FROM extracted_claims WHERE id=?').get('claim_admin_parcel');
       assert.strictEqual(claim.status, 'pending_review');
+    });
+
+    await test('POST /admin/document-claims/:id/apply rejects rejected and superseded source versions', async () => {
+      const pageRes = await fetch(`${baseUrl}/admin/document-claims?status=approved`, {
+        headers: { Cookie: cookie },
+      });
+      assert.strictEqual(pageRes.status, 200);
+      const csrf = csrfFrom(await pageRes.text());
+      const postCookie = mergeCookies(cookie, pageRes);
+
+      for (const claimId of ['claim_admin_rejected_source', 'claim_admin_superseded_source']) {
+        const res = await fetch(`${baseUrl}/admin/document-claims/${claimId}/apply`, {
+          method: 'POST',
+          headers: {
+            Cookie: postCookie,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({ _csrf: csrf }),
+        });
+        assert.strictEqual(res.status, 400);
+        const html = await res.text();
+        assert(html.includes('Claims from rejected or superseded versions cannot be applied.'));
+        const claim = testDb.prepare('SELECT status FROM extracted_claims WHERE id=?').get(claimId);
+        assert.strictEqual(claim.status, 'approved');
+      }
+
+      const property = testDb.prepare('SELECT road_access FROM properties WHERE id=?').get(PROPERTY_ID);
+      assert.strictEqual(property.road_access, null);
+      const auditCount = testDb.prepare(`
+        SELECT COUNT(*) AS c FROM audit_events
+        WHERE entity_id IN ('claim_admin_rejected_source', 'claim_admin_superseded_source')
+      `).get().c;
+      assert.strictEqual(auditCount, 0);
     });
 
     await test('GET /admin/document-claims supports effective property and document type filters', async () => {


### PR DESCRIPTION
## Summary

Completes the Document Registry Phase 2 apply slice:

- adds CSRF-protected `POST /admin/document-claims/:claimId/apply`
- allows only approved extracted claims to be applied
- supports only explicitly mapped claim types and property fields
- rejects claims from rejected or superseded source versions
- coerces mapped text, number, and boolean values
- updates the property and claim status in one transaction
- writes `property.claim_applied` and `extracted_claim.applied` audit rows
- adds an apply button for approved, mapped claims in `/admin/document-claims`
- expands the admin document-review HTTP smoke test to cover the apply workflow
- marks Phase 2 complete and moves the registry roadmap to Phase 3 Drive event automation

This does not apply unmapped claim types, document summaries, public copy, or Drive/Gmail automation.

## Validation

- `node --check api/routes/admin.js`
- `node --check tests/admin-document-review.test.js`
- `node tests/admin-document-review.test.js`
- `bash scripts/preflight.sh`
- `node tests/verify-security-fixes.test.js`
- `git diff --check`

## Production

No VPS, DNS, Railway, Vercel, or production environment changes. Merge does not deploy.

## Summary by Sourcery

Add an audited admin workflow to apply approved document claims to mapped property fields and mark Document Registry Phase 2 as complete.

New Features:
- Introduce CSRF-protected POST /admin/document-claims/:claimId/apply to apply approved, mapped claims to linked properties with type-aware value coercion.
- Add an apply action button in the admin document-claims UI for approved claims that map to supported property fields.

Enhancements:
- Record property and extracted claim apply operations as redacted audit events for traceability.
- Normalize and validate numeric and boolean claim values before writing them to property records.

Documentation:
- Update project roadmap and document registry spec to reflect completion of Phase 2 and the new claim-apply endpoint.

Tests:
- Extend admin document review HTTP tests to cover the apply workflow, including CSRF handling, property mutation, audit records, and rejection of non-approved claims.

Chores:
- Update tasks and project state tracking files to move focus from Phase 2 apply workflow to Phase 3 Drive event automation.