### PR TITLE
feat: persist lead attribution

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -32,6 +32,7 @@
 
 ## Completed
 
+- [x] **First-touch lead attribution for `/api/contacts`** — homepage shared forms, property modal, chat lead, listing detail form, and `/start` buyer-guide form now capture first-touch `utm_*`/referrer/landing data and POST it to `/api/contacts`; API sanitizes, persists in `contacts.attribution`, exposes it in the protected contacts list, and includes it in the existing email notification body without changing the email transport — 2026-06-28
 - [x] **Phase 2: AI Review Queue API** — added `GET /api/documents/review/claims` for status-filtered extracted-claim review queues with HTTP coverage in `tests/document-registry.test.js` — 2026-06-18
 - [x] **Phase 2: AI Review Queue admin UI** — added an authenticated read-only `/admin/document-claims` page with filters, safe rendered evidence, source/storage URI redaction, and HTTP coverage in `tests/admin-document-review.test.js` — 2026-06-19
 - [x] **Phase 2: AI Review Queue apply workflow** — added CSRF-protected `/admin/document-claims/:claimId/apply` for approved, explicitly mapped claims; updates listing fields in a transaction, marks claims applied, and writes property + claim audit rows with HTTP coverage — 2026-06-19

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -5,6 +5,40 @@
 
 ---
 
+## 2026-06-28 — Codex
+
+### Objective
+Apply and verify Claude's corrected VPS lead-attribution patch on a clean `origin/main` worktree without touching the dirty local feature branch or production.
+
+### Changes Made
+- Added first-touch attribution capture to `app/index.html`, `app/listing.js`, and `app/start.html` using the shared `ml_attribution` localStorage key. Capture is first-touch, best-effort, and non-fatal if storage is unavailable.
+- Wired attribution into all known public `/api/contacts` POST paths: homepage shared `submitForm()` forms, `pmSend()`, `submitChatLead()`, listing detail `submitContact()`, and the `/start` buyer-guide form.
+- Added `contacts.attribution` as an idempotent SQLite migration in `api/db.js`.
+- Added `sanitizeAttribution()` to `api/routes/api.js`; it allow-lists known attribution keys, trims/caps values, rejects arrays/non-objects, persists JSON-or-null, and forwards sanitized attribution to `sendLeadNotification()`.
+- Included `c.attribution` in the protected `GET /api/contacts` list so API-key lead review can see persisted attribution.
+- Added an escaped Attribution row to the existing `api/services/email.js` lead email body. The email transport path was not changed.
+- Updated `tests/verify-security-fixes.test.js` and `tests/http-smoke.test.js` to cover attribution sanitization, persistence, notification pass-through, and HTTP-level storage/retrieval.
+- Updated `TASKS.md`, `docs/agent-handoff.md`, and this work log.
+
+### Verification (Truthfulness Rule)
+- `npm ci` in `api/` -> pass, 0 vulnerabilities reported by install audit.
+- `node --check api/db.js && node --check api/routes/api.js && node --check api/services/email.js && node --check app/listing.js` -> pass.
+- `node --check tests/http-smoke.test.js` -> pass.
+- `node tests/verify-security-fixes.test.js` -> 59/59 pass.
+- `node tests/http-smoke.test.js` -> 11/11 pass, including attribution persistence/retrieval through `/api/contacts`.
+- `node tests/email.test.js` -> 10 pass.
+- `node tests/lead-notifications.test.js` -> 6 pass.
+- `node tests/public-assistant-flag.test.js` -> 7 pass.
+- `node tests/admin-document-review.test.js` -> 9 pass.
+- `node tests/ai-generator-routing.test.js` -> 18 pass.
+- `node tests/chat-assistant.test.js` -> 14 pass.
+- `node tests/document-registry.test.js` -> 28 pass.
+- `cd api && npm test` -> syntax OK.
+
+### Remaining Risks
+- This is repo-safe only. No VPS deploy, live database mutation, live email, DNS, Vercel, Cloudflare Worker, or listing-route change was performed.
+- Production still requires a human-approved manual deploy and the mutating lead-pipeline smoke from `docs/SMOKE_CHECKLIST.md` to prove live email delivery.
+
 ## 2026-05-27 — Claude Code (Sonnet 4.6)
 
 ### Objective

