### PR TITLE
Add Drive event document import foundation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -277,5 +277,5 @@ Merged into `main` @ `dc8cc53` via PR #76; live read-only production smoke passe
 - **Phase 0**: OpenHands executor validation — still awaiting developer action
 - **Phase 1**: Document Registry skeleton — spec and API/database skeleton merged in #118/#120; deploy pending
 - **Phase 2**: AI Review Queue — backend queue API (#124), read-only admin page (#126), and audited apply workflow (#127) added; deploy pending
-- **Phase 3** (current): Drive event automation; sanitized integration event capture API merged in #128 and queued on `origin/main`, while real Google Drive watch setup/import credentials remain pending
+- **Phase 3** (current): Drive event automation; sanitized integration event capture API is merged, and local Drive-event document import foundation is implemented as repo-safe code. Real Google Drive watch setup, remote file fetch/OCR worker, and runtime credentials remain pending
 - **Phase 4**: Gmail intake (Pub/Sub)

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,7 +25,7 @@
 
 ## Low Priority
 
-- [ ] **Phase 3: Drive event automation** — integration-event recording API is in place; remaining work is Google Drive watch setup/import worker and runtime credentials — **Gemini leads**
+- [ ] **Phase 3: Drive event automation** — integration-event recording and local Drive-event document import foundation are in place; remaining work is Google Drive watch setup, remote file fetch/OCR worker, and runtime credentials — **Gemini leads**
 - [ ] **Phase 4: Gmail intake** — depends on Phase 3 — **Gemini leads**
 
 ---
@@ -36,6 +36,7 @@
 - [x] **Phase 2: AI Review Queue admin UI** — added an authenticated read-only `/admin/document-claims` page with filters, safe rendered evidence, source/storage URI redaction, and HTTP coverage in `tests/admin-document-review.test.js` — 2026-06-19
 - [x] **Phase 2: AI Review Queue apply workflow** — added CSRF-protected `/admin/document-claims/:claimId/apply` for approved, explicitly mapped claims; updates listing fields in a transaction, marks claims applied, and writes property + claim audit rows with HTTP coverage — 2026-06-19
 - [x] **Phase 3: Integration event capture API** — added API-key protected `GET/POST /api/documents/integration-events` for sanitized Drive/Gmail/OCR/AI/system event recording with HTTP coverage; does not create external watches or require Google credentials — 2026-06-19
+- [x] **Phase 3: Drive event document import foundation** — added API-key protected `POST /api/documents/integration-events/:eventId/import-document` to convert already-recorded Google Drive metadata into draft document/version rows, mark the event processed, and write redacted audit rows; does not call Google APIs or require credentials — 2026-06-19
 - [x] **Add integration/E2E tests** — `tests/http-smoke.test.js` starts the real Express app against a temporary SQLite database and is enforced by `scripts/preflight.sh`; covers health/config/listings-off/contact-origin/chat-fallback behavior over HTTP — 2026-06-18
 - [x] **Remove disabled Twilio path** — deleted the unused dynamic Twilio sender, removed lead-route SMS calls, and updated docs so lead notifications are email/local persistence only until a future SMS provider is intentionally specified — 2026-06-18
 - [x] **CORS origin restriction review** — existing `CORS_ORIGIN` allowlist behavior verified and regression-covered in `tests/http-smoke.test.js`; trusted origins receive CORS headers and can submit guarded leads, untrusted origins do not receive CORS access and are rejected by same-origin lead guards — 2026-06-18

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -1142,3 +1142,29 @@ Remove stale coordinator state after the repo-safe queue continued overnight, es
 ### Remaining Risks
 - This is docs/state cleanup only and does not deploy #116/#120/#121/#124/#126/#127/#128 runtime changes to the VPS.
 - Production remains on the last verified manual deploy (`24ee74b`) until Phil approves a VPS deploy and `scripts/verify-vps-prod.sh` proves the new SHA live.
+
+---
+
+## 2026-06-19 — Codex — Drive event document import foundation
+
+### Objective
+Advance Phase 3 without crossing into Google credentials or production infrastructure by converting already-recorded Google Drive integration event metadata into draft registry documents and first versions.
+
+### Changes Made
+- `api/routes/documents.js` — added `POST /api/documents/integration-events/:eventId/import-document` for API-key protected import of `google_drive` events in `recorded` state.
+- `api/routes/documents.js` — import runs in one transaction: create `documents` row, create version 1 in `document_versions`, mark the integration event `processed`, link event to the new document/version, and write audit rows.
+- `api/routes/documents.js` — tightened audit snapshots by redacting `payload_json`, preventing provider payload links/metadata from being duplicated into audit JSON.
+- `tests/document-registry.test.js` — added HTTP coverage for Drive event import, processed-event reimport rejection, duplicate Drive file rejection, and audit redaction.
+- `docs/DOCUMENT_REGISTRY_SPEC.md`, `TASKS.md`, `PROJECT_STATE.md` — recorded the repo-safe Phase 3 boundary: local import foundation complete; Drive watch setup, remote file fetch/OCR worker, and runtime credentials remain pending.
+
+### Verification
+- `node --check api/routes/documents.js && node --check tests/document-registry.test.js` passed.
+- `node tests/document-registry.test.js` passed — 28/28.
+- `git diff --check` passed.
+- `npm run validate-api-docs --if-present` completed successfully.
+- `bash scripts/preflight.sh` passed.
+- `node tests/verify-security-fixes.test.js` passed — 57/57.
+
+### Remaining Risks
+- This does not call Google APIs, create Drive watches, fetch remote files, run OCR, or configure runtime credentials.
+- Merge still does not deploy the new endpoint to the VPS; production remains on the last verified manual deploy until Phil approves a deployment and SHA proof is collected.

--- a/api/routes/documents.js
+++ b/api/routes/documents.js
@@ -13,8 +13,10 @@ const DOCUMENT_TYPES = new Set([
 const SOURCE_PROVIDERS = new Set(['manual', 'google_drive', 'gmail', 'api', 'system']);
 const INTEGRATION_EVENT_PROVIDERS = new Set(['google_drive', 'gmail', 'ocr', 'ai_extraction', 'api', 'system']);
 const INTEGRATION_EVENT_STATUSES = new Set(['recorded', 'processed', 'failed', 'ignored']);
+const DRIVE_IMPORT_EVENT_TYPES = new Set(['file_imported', 'file_created', 'file_updated', 'file_changed']);
 const DOCUMENT_STATUSES = new Set(['draft', 'active', 'superseded', 'archived', 'rejected']);
 const VERSION_APPROVAL_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded']);
+const OCR_STATUSES = new Set(['not_started', 'pending', 'complete', 'failed']);
 const CLAIM_STATUSES = new Set(['pending_review', 'approved', 'rejected', 'superseded', 'applied']);
 const CLAIM_VALUE_TYPES = new Set(['string', 'number', 'boolean', 'date', 'money', 'area', 'list', 'object']);
 const CLAIM_TYPES = new Set([
@@ -74,6 +76,7 @@ function createDocumentsRouter({ db }) {
       'source_quote',
       'source_location_json',
       'review_note',
+      'payload_json',
     ]) {
       if (copy[key] != null) copy[key] = '[redacted]';
     }
@@ -284,6 +287,103 @@ function createDocumentsRouter({ db }) {
     } catch (_) {
       return fallback;
     }
+  }
+
+  function payloadString(payload, keys, max = 500) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+    for (const key of keys) {
+      const raw = payload[key];
+      if (raw != null && (typeof raw === 'object' || typeof raw === 'function')) continue;
+      const value = cleanString(raw, max);
+      if (value) return value;
+    }
+    return null;
+  }
+
+  function payloadNumber(payload, keys) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return { value: null };
+    for (const key of keys) {
+      if (payload[key] == null || payload[key] === '') continue;
+      if (typeof payload[key] === 'object' || typeof payload[key] === 'function') {
+        return { error: `${key} must be a non-negative number` };
+      }
+      const value = Number(payload[key]);
+      if (!Number.isFinite(value) || value < 0) return { error: `${key} must be a non-negative number` };
+      return { value: Math.floor(value) };
+    }
+    return { value: null };
+  }
+
+  function prepareDriveDocumentImport(event) {
+    if (event.provider !== 'google_drive') {
+      return { status: 400, error: 'Only google_drive events can be imported as Drive documents.' };
+    }
+    if (!DRIVE_IMPORT_EVENT_TYPES.has(event.event_type)) {
+      return { status: 400, error: 'Google Drive event type is not importable as a document.' };
+    }
+    if (event.status === 'processed') {
+      return { status: 409, error: 'Integration event is already processed.' };
+    }
+    if (event.status !== 'recorded') {
+      return { status: 400, error: `Integration event status must be recorded, not ${event.status}.` };
+    }
+    if (event.document_id || event.document_version_id) {
+      return { status: 409, error: 'Integration event is already linked to a document.' };
+    }
+
+    const parsedPayload = parseJsonField(event.payload_json, {});
+    const payload = parsedPayload && typeof parsedPayload === 'object' && !Array.isArray(parsedPayload)
+      ? parsedPayload
+      : {};
+    const externalId = cleanString(
+      event.external_id || payloadString(payload, ['id', 'fileId', 'file_id', 'external_id'], 300),
+      300
+    );
+    if (!externalId) return { status: 400, error: 'Drive event external_id is required.' };
+
+    const fileName = payloadString(payload, ['file_name', 'fileName', 'name', 'title'], 300);
+    if (!fileName) return { status: 400, error: 'Drive event payload must include a file name.' };
+
+    const documentType = payloadString(payload, ['document_type', 'documentType'], 80) || 'other';
+    if (!DOCUMENT_TYPES.has(documentType)) return { status: 400, error: 'document_type is invalid' };
+
+    const fileSize = payloadNumber(payload, ['file_size_bytes', 'fileSizeBytes', 'size']);
+    if (fileSize.error) return { status: 400, error: fileSize.error };
+
+    const sha256 = payloadString(payload, ['sha256', 'sha256Checksum', 'sha256_checksum'], 128);
+    if (sha256 && !/^[a-f0-9]{64}$/i.test(sha256)) {
+      return { status: 400, error: 'sha256 must be a 64-character hex digest' };
+    }
+
+    const ocrStatus = payloadString(payload, ['ocr_status', 'ocrStatus'], 40) || 'not_started';
+    if (!OCR_STATUSES.has(ocrStatus)) return { status: 400, error: 'ocr_status is invalid' };
+
+    const sourceUri = payloadString(
+      payload,
+      ['webViewLink', 'web_view_link', 'alternateLink', 'drive_url', 'url'],
+      2048
+    ) || `google-drive://${externalId}`;
+    const title = payloadString(payload, ['document_title', 'documentTitle'], 200) || fileName;
+
+    return {
+      values: {
+        document_id: makeId('doc'),
+        version_id: makeId('ver'),
+        title,
+        document_type: documentType,
+        property_id: payloadString(payload, ['property_id', 'propertyId'], 80),
+        source_uri: sourceUri,
+        source_external_id: externalId,
+        file_name: fileName,
+        mime_type: payloadString(payload, ['mime_type', 'mimeType'], 120),
+        file_size_bytes: fileSize.value,
+        sha256,
+        storage_uri: sourceUri,
+        storage_external_id: externalId,
+        ocr_status: ocrStatus,
+        created_by: payloadString(payload, ['created_by', 'createdBy'], 80),
+      },
+    };
   }
 
   function claimForReview(row) {
@@ -521,6 +621,104 @@ function createDocumentsRouter({ db }) {
       }
       console.error(err);
       res.status(500).json({ error: 'Failed to record integration event' });
+    }
+  });
+
+  router.post('/integration-events/:eventId/import-document', (req, res) => {
+    const event = getIntegrationEvent(req.params.eventId);
+    if (!event) return res.status(404).json({ error: 'Integration event not found' });
+
+    const prepared = prepareDriveDocumentImport(event);
+    if (prepared.error) return res.status(prepared.status).json({ error: prepared.error });
+    const f = prepared.values;
+    const actor = actorFrom(req);
+
+    try {
+      const tx = db.transaction(() => {
+        db.prepare(`
+          INSERT INTO documents (
+            id, property_id, title, document_type, source_provider, source_uri,
+            source_external_id, status, created_by
+          ) VALUES (?,?,?,?,?,?,?,?,?)
+        `).run(
+          f.document_id,
+          f.property_id,
+          f.title,
+          f.document_type,
+          'google_drive',
+          f.source_uri,
+          f.source_external_id,
+          'draft',
+          f.created_by || actor
+        );
+        const document = getDocument(f.document_id);
+        if (!document) throw new Error('Drive document import failed to read created document');
+        writeAudit({
+          actor,
+          action: 'document.created',
+          entityType: 'document',
+          entityId: f.document_id,
+          after: document,
+          reason: req.body.reason || `Imported from integration event ${event.id}`,
+        });
+
+        db.prepare(`
+          INSERT INTO document_versions (
+            id, document_id, version_number, file_name, mime_type, file_size_bytes, sha256,
+            storage_uri, storage_external_id, ocr_text, ocr_status
+          ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+        `).run(
+          f.version_id,
+          f.document_id,
+          1,
+          f.file_name,
+          f.mime_type,
+          f.file_size_bytes,
+          f.sha256,
+          f.storage_uri,
+          f.storage_external_id,
+          null,
+          f.ocr_status
+        );
+        const version = getVersion(f.version_id);
+        if (!version) throw new Error('Drive document import failed to read created version');
+        writeAudit({
+          actor,
+          action: 'document_version.created',
+          entityType: 'document_version',
+          entityId: f.version_id,
+          after: version,
+          reason: req.body.reason || `Imported from integration event ${event.id}`,
+        });
+
+        db.prepare(`
+          UPDATE integration_events
+          SET document_id=?, document_version_id=?, status='processed'
+          WHERE id=?
+        `).run(f.document_id, f.version_id, event.id);
+        const processedEvent = getIntegrationEvent(event.id);
+        writeAudit({
+          actor,
+          action: 'integration_event.processed',
+          entityType: 'integration_event',
+          entityId: event.id,
+          before: event,
+          after: processedEvent,
+          reason: req.body.reason || `Imported Drive file ${f.source_external_id}`,
+        });
+
+        return { document, version, event: processedEvent };
+      });
+      res.status(201).json(tx());
+    } catch (err) {
+      if (err && err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        return res.status(409).json({ error: 'Drive document or version already exists.' });
+      }
+      if (err && err.code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+        return res.status(400).json({ error: 'property_id does not exist.' });
+      }
+      console.error(err);
+      res.status(500).json({ error: 'Failed to import Drive document event' });
     }
   });
 

