### PR TITLE
Add document integration event capture

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -272,5 +272,5 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 - **Phase 0**: OpenHands executor validation — still awaiting developer action
 - **Phase 1**: Document Registry skeleton — spec and API/database skeleton merged in #118/#120; deploy pending
 - **Phase 2**: AI Review Queue — backend queue API, read-only admin page, and audited apply workflow added; deploy pending
-- **Phase 3** (current): Drive event automation
+- **Phase 3** (current): Drive event automation; sanitized integration event capture API is queued on `origin/main` after merge, while real Google Drive watch setup/import credentials remain pending
 - **Phase 4**: Gmail intake (Pub/Sub)

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,7 +25,7 @@
 
 ## Low Priority
 
-- [ ] **Phase 3: Drive event automation** — depends on Phase 2 — **Gemini leads**
+- [ ] **Phase 3: Drive event automation** — integration-event recording API is in place; remaining work is Google Drive watch setup/import worker and runtime credentials — **Gemini leads**
 - [ ] **Phase 4: Gmail intake** — depends on Phase 3 — **Gemini leads**
 
 ---
@@ -35,6 +35,7 @@
 - [x] **Phase 2: AI Review Queue API** — added `GET /api/documents/review/claims` for status-filtered extracted-claim review queues with HTTP coverage in `tests/document-registry.test.js` — 2026-06-18
 - [x] **Phase 2: AI Review Queue admin UI** — added an authenticated read-only `/admin/document-claims` page with filters, safe rendered evidence, source/storage URI redaction, and HTTP coverage in `tests/admin-document-review.test.js` — 2026-06-19
 - [x] **Phase 2: AI Review Queue apply workflow** — added CSRF-protected `/admin/document-claims/:claimId/apply` for approved, explicitly mapped claims; updates listing fields in a transaction, marks claims applied, and writes property + claim audit rows with HTTP coverage — 2026-06-19
+- [x] **Phase 3: Integration event capture API** — added API-key protected `GET/POST /api/documents/integration-events` for sanitized Drive/Gmail/OCR/AI/system event recording with HTTP coverage; does not create external watches or require Google credentials — 2026-06-19
 - [x] **Add integration/E2E tests** — `tests/http-smoke.test.js` starts the real Express app against a temporary SQLite database and is enforced by `scripts/preflight.sh`; covers health/config/listings-off/contact-origin/chat-fallback behavior over HTTP — 2026-06-18
 - [x] **Remove disabled Twilio path** — deleted the unused dynamic Twilio sender, removed lead-route SMS calls, and updated docs so lead notifications are email/local persistence only until a future SMS provider is intentionally specified — 2026-06-18
 - [x] **CORS origin restriction review** — existing `CORS_ORIGIN` allowlist behavior verified and regression-covered in `tests/http-smoke.test.js`; trusted origins receive CORS headers and can submit guarded leads, untrusted origins do not receive CORS access and are rejected by same-origin lead guards — 2026-06-18

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -1100,3 +1100,21 @@ Complete Phase 2 by allowing a human admin to apply approved extracted claims to
 ### Remaining Risks
 - Only explicitly mapped property fields can be applied. Document-summary/public-copy application remains out of scope.
 - Merge still does not deploy this admin workflow to the VPS; production changes require Phil's manual deploy approval.
+
+---
+
+## 2026-06-19 — Codex — Document Registry Phase 3 integration event capture
+
+### Objective
+Start Phase 3 with a safe event-ingest foundation that can record Drive/Gmail/OCR/AI automation events without creating external watches, fetching remote files, or requiring new runtime credentials.
+
+### Changes Made
+- `api/routes/documents.js` — added API-key protected `GET /api/documents/integration-events` and `POST /api/documents/integration-events`; events validate provider/status values, preserve document/version links, redact secret-like payload fields, and write an `integration_event.recorded` audit row.
+- `tests/document-registry.test.js` — added HTTP coverage for invalid provider rejection, sanitized Google Drive event recording, filtered event listing, foreign-key validation, and audit redaction.
+- `docs/DOCUMENT_REGISTRY_SPEC.md`, `TASKS.md`, `PROJECT_STATE.md` — recorded the event-capture API as the safe Phase 3 foundation while leaving real Drive watch setup/import worker work open.
+
+### Verification
+- Required validation before PR: `node --check api/routes/documents.js`; `node tests/document-registry.test.js`; `bash scripts/preflight.sh`; `node tests/verify-security-fixes.test.js`; `git diff --check`.
+
+### Remaining Risks
+- This records sanitized events only. It does not configure Google Drive watches, create webhook channels, import files, or deploy anything to the VPS.