--- a/api/db.js
+++ b/api/db.js
@@ -301,6 +301,14 @@ if (db.prepare('SELECT COUNT(*) as c FROM counties').get().c === 0) {
   add('price',                'REAL');
 }
 
+// First-touch lead attribution (utm_*/referrer/landing), stored as JSON text.
+{
+  const cols = db.prepare('PRAGMA table_info(contacts)').all().map(r => r.name);
+  if (!cols.includes('attribution')) {
+    try { db.exec('ALTER TABLE contacts ADD COLUMN attribution TEXT'); } catch (_) {}
+  }
+}
+
 // ── Listing seed/migration: 37 Advent Dr ─────────────────
 {
   const hampshire = db.prepare("SELECT id FROM counties WHERE name='Hampshire'").get();

--- a/api/routes/api.js
+++ b/api/routes/api.js
@@ -98,6 +98,21 @@ router.get('/analytics', publicReadRateLimit, (_req, res) => {
 });
 
 // ── Contacts ──────────────────────────────────────────────
+// First-touch attribution: client sends a flat object; we allow-list known
+// keys, coerce to short strings, and drop empties. Stored as JSON in
+// contacts.attribution and echoed into the lead notification (never executed).
+const ATTRIBUTION_KEYS = ['utm_source','utm_medium','utm_campaign','utm_term','utm_content','referrer','landing_page','landing_at'];
+function sanitizeAttribution(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const out = {};
+  for (const k of ATTRIBUTION_KEYS) {
+    if (raw[k] == null) continue;
+    const v = String(raw[k]).trim().slice(0, 300);
+    if (v) out[k] = v;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
 router.post('/contacts', contactsRateLimit, (req, res) => {
   const { property_id, name, email, phone, message, interest } = req.body;
   const source = String(req.body.source || 'web').trim().slice(0, 80).replace(/[^a-zA-Z0-9_-]/g, '') || 'web';
@@ -105,19 +120,20 @@ router.post('/contacts', contactsRateLimit, (req, res) => {
   const combinedMessage = interestText
     ? `[Interest: ${interestText}] ${message || ''}`.trim()
     : message;
+  const attribution = sanitizeAttribution(req.body.attribution);
   if (!name || !email) return res.status(400).json({ error: 'Name and email required' });
   if (!isValidEmail(email)) return res.status(400).json({ error: 'Invalid email address' });
 
   const result = db.prepare(
-    'INSERT INTO contacts (property_id,name,email,phone,message,source) VALUES (?,?,?,?,?,?)'
-  ).run(property_id||null, name, email, phone, combinedMessage, source);
+    'INSERT INTO contacts (property_id,name,email,phone,message,source,attribution) VALUES (?,?,?,?,?,?,?)'
+  ).run(property_id||null, name, email, phone, combinedMessage, source, attribution ? JSON.stringify(attribution) : null);
 
   const property = property_id
     ? db.prepare(`SELECT p.id, p.address, p.city, c.name AS county
                   FROM properties p LEFT JOIN counties c ON c.id=p.county_id
                   WHERE p.id=?`).get(property_id)
     : null;
-  sendLeadNotification({ name, email, phone, message: combinedMessage, source }, property)
+  sendLeadNotification({ name, email, phone, message: combinedMessage, source, attribution }, property)
     .then((sent) => {
       if (!sent) {
         console.warn(`[Contacts] Lead #${result.lastInsertRowid} CAPTURED but NOT notified — email provider unconfigured or send failed.`);
@@ -132,7 +148,7 @@ router.post('/contacts', contactsRateLimit, (req, res) => {
 
 router.get('/contacts', apiWriteRateLimit, requireApiKey, (_req, res) => {
   const contacts = db.prepare(`
-    SELECT c.id, c.name, c.email, c.phone, c.property_id, c.message, c.source, c.created_at,
+    SELECT c.id, c.name, c.email, c.phone, c.property_id, c.message, c.source, c.attribution, c.created_at,
            p.address AS property_address
     FROM contacts c
     LEFT JOIN properties p ON p.id = c.property_id

--- a/api/services/email.js
+++ b/api/services/email.js
@@ -119,6 +119,16 @@ function buildLeadHtml(contact = {}, property) {
   const telHref = esc(sanitizePhoneForHref(contact.phone));              // safe tel: href
   const mailHref = esc(sanitizeEmailForHref(contact.email));             // safe mailto: href
 
+  // First-touch attribution row (all values escaped). Omitted when absent.
+  const att = contact.attribution && typeof contact.attribution === 'object' ? contact.attribution : null;
+  const attribLines = att
+    ? ['utm_source','utm_medium','utm_campaign','utm_term','utm_content','referrer','landing_page','landing_at']
+        .filter((k) => att[k]).map((k) => `${esc(k)}: ${esc(att[k])}`).join('<br>')
+    : '';
+  const attribRow = attribLines
+    ? `<tr><td style="padding:.4rem 0;color:#555;vertical-align:top;"><b>Attribution</b></td><td style="font-size:.82rem;color:#555;white-space:normal;">${attribLines}</td></tr>`
+    : '';
+
   return `<!DOCTYPE html>
 <html>
 <body style="font-family:Arial,sans-serif;background:#F9F6F0;padding:2rem;">
@@ -134,6 +144,7 @@ function buildLeadHtml(contact = {}, property) {
         <tr><td style="padding:.4rem 0;color:#555;"><b>Phone</b></td><td>${phone ? `<a href="tel:${telHref}">${phone}</a>` : '—'}</td></tr>
         <tr><td style="padding:.4rem 0;color:#555;vertical-align:top;"><b>Message</b></td><td style="white-space:pre-wrap;">${esc(contact.message) || '—'}</td></tr>
         <tr><td style="padding:.4rem 0;color:#555;"><b>Source</b></td><td>${esc(contact.source) || 'web'}</td></tr>
+        ${attribRow}
       </table>
       <div style="margin-top:1.5rem;">
         <a href="tel:${telHref}" style="background:#1B4332;color:#D4AF37;padding:.65rem 1.25rem;border-radius:6px;text-decoration:none;font-weight:700;margin-right:.5rem;">\u{1F4DE} Call Now</a>

--- a/app/index.html
+++ b/app/index.html
@@ -1660,6 +1660,34 @@ function jsArg(str) {
   return esc(JSON.stringify(String(str == null ? '' : str)));
 }
 
+// ---- FIRST-TOUCH ATTRIBUTION ----
+// Capture utm_*/referrer/landing ONCE on the visitor's first page view and
+// keep it in localStorage so it survives navigation to any form. Never
+// overwritten (first-touch). All failures are non-fatal (private mode etc.).
+(function captureFirstTouchAttribution() {
+  try {
+    var KEY = 'ml_attribution';
+    if (localStorage.getItem(KEY)) return; // first-touch: do not overwrite
+    var p = new URLSearchParams(location.search);
+    var att = {
+      utm_source:   p.get('utm_source')   || '',
+      utm_medium:   p.get('utm_medium')   || '',
+      utm_campaign: p.get('utm_campaign') || '',
+      utm_term:     p.get('utm_term')     || '',
+      utm_content:  p.get('utm_content')  || '',
+      referrer:     document.referrer || '',
+      landing_page: location.pathname + location.search,
+      landing_at:   new Date().toISOString()
+    };
+    localStorage.setItem(KEY, JSON.stringify(att));
+  } catch (_) { /* storage unavailable — attribution is best-effort */ }
+})();
+
+function getAttribution() {
+  try { return JSON.parse(localStorage.getItem('ml_attribution') || '{}'); }
+  catch (_) { return {}; }
+}
+
 // ---- FORM SUBMISSION ----
 async function submitForm(form, successId, errorId) {
   if (!form.checkValidity()) {
@@ -1668,6 +1696,7 @@ async function submitForm(form, successId, errorId) {
   }
   const data = {};
   new FormData(form).forEach((v, k) => data[k] = v);
+  data.attribution = getAttribution(); // first-touch marketing attribution
   const btn = form.querySelector('[type="submit"]');
   const btnLabel = btn ? btn.textContent : null;
   const errorEl = errorId ? document.getElementById(errorId) : null;
@@ -1953,7 +1982,7 @@ async function pmSend(propertyId, btn) {
   try {
     const r = await fetch('/api/contacts', {
       method: 'POST', headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({ property_id: propertyId, name, email, phone, message: msg, source: 'homepage_detail' })
+      body: JSON.stringify({ property_id: propertyId, name, email, phone, message: msg, source: 'homepage_detail', attribution: getAttribution() })
     });
     if (r.ok) {
       btn.textContent = "✅ Sent! Phil will be in touch.";
@@ -2124,7 +2153,7 @@ async function submitChatLead(btn) {
   try {
     const r = await fetch('/api/contacts', {
       method:'POST', headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ name, email, phone, message: 'Chat: ' + summary, source: 'website_chat' })
+      body: JSON.stringify({ name, email, phone, message: 'Chat: ' + summary, source: 'website_chat', attribution: getAttribution() })
     });
     if (!r.ok) throw new Error('HTTP ' + r.status);
   } catch(e) {

--- a/app/listing.js
+++ b/app/listing.js
@@ -2,6 +2,31 @@
 
 const API = '/api';
 
+// First-touch attribution (self-contained so a direct landing on a listing
+// page still captures it). Shares the `ml_attribution` localStorage key with
+// the homepage; first-touch — never overwritten. All failures are non-fatal.
+(function captureFirstTouchAttribution() {
+  try {
+    if (localStorage.getItem('ml_attribution')) return;
+    const p = new URLSearchParams(location.search);
+    localStorage.setItem('ml_attribution', JSON.stringify({
+      utm_source:   p.get('utm_source')   || '',
+      utm_medium:   p.get('utm_medium')   || '',
+      utm_campaign: p.get('utm_campaign') || '',
+      utm_term:     p.get('utm_term')     || '',
+      utm_content:  p.get('utm_content')  || '',
+      referrer:     document.referrer || '',
+      landing_page: location.pathname + location.search,
+      landing_at:   new Date().toISOString()
+    }));
+  } catch (_) { /* storage unavailable — attribution is best-effort */ }
+})();
+
+function getAttribution() {
+  try { return JSON.parse(localStorage.getItem('ml_attribution') || '{}'); }
+  catch (_) { return {}; }
+}
+
 function listingIdentifierFromPath() {
   const parts = window.location.pathname.replace(/\/+$/, '').split('/').filter(Boolean);
   const idx = parts.indexOf('listing');
@@ -137,7 +162,7 @@ async function submitContact(propertyId) {
   const res = await fetch(`${API}/contacts`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ property_id: propertyId, name, email, phone, message }),
+    body: JSON.stringify({ property_id: propertyId, name, email, phone, message, attribution: getAttribution() }),
   });
 
   if (!res.ok) {

--- a/app/start.html
+++ b/app/start.html
@@ -163,6 +163,24 @@
       var successPanel = document.getElementById('successPanel');
       var utm = { utm_source: document.getElementById('utm_source'), utm_medium: document.getElementById('utm_medium'), utm_campaign: document.getElementById('utm_campaign') };
       Object.keys(utm).forEach(function (k) { if (utm[k]) utm[k].value = params.get(k) || ''; });
+
+      // First-touch attribution (self-contained; shares the `ml_attribution`
+      // localStorage key with the homepage; never overwritten). Best-effort.
+      try {
+        if (!localStorage.getItem('ml_attribution')) {
+          localStorage.setItem('ml_attribution', JSON.stringify({
+            utm_source: params.get('utm_source') || '', utm_medium: params.get('utm_medium') || '',
+            utm_campaign: params.get('utm_campaign') || '', utm_term: params.get('utm_term') || '',
+            utm_content: params.get('utm_content') || '', referrer: document.referrer || '',
+            landing_page: location.pathname + location.search, landing_at: new Date().toISOString()
+          }));
+        }
+      } catch (_) { /* storage unavailable — attribution is best-effort */ }
+      function getAttribution() {
+        try { return JSON.parse(localStorage.getItem('ml_attribution') || '{}'); }
+        catch (_) { return {}; }
+      }
+
       if (!form) return;
 
       form.addEventListener('submit', async function (event) {
@@ -189,7 +207,8 @@
           source: 'buyers-guide',
           utm_source: form.utm_source.value,
           utm_medium: form.utm_medium.value,
-          utm_campaign: form.utm_campaign.value
+          utm_campaign: form.utm_campaign.value,
+          attribution: getAttribution()
         };
 
         try {

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -138,5 +138,5 @@ See `AGENTS.md` for full operating rules, forbidden actions, and workflow.
 - **Routes:** `/api/properties` and `/api/listings` are alias routes for the same handler. `/properties/:slug` and `/listing/:slug` are both active.
 - **Deploy:** Hostinger VPS (`31.97.58.203`) — Docker + Traefik via `api/Dockerfile`; **manual** deploy (merge ≠ deploy). See `docs/CANONICAL_MAP.md`. The old Railway twin is deleted and is not production proof.
 - **Smoke scripts:** `scripts/preflight.sh`, `scripts/smoke-admin.sh`, `scripts/smoke-prod.sh` (read-only), `scripts/check-env.sh`. For the lead capture→email path use the manual **`docs/SMOKE_CHECKLIST.md`** (it mutates prod: creates a row + sends a real email).
-- **Lead capture:** `/api/leads` is mounted; the Google Sheets adapter is local-safe when sheet credentials are absent
+- **Lead capture:** `/api/leads` is mounted; the Google Sheets adapter is local-safe when sheet credentials are absent. `/api/contacts` accepts sanitized first-touch attribution (`utm_*`, referrer, landing page/time), persists it as JSON in `contacts.attribution`, returns it from API-key `GET /api/contacts`, and includes it in the existing lead email body. This is repo-safe until manually deployed and live-smoked.
 - **CI:** `.github/workflows/preflight.yml` runs `preflight.sh` on all PRs and pushes to `main`.

--- a/tests/http-smoke.test.js
+++ b/tests/http-smoke.test.js
@@ -207,6 +207,12 @@ async function main() {
     });
 
     await test('POST /api/contacts stores a same-origin lead', async () => {
+      const attribution = {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        referrer: 'https://referrer.example/path',
+        landing_page: '/?utm_source=google&utm_medium=cpc',
+      };
       const res = await fetch(`${baseUrl}/api/contacts`, {
         method: 'POST',
         headers: {
@@ -219,11 +225,22 @@ async function main() {
           phone: '304-555-0101',
           message: 'HTTP smoke contact',
           source: 'http_smoke',
+          attribution,
         }),
       });
       assert.strictEqual(res.status, 201);
       const body = await json(res);
       assert(Number.isInteger(body.id), 'response should include integer lead id');
+
+      const list = await fetch(`${baseUrl}/api/contacts`, {
+        headers: { Authorization: 'Bearer http-smoke-api-key' },
+      });
+      assert.strictEqual(list.status, 200);
+      const contacts = await json(list);
+      const stored = contacts.find((contact) => contact.id === body.id);
+      assert(stored, 'stored lead should be present in API-key contacts list');
+      assert.strictEqual(stored.source, 'http_smoke');
+      assert.deepStrictEqual(JSON.parse(stored.attribution), attribution);
     });
 
     await test('POST /api/chat returns disabled-assistant fallback over HTTP', async () => {

--- a/tests/verify-security-fixes.test.js
+++ b/tests/verify-security-fixes.test.js
@@ -377,12 +377,42 @@ test('contacts route preserves submitted source tag', () => {
     'POST /contacts should read the submitted source from req.body.source');
   assert(/\bsource\s*=.*\.replace\(\s*\/\[\^a-zA-Z0-9_-\]\//s.test(routeBody),
     'POST /contacts should sanitize source before storing or emailing it');
-  assert(/INSERT INTO contacts\s*\(property_id,name,email,phone,message,source\)/.test(routeBody),
+  assert(/INSERT INTO contacts\s*\(property_id,name,email,phone,message,source,attribution\)/.test(routeBody),
     'POST /contacts should insert the submitted source into contacts.source');
-  assert(/\.run\([^)]*combinedMessage,\s*source\)/s.test(routeBody),
+  assert(/combinedMessage,\s*source,\s*attribution\b/s.test(routeBody),
     'POST /contacts should pass the submitted source variable into the INSERT run call');
   assert(/combinedMessage/.test(routeBody) && /Interest:/.test(routeBody),
     'POST /contacts should preserve submitted interest in the saved contact message');
+});
+
+test('contacts route captures, sanitizes, persists and forwards lead attribution', () => {
+  const routeStart = apiRoutesCode.indexOf("router.post('/contacts'");
+  assert(routeStart !== -1, 'POST /contacts route not found in routes/api.js');
+  const routeEnd = apiRoutesCode.indexOf("\nrouter.get('/contacts'", routeStart);
+  const routeBody = apiRoutesCode.slice(routeStart, routeEnd);
+
+  // Reads + sanitizes the client-supplied attribution object
+  assert(/sanitizeAttribution\(\s*req\.body\.attribution\s*\)/.test(routeBody),
+    'POST /contacts should sanitize req.body.attribution');
+  // Persists it as the new contacts.attribution column (JSON or null)
+  assert(/attribution\s*\?\s*JSON\.stringify\(attribution\)\s*:\s*null/.test(routeBody),
+    'POST /contacts should store attribution as JSON (or null) in the INSERT');
+  // Forwards it through the existing lead notification path
+  assert(/sendLeadNotification\(\s*\{[^}]*\battribution\b[^}]*\}/s.test(routeBody),
+    'POST /contacts should pass attribution into sendLeadNotification');
+
+  // sanitizeAttribution allow-lists known keys and caps length (defensive)
+  const sanStart = apiRoutesCode.indexOf('function sanitizeAttribution');
+  assert(sanStart !== -1, 'sanitizeAttribution helper not found in routes/api.js');
+  const sanBody = apiRoutesCode.slice(sanStart, sanStart + 600);
+  ['utm_source', 'utm_medium', 'utm_campaign', 'referrer', 'landing_page'].forEach((k) => {
+    assert(new RegExp(`'${k}'`).test(apiRoutesCode.slice(0, sanStart + 600)),
+      `attribution allow-list should include ${k}`);
+  });
+  assert(/\.slice\(0,\s*300\)/.test(sanBody),
+    'sanitizeAttribution should cap each value length');
+  assert(/Array\.isArray\(raw\)/.test(sanBody),
+    'sanitizeAttribution should reject array payloads');
 });
 
 test('lead routes are mounted behind server-side origin and JSON guards', () => {


### PR DESCRIPTION
## Summary\n- Capture first-touch attribution on homepage, listing detail, and /start entry points using the shared ml_attribution localStorage key\n- Include attribution in every known public /api/contacts POST path: shared homepage forms, property modal, chat lead, listing detail form, and buyer-guide form\n- Sanitize, persist, expose via protected GET /api/contacts, and include escaped attribution in the existing lead email body\n- Add/expand security and HTTP smoke coverage for attribution persistence and notification pass-through\n\n## Verification\n- cd api && npm ci -> pass\n- cd api && npm audit -> 0 vulnerabilities\n- node --check api/db.js && node --check api/routes/api.js && node --check api/services/email.js && node --check app/listing.js -> pass\n- node --check tests/http-smoke.test.js -> pass\n- node tests/verify-security-fixes.test.js -> 59/59 pass\n- node tests/http-smoke.test.js -> 11/11 pass, including attribution persistence/retrieval\n- node tests/email.test.js -> 10 pass\n- node tests/lead-notifications.test.js -> 6 pass\n- node tests/public-assistant-flag.test.js -> 7 pass\n- node tests/admin-document-review.test.js -> 9 pass\n- node tests/ai-generator-routing.test.js -> 18 pass\n- node tests/chat-assistant.test.js -> 14 pass\n- node tests/document-registry.test.js -> 28 pass\n- cd api && npm test -> Syntax OK\n- bash scripts/preflight.sh -> PRE-FLIGHT PASSED\n- git diff --check -> pass\n\n## Deployment\nNot deployed. No VPS SSH, live DB mutation, live email, DNS, Vercel, Cloudflare Worker, Resend transport, or /listings behavior changes were performed. Production still requires manual owner-approved VPS deploy and mutating lead-pipeline smoke from docs/SMOKE_CHECKLIST.md.

## Summary by Sourcery

Capture and persist first-touch lead attribution across public contact entry points and surface it through the contacts API and notification emails.

New Features:
- Add client-side first-touch marketing attribution capture on homepage, listing detail, and buyer-guide entry points using a shared localStorage key.
- Include attribution payloads in all public `/api/contacts` POST lead sources and expose stored attribution in the protected contacts listing and lead emails.

Enhancements:
- Introduce a sanitized JSON attribution field on the contacts schema and forward it through the existing lead notification pipeline.
- Expand HTTP smoke and security verification tests to cover attribution sanitization, persistence, and retrieval, and update project docs and tasks to describe the new lead attribution behavior.

Documentation:
- Update agent handoff documentation and TASKS checklist to document the new first-touch attribution behavior for `/api/contacts` and its deployment safety.

Tests:
- Extend verify-security-fixes and HTTP smoke tests to assert attribution handling in the contacts route and API-key listing responses.