--- a/docs/DOCUMENT_REGISTRY_SPEC.md
+++ b/docs/DOCUMENT_REGISTRY_SPEC.md
@@ -208,6 +208,7 @@ Implementation should add a new router under `/api/documents`. Mutating routes r
 | `GET` | `/api/documents/review/claims` | API key | List extracted claims by review status for the human review queue. Defaults to `pending_review`; supports `status`, `property_id`, `claim_type`, `document_type`, and `limit`; property filtering falls back to the document property when the claim was extracted before the document was linked; rejected/superseded source versions are excluded. |
 | `GET` | `/api/documents/integration-events` | API key | List sanitized integration events with filters: `provider`, `event_type`, `status`, `document_id`, `document_version_id`, `external_id`, and `limit`. |
 | `POST` | `/api/documents/integration-events` | API key | Record a sanitized external event from Drive/Gmail/OCR/AI/system automation. This is event capture only; it does not create Google watches or fetch external files. |
+| `POST` | `/api/documents/integration-events/:eventId/import-document` | API key | Import an already-recorded Google Drive event into a draft `documents` row plus first `document_versions` row. This consumes local event metadata only; it does not call Google APIs or create Drive watches. |
 | `POST` | `/api/documents` | API key | Create a logical document. |
 | `GET` | `/api/documents/:id` | API key | Read document, current version, versions, and claims. |
 | `PATCH` | `/api/documents/:id` | API key | Update title/type/status metadata. |