--- a/api/routes/documents.js
+++ b/api/routes/documents.js
@@ -11,6 +11,8 @@ const DOCUMENT_TYPES = new Set([
 ]);
 
 const SOURCE_PROVIDERS = new Set(['manual', 'google_drive', 'gmail', 'api', 'system']);
+const INTEGRATION_EVENT_PROVIDERS = new Set(['google_drive', 'gmail', 'ocr', 'ai_extraction', 'api', 'system']);
+const INTEGRATION_EVENT_STATUSES = new Set(['recorded', 'processed', 'failed', 'ignored']);
 const DOCUMENT_STATUSES = new Set(['draft', 'active', 'superseded', 'archived', 'rejected']);
 const VERSION_APPROVAL_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded']);
 const CLAIM_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded', 'applied']);
@@ -37,6 +39,7 @@ function createDocumentsRouter({ db }) {
     INSERT INTO audit_events (id,actor,action,entity_type,entity_id,before_json,after_json,reason)
     VALUES (?,?,?,?,?,?,?,?)
   `);
+  const selectIntegrationEvent = db.prepare('SELECT * FROM integration_events WHERE id=?');
   const selectDocument = db.prepare('SELECT * FROM documents WHERE id=?');
   const selectVersion = db.prepare('SELECT * FROM document_versions WHERE id=?');
   const selectClaim = db.prepare('SELECT * FROM extracted_claims WHERE id=?');
@@ -92,6 +95,10 @@ function createDocumentsRouter({ db }) {
 
   function getDocument(id) {
     return selectDocument.get(id);
+  }
+
+  function getIntegrationEvent(id) {
+    return selectIntegrationEvent.get(id);
   }
 
   function getVersion(id) {
@@ -218,6 +225,54 @@ function createDocumentsRouter({ db }) {
         source_quote: quote,
         source_location_json: sourceLocationJson,
         confidence,
+      },
+    };
+  }
+
+  function redactIntegrationPayload(value) {
+    if (Array.isArray(value)) return value.map(redactIntegrationPayload);
+    if (!value || typeof value !== 'object') return value;
+    const redacted = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (/token|secret|authorization|credential|password|cookie|source_uri|storage_uri/i.test(key)) {
+        redacted[key] = '[redacted]';
+      } else {
+        redacted[key] = redactIntegrationPayload(child);
+      }
+    }
+    return redacted;
+  }
+
+  function validateIntegrationEventInput(body) {
+    const provider = cleanString(body.provider, 40);
+    const eventType = cleanString(body.event_type, 120);
+    const status = cleanString(body.status, 40) || 'recorded';
+
+    const providerErr = ensureKnown(provider, INTEGRATION_EVENT_PROVIDERS, 'provider');
+    if (providerErr) return { error: providerErr };
+    if (!eventType) return { error: 'event_type is required' };
+    const statusErr = ensureKnown(status, INTEGRATION_EVENT_STATUSES, 'status');
+    if (statusErr) return { error: statusErr };
+
+    let payloadJson = null;
+    if (body.payload != null) {
+      try {
+        payloadJson = JSON.stringify(redactIntegrationPayload(body.payload));
+      } catch (_) {
+        return { error: 'payload must be JSON serializable' };
+      }
+    }
+
+    return {
+      values: {
+        provider,
+        event_type: eventType,
+        document_id: cleanString(body.document_id, 120),
+        document_version_id: cleanString(body.document_version_id, 120),
+        external_id: cleanString(body.external_id, 300),
+        status,
+        payload_json: payloadJson,
+        error_message: cleanString(body.error_message, 500),
       },
     };
   }
@@ -382,6 +437,90 @@ function createDocumentsRouter({ db }) {
       }
       console.error(err);
       res.status(500).json({ error: 'Failed to create document' });
+    }
+  });
+
+  router.get('/integration-events', (req, res) => {
+    const conditions = [];
+    const values = [];
+    const filters = {};
+    for (const [key, column] of [
+      ['provider', 'provider'],
+      ['event_type', 'event_type'],
+      ['status', 'status'],
+      ['document_id', 'document_id'],
+      ['document_version_id', 'document_version_id'],
+      ['external_id', 'external_id'],
+    ]) {
+      const value = cleanString(req.query[key], 300);
+      if (!value) continue;
+      if (key === 'provider' && !INTEGRATION_EVENT_PROVIDERS.has(value)) {
+        return res.status(400).json({ error: 'provider is invalid' });
+      }
+      if (key === 'status' && !INTEGRATION_EVENT_STATUSES.has(value)) {
+        return res.status(400).json({ error: 'status is invalid' });
+      }
+      filters[key] = value;
+      conditions.push(`${column}=?`);
+      values.push(value);
+    }
+
+    const requestedLimit = Number(req.query.limit || 50);
+    const limit = Number.isFinite(requestedLimit) && requestedLimit > 0
+      ? Math.min(Math.floor(requestedLimit), 100)
+      : 50;
+    filters.limit = limit;
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const events = db.prepare(`
+      SELECT id, provider, event_type, document_id, document_version_id, external_id,
+             status, payload_json, error_message, created_at
+      FROM integration_events
+      ${where}
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).all(...values, limit);
+    res.json({ events, filters });
+  });
+
+  router.post('/integration-events', (req, res) => {
+    const validated = validateIntegrationEventInput(req.body || {});
+    if (validated.error) return res.status(400).json({ error: validated.error });
+    const f = validated.values;
+    const id = makeId('evt');
+    try {
+      db.prepare(`
+        INSERT INTO integration_events (
+          id, provider, event_type, document_id, document_version_id, external_id,
+          status, payload_json, error_message
+        ) VALUES (?,?,?,?,?,?,?,?,?)
+      `).run(
+        id,
+        f.provider,
+        f.event_type,
+        f.document_id,
+        f.document_version_id,
+        f.external_id,
+        f.status,
+        f.payload_json,
+        f.error_message
+      );
+      const row = getIntegrationEvent(id);
+      writeAudit({
+        actor: actorFrom(req),
+        action: 'integration_event.recorded',
+        entityType: 'integration_event',
+        entityId: id,
+        after: row,
+        reason: req.body.reason,
+      });
+      res.status(201).json(row);
+    } catch (err) {
+      if (err && err.code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+        return res.status(400).json({ error: 'document_id or document_version_id does not exist.' });
+      }
+      console.error(err);
+      res.status(500).json({ error: 'Failed to record integration event' });
     }
   });
 

--- a/api/routes/documents.js
+++ b/api/routes/documents.js
@@ -234,7 +234,7 @@ function createDocumentsRouter({ db }) {
     if (!value || typeof value !== 'object') return value;
     const redacted = {};
     for (const [key, child] of Object.entries(value)) {
-      if (/token|secret|authorization|credential|password|cookie|source_uri|storage_uri/i.test(key)) {
+      if (/token|secret|authorization|credential|password|cookie|api_?key|source_uri|storage_uri/i.test(key)) {
         redacted[key] = '[redacted]';
       } else {
         redacted[key] = redactIntegrationPayload(child);
@@ -512,7 +512,7 @@ function createDocumentsRouter({ db }) {
         entityType: 'integration_event',
         entityId: id,
         after: row,
-        reason: req.body.reason,
+        reason: req.body && req.body.reason,
       });
       res.status(201).json(row);
     } catch (err) {

--- a/docs/DOCUMENT_REGISTRY_SPEC.md
+++ b/docs/DOCUMENT_REGISTRY_SPEC.md
@@ -206,6 +206,8 @@ Implementation should add a new router under `/api/documents`. Mutating routes r
 |--------|------|------|---------|
 | `GET` | `/api/documents` | API key | List documents with filters: `property_id`, `status`, `document_type`. |
 | `GET` | `/api/documents/review/claims` | API key | List extracted claims by review status for the human review queue. Defaults to `pending_review`; supports `status`, `property_id`, `claim_type`, `document_type`, and `limit`; property filtering falls back to the document property when the claim was extracted before the document was linked; rejected/superseded source versions are excluded. |
+| `GET` | `/api/documents/integration-events` | API key | List sanitized integration events with filters: `provider`, `event_type`, `status`, `document_id`, `document_version_id`, `external_id`, and `limit`. |
+| `POST` | `/api/documents/integration-events` | API key | Record a sanitized external event from Drive/Gmail/OCR/AI/system automation. This is event capture only; it does not create Google watches or fetch external files. |
 | `POST` | `/api/documents` | API key | Create a logical document. |
 | `GET` | `/api/documents/:id` | API key | Read document, current version, versions, and claims. |
 | `PATCH` | `/api/documents/:id` | API key | Update title/type/status metadata. |
@@ -303,5 +305,5 @@ A future implementation PR should satisfy all of these:
 | Phase 1 spec | This document: schema, state machine, AI JSON contract, API skeleton. |
 | Phase 1 implementation | SQLite tables, helpers, API skeleton, tests. |
 | Phase 2 AI Review Queue | Review-queue API for extracted claims, read-only admin UI for reviewing claims, and audited application of approved facts. The queue API is implemented at `/api/documents/review/claims`; the admin review page is implemented at `/admin/document-claims`; approved, mapped claims can be applied through `/admin/document-claims/:claimId/apply`. |
-| Phase 3 Drive event automation | Drive watch/import pipeline into `documents` and `document_versions`. |
+| Phase 3 Drive event automation | Drive watch/import pipeline into `documents` and `document_versions`; integration event capture is available at `/api/documents/integration-events` as the safe ingest foundation. |
 | Phase 4 Gmail intake | Email attachment/message ingestion into the registry. |

--- a/tests/document-registry.test.js
+++ b/tests/document-registry.test.js
@@ -243,7 +243,28 @@ async function main() {
       assert.strictEqual((await json(res)).error, 'provider is invalid');
     });
 
+    await test('POST /api/documents/integration-events validates event type and status', async () => {
+      const missingType = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: { provider: 'google_drive' },
+      });
+      assert.strictEqual(missingType.status, 400);
+      assert.strictEqual((await json(missingType)).error, 'event_type is required');
+
+      const invalidStatus = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'file_imported',
+          status: 'unknown',
+        },
+      });
+      assert.strictEqual(invalidStatus.status, 400);
+      assert.strictEqual((await json(invalidStatus)).error, 'status is invalid');
+    });
+
     await test('POST /api/documents/integration-events records redacted Drive event metadata', async () => {
+      const longReason = `Drive watch import ${'x'.repeat(800)}`;
       const res = await api(baseUrl, '/api/documents/integration-events', {
         method: 'POST',
         body: {
@@ -262,6 +283,7 @@ async function main() {
               safe_value: 'kept',
             },
           },
+          reason: longReason,
         },
       });
       assert.strictEqual(res.status, 201);
@@ -294,6 +316,8 @@ async function main() {
       `).get(event.id);
       assert(audit);
       assert.strictEqual(audit.action, 'integration_event.recorded');
+      assert.strictEqual(audit.reason.length, 500);
+      assert.strictEqual(audit.reason, longReason.slice(0, 500));
       assert(!String(audit.after_json || '').includes('should-not-persist'));
     });
 

--- a/tests/document-registry.test.js
+++ b/tests/document-registry.test.js
@@ -231,6 +231,85 @@ async function main() {
       assert.strictEqual((await json(res)).error, 'Document version file hash already exists.');
     });
 
+    await test('POST /api/documents/integration-events rejects invalid providers', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'dropbox',
+          event_type: 'file_imported',
+        },
+      });
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'provider is invalid');
+    });
+
+    await test('POST /api/documents/integration-events records redacted Drive event metadata', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'file_imported',
+          document_id: document.id,
+          document_version_id: version.id,
+          external_id: 'drive-file-123',
+          actor: 'drive-watch-test',
+          payload: {
+            name: 'advent-tax-card.pdf',
+            mimeType: 'application/pdf',
+            source_uri: 'https://drive.google.com/secret-file-link',
+            nested: {
+              access_token: 'should-not-persist',
+              safe_value: 'kept',
+            },
+          },
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      const event = await json(res);
+      assert(event.id.startsWith('evt_'));
+      assert.strictEqual(event.provider, 'google_drive');
+      assert.strictEqual(event.status, 'recorded');
+      assert.strictEqual(event.document_id, document.id);
+      assert.strictEqual(event.document_version_id, version.id);
+      const payload = JSON.parse(event.payload_json);
+      assert.strictEqual(payload.name, 'advent-tax-card.pdf');
+      assert.strictEqual(payload.source_uri, '[redacted]');
+      assert.strictEqual(payload.nested.access_token, '[redacted]');
+      assert.strictEqual(payload.nested.safe_value, 'kept');
+      assert(!event.payload_json.includes('should-not-persist'));
+      assert(!event.payload_json.includes('secret-file-link'));
+
+      const listRes = await api(
+        baseUrl,
+        `/api/documents/integration-events?provider=google_drive&external_id=${encodeURIComponent('drive-file-123')}`
+      );
+      assert.strictEqual(listRes.status, 200);
+      const listed = await json(listRes);
+      assert.strictEqual(listed.filters.provider, 'google_drive');
+      assert.strictEqual(listed.filters.external_id, 'drive-file-123');
+      assert(listed.events.some((row) => row.id === event.id));
+
+      const audit = testDb.prepare(`
+        SELECT * FROM audit_events WHERE entity_type='integration_event' AND entity_id=?
+      `).get(event.id);
+      assert(audit);
+      assert.strictEqual(audit.action, 'integration_event.recorded');
+      assert(!String(audit.after_json || '').includes('should-not-persist'));
+    });
+
+    await test('POST /api/documents/integration-events rejects missing document links', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'file_imported',
+          document_id: 'missing-document',
+        },
+      });
+      assert.strictEqual(res.status, 400);
+      assert.strictEqual((await json(res)).error, 'document_id or document_version_id does not exist.');
+    });
+
     await test('POST /api/documents/:id/claims rejects invalid AI extraction payloads', async () => {
       const res = await api(baseUrl, `/api/documents/${document.id}/claims`, {
         method: 'POST',

--- a/tests/document-registry.test.js
+++ b/tests/document-registry.test.js
@@ -280,6 +280,7 @@ async function main() {
             source_uri: 'https://drive.google.com/secret-file-link',
             nested: {
               access_token: 'should-not-persist',
+              api_key: 'also-should-not-persist',
               safe_value: 'kept',
             },
           },
@@ -297,8 +298,10 @@ async function main() {
       assert.strictEqual(payload.name, 'advent-tax-card.pdf');
       assert.strictEqual(payload.source_uri, '[redacted]');
       assert.strictEqual(payload.nested.access_token, '[redacted]');
+      assert.strictEqual(payload.nested.api_key, '[redacted]');
       assert.strictEqual(payload.nested.safe_value, 'kept');
       assert(!event.payload_json.includes('should-not-persist'));
+      assert(!event.payload_json.includes('also-should-not-persist'));
       assert(!event.payload_json.includes('secret-file-link'));
 
       const listRes = await api(


### PR DESCRIPTION
## Summary
- add API-key protected `GET/POST /api/documents/integration-events` for sanitized Drive/Gmail/OCR/AI/system event recording
- redact secret-like payload fields before persistence and audit logging
- document this as the Phase 3 event-capture foundation while leaving real Google Drive watch/import setup open

## Verification
- `node --check api/routes/documents.js`
- `node tests/document-registry.test.js`
- `bash scripts/preflight.sh`
- `node tests/verify-security-fixes.test.js`
- `git diff --check`

## Scope boundary
This does not touch VPS/DNS/Railway/Vercel, create Google Drive watches, fetch remote files, or require new production credentials.

## Summary by Sourcery

Add an API-key protected integration event capture endpoint for the document registry and document it as the Phase 3 ingest foundation.

New Features:
- Expose GET/POST /api/documents/integration-events for recording and listing sanitized integration events across Drive, Gmail, OCR, AI, API, and system providers.

Enhancements:
- Redact secret-like fields from integration event payloads before persistence and audit logging, and validate provider/status values against allowed sets.
- Link integration events to documents and versions with foreign-key enforcement and audit logging when events are recorded.

Documentation:
- Document the integration event capture API in the document registry spec and project/task tracking files as the Phase 3 automation baseline.

Tests:
- Extend document registry tests to cover integration event creation, redaction behavior, listing filters, invalid provider handling, and foreign-key validation.