@@ -305,5 +306,5 @@ A future implementation PR should satisfy all of these:
 | Phase 1 spec | This document: schema, state machine, AI JSON contract, API skeleton. |
 | Phase 1 implementation | SQLite tables, helpers, API skeleton, tests. |
 | Phase 2 AI Review Queue | Review-queue API for extracted claims, read-only admin UI for reviewing claims, and audited application of approved facts. The queue API is implemented at `/api/documents/review/claims`; the admin review page is implemented at `/admin/document-claims`; approved, mapped claims can be applied through `/admin/document-claims/:claimId/apply`. |
-| Phase 3 Drive event automation | Drive watch/import pipeline into `documents` and `document_versions`; integration event capture is available at `/api/documents/integration-events` as the safe ingest foundation. |
+| Phase 3 Drive event automation | Drive watch/import pipeline into `documents` and `document_versions`; integration event capture is available at `/api/documents/integration-events`, and already-recorded Google Drive events can be imported into draft document/version metadata through `/api/documents/integration-events/:eventId/import-document`. Real Drive watch setup, remote file fetching, and runtime credentials remain outside the repo-safe foundation. |
 | Phase 4 Gmail intake | Email attachment/message ingestion into the registry. |

--- a/tests/document-registry.test.js
+++ b/tests/document-registry.test.js
@@ -133,6 +133,7 @@ async function main() {
     let version = null;
     let approvedClaim = null;
     let rejectedClaim = null;
+    let importedDriveDocument = null;
 
     await test('GET /api/documents requires API key auth', async () => {
       const res = await api(baseUrl, '/api/documents', { auth: false });
@@ -322,6 +323,173 @@ async function main() {
       assert.strictEqual(audit.reason.length, 500);
       assert.strictEqual(audit.reason, longReason.slice(0, 500));
       assert(!String(audit.after_json || '').includes('should-not-persist'));
+    });
+
+    await test('POST /api/documents/integration-events/:id/import-document imports Drive file metadata', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'file_imported',
+          external_id: 'drive-file-import-456',
+          actor: 'drive-watch-test',
+          payload: {
+            name: 'Imported disclosure.pdf',
+            mimeType: 'application/pdf',
+            size: '54321',
+            sha256Checksum: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            webViewLink: 'https://drive.google.com/file/d/drive-file-import-456/view',
+            document_type: 'disclosure',
+            property_id: REVIEW_PROPERTY_ID,
+            created_by: 'drive-watch-test',
+          },
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      const event = await json(res);
+      assert.strictEqual(event.document_id, null);
+      assert.strictEqual(event.status, 'recorded');
+
+      const importRes = await api(baseUrl, `/api/documents/integration-events/${event.id}/import-document`, {
+        method: 'POST',
+        body: { actor: 'drive-import-test', reason: 'Import already-recorded Drive metadata.' },
+      });
+      assert.strictEqual(importRes.status, 201);
+      const body = await json(importRes);
+      importedDriveDocument = body.document;
+      assert(importedDriveDocument.id.startsWith('doc_'));
+      assert.strictEqual(importedDriveDocument.status, 'draft');
+      assert.strictEqual(importedDriveDocument.document_type, 'disclosure');
+      assert.strictEqual(importedDriveDocument.source_provider, 'google_drive');
+      assert.strictEqual(importedDriveDocument.source_external_id, 'drive-file-import-456');
+      assert.strictEqual(importedDriveDocument.property_id, REVIEW_PROPERTY_ID);
+      assert.strictEqual(body.version.document_id, importedDriveDocument.id);
+      assert.strictEqual(body.version.version_number, 1);
+      assert.strictEqual(body.version.file_name, 'Imported disclosure.pdf');
+      assert.strictEqual(body.version.file_size_bytes, 54321);
+      assert.strictEqual(body.version.storage_external_id, 'drive-file-import-456');
+      assert.strictEqual(body.version.ocr_status, 'not_started');
+      assert.strictEqual(body.event.status, 'processed');
+      assert.strictEqual(body.event.document_id, importedDriveDocument.id);
+      assert.strictEqual(body.event.document_version_id, body.version.id);
+
+      const detailRes = await api(baseUrl, `/api/documents/${importedDriveDocument.id}`);
+      assert.strictEqual(detailRes.status, 200);
+      const detail = await json(detailRes);
+      assert.strictEqual(detail.document.id, importedDriveDocument.id);
+      assert.strictEqual(detail.versions.length, 1);
+
+      const auditRows = testDb.prepare(`
+        SELECT action, after_json FROM audit_events WHERE entity_id IN (?, ?, ?) ORDER BY created_at, id
+      `).all(importedDriveDocument.id, body.version.id, body.event.id);
+      assert(auditRows.some((row) => row.action === 'document.created'));
+      assert(auditRows.some((row) => row.action === 'document_version.created'));
+      assert(auditRows.some((row) => row.action === 'integration_event.processed'));
+      const sourceAudit = auditRows.filter((row) => row.action !== 'integration_event.processed');
+      assert(sourceAudit.every((row) => !String(row.after_json || '').includes('/drive-file-import-456/view')));
+
+      const repeatImport = await api(baseUrl, `/api/documents/integration-events/${event.id}/import-document`, {
+        method: 'POST',
+        body: { actor: 'drive-import-test' },
+      });
+      assert.strictEqual(repeatImport.status, 409);
+      assert.strictEqual((await json(repeatImport)).error, 'Integration event is already processed.');
+    });
+
+    await test('POST /api/documents/integration-events/:id/import-document rejects duplicate Drive files', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'file_imported',
+          external_id: 'drive-file-import-456',
+          actor: 'drive-watch-test',
+          payload: {
+            name: 'Imported disclosure duplicate.pdf',
+            mimeType: 'application/pdf',
+            webViewLink: 'https://drive.google.com/file/d/drive-file-import-456/view',
+            document_type: 'disclosure',
+          },
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      const event = await json(res);
+      const importRes = await api(baseUrl, `/api/documents/integration-events/${event.id}/import-document`, {
+        method: 'POST',
+        body: { actor: 'drive-import-test' },
+      });
+      assert.strictEqual(importRes.status, 409);
+      assert.strictEqual((await json(importRes)).error, 'Drive document or version already exists.');
+    });
+
+    await test('POST /api/documents/integration-events/:id/import-document rejects non-file Drive events', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'watch_renewed',
+          external_id: 'drive-channel-1',
+          payload: {
+            name: 'Not a file.pdf',
+          },
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      const event = await json(res);
+      const importRes = await api(baseUrl, `/api/documents/integration-events/${event.id}/import-document`, {
+        method: 'POST',
+        body: { actor: 'drive-import-test' },
+      });
+      assert.strictEqual(importRes.status, 400);
+      assert.strictEqual((await json(importRes)).error, 'Google Drive event type is not importable as a document.');
+    });
+
+    await test('POST /api/documents/integration-events/:id/import-document rejects invalid property links', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'file_imported',
+          external_id: 'drive-file-invalid-property',
+          payload: {
+            name: 'Invalid property disclosure.pdf',
+            document_type: 'disclosure',
+            property_id: 'missing-property-id',
+          },
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      const event = await json(res);
+      const importRes = await api(baseUrl, `/api/documents/integration-events/${event.id}/import-document`, {
+        method: 'POST',
+        body: { actor: 'drive-import-test' },
+      });
+      assert.strictEqual(importRes.status, 400);
+      assert.strictEqual((await json(importRes)).error, 'property_id does not exist.');
+    });
+
+    await test('POST /api/documents/integration-events/:id/import-document rejects object-valued numeric payloads', async () => {
+      const res = await api(baseUrl, '/api/documents/integration-events', {
+        method: 'POST',
+        body: {
+          provider: 'google_drive',
+          event_type: 'file_imported',
+          external_id: 'drive-file-object-size',
+          payload: {
+            name: 'Object size disclosure.pdf',
+            document_type: 'disclosure',
+            size: { bytes: 123 },
+          },
+        },
+      });
+      assert.strictEqual(res.status, 201);
+      const event = await json(res);
+      const importRes = await api(baseUrl, `/api/documents/integration-events/${event.id}/import-document`, {
+        method: 'POST',
+        body: { actor: 'drive-import-test' },
+      });
+      assert.strictEqual(importRes.status, 400);
+      assert.strictEqual((await json(importRes)).error, 'size must be a non-negative number');
     });
 
     await test('POST /api/documents/integration-events rejects missing document links', async () => {


### PR DESCRIPTION
## Summary
- add API-key protected `POST /api/documents/integration-events/:eventId/import-document`
- convert already-recorded Google Drive file events into draft document + version metadata in one transaction
- mark imported integration events processed and write redacted audit rows
- document the Phase 3 boundary: no Google API calls, no watches, no credentials, no deploy

## Validation
- node --check api/routes/documents.js && node --check tests/document-registry.test.js
- node tests/document-registry.test.js (26/26)
- git diff --check
- npm run validate-api-docs --if-present
- bash scripts/preflight.sh
- node tests/verify-security-fixes.test.js (57/57)

## Deploy
No deploy. Runtime changes are queued on main only after merge; live VPS remains on the last Phil-approved manual deploy until a deploy is explicitly approved and verified.

## Summary by Sourcery

Add an API-key protected endpoint to import recorded Google Drive integration events into draft documents and initial versions, updating event status and audits while keeping the implementation within the repo-safe Phase 3 boundary.

New Features:
- Introduce POST /api/documents/integration-events/:eventId/import-document to convert eligible Google Drive events into draft document and document_version records in a single transaction.

Enhancements:
- Redact integration event payload JSON from audit snapshots to avoid persisting external provider metadata and links.
- Extend document registry spec and project/task tracking docs to describe the Drive event import capability and clarify the non-deployed, repo-safe Phase 3 boundary.

Documentation:
- Document the new Drive integration-event document import endpoint and update Phase 3 Drive automation descriptions to distinguish local import foundation from future watch/worker/credential work.

Tests:
- Add HTTP tests covering successful Drive event import, rejection of re-importing processed events, duplicate Drive file conflicts, and non-importable Drive event types.