### PR TITLE
feat(assistant): public-assistant cost flag, homepage XSS hardening, nav aliases + doc alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,15 @@ secrets/
 # Build output
 dist/
 
+# Stray root lockfile — the real npm project lives in api/ (api/package-lock.json)
+/package-lock.json
+
+# Local-only Docker Compose override (machine-specific uid, localhost bind).
+# Docker auto-merges this file; keeping it out of git prevents it from
+# reaching the Traefik-fronted VPS and breaking production networking.
+compose.override.yml
+docker-compose.override.yml
+
 # Local agent/worktree state
 .claude/worktrees/
 .claire/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,26 +274,42 @@ Every agent session that makes changes must append an entry to `WORK_LOG.md`. Th
 
 ## External Assistant / Codex Handoff Protocol
 
-Codex (and any external reviewer that cannot attach to the Cursor account) gets all context **through the repository**, not through Cursor session state:
+Codex is the independent gatekeeper. GitHub and the live VPS state are the only final sources of truth.
+Claude (or any other implementing agent) **may not** call a PR "ready" based on its own summary. Ready means Codex has verified the live GitHub state and deployment state independently.
 
-- Paste relevant Cursor/agent output directly into the external assistant's chat when needed.
-- Share or attach the files the implementing agent created or changed.
-- Point the assistant at the same GitHub repo and branch so it can inspect committed or uncommitted changes locally. The canonical local checkout and remote are recorded in `PROJECT_STATE.md` and `docs/CANONICAL_MAP.md`.
-- Keep plans, rules, and decisions in tracked files (`.cursor/rules/`, `docs/`, and the root `*.md` coordination docs) so they survive across assistants — see the Repository Authority Rule above for which file owns which state.
+### Claude Handoff Format
+When an implementing agent completes work, hand off using this exact format:
 
-Every time an implementing agent finishes a chunk of work, hand off:
+```text
+CLAUDE HANDOFF
+PR: <url or number>
+Head SHA: <sha>
+What changed: <brief description>
+What was tested: <tests run>
+Known unresolved: <known issues/threads>
+Do not claim ready until Codex verifies:
+- gh pr view
+- gh pr checks
+- reviewThreads unresolved=0
+- VPS SHA unchanged unless deploy approved
+```
 
-- The **branch** worked on (`git branch --show-current`).
-- The **files touched** (`git status` / `git diff --name-only`).
-- **What changed and why** (link the relevant `*.md` doc or commit message).
+### Codex Verification Response
+Codex will independently verify against GitHub/VPS and reply **only** with this format:
 
-Quick commands to copy/paste for a handoff:
+```text
+VERDICT:
+READY / NOT READY
 
-```bash
-git branch --show-current        # current branch
-git status                       # uncommitted changes
-git diff --name-only             # changed file paths
-git log --oneline -10            # recent commits
+Blocking facts:
+- <list any blocking issues, failing checks, unresolved threads>
+
+Verified:
+- checks
+- threads
+- merge state
+- head SHA
+- VPS SHA
 ```
 
 ---

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Copyright (c) 2026 MalickLand Real Estate. All rights reserved.
+
+This software contains business-specific workflows, integrations, operational
+logic, and real estate tooling.
+
+No permission is granted to copy, redistribute, modify, sublicense, publish,
+host, deploy, or otherwise use this code without prior written permission from
+MalickLand Real Estate.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,24 @@ West Virginia real estate listing platform. Admin panel, public listing pages, p
 | Auth | Session-based (admin panel) + API key (REST) |
 | Images | Local disk + Google Drive backup |
 | Email | Gmail API via OAuth2 |
-| AI | OpenAI GPT-4o (listing content generation) |
+| AI | Vercel AI Gateway / Anthropic / OpenAI (listing content generation) |
 | Deploy | Railway (Docker) |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+  visitor[Visitor] --> publicPages[Public listing pages]
+  admin[Admin] --> adminPanel[Admin panel]
+  publicPages --> api[Express API]
+  adminPanel --> api
+  api --> db[(SQLite database)]
+  api --> ai[AI content generator]
+  api --> drive[Google Drive backup]
+  api --> gmail[Gmail notifications]
+```
 
 ---
 
@@ -30,7 +46,7 @@ wv-property-intelligence/
 │   ├── db.js               ← SQLite connection, schema, migrations, seeding
 │   ├── helpers.js          ← Shared utilities (esc, slugify, etc.)
 │   ├── google.js           ← Gmail + Drive integration (no SDK)
-│   ├── ai-generator.js     ← OpenAI listing content engine
+│   ├── ai-generator.js     ← AI listing content engine (Gateway / Anthropic / OpenAI)
 │   ├── db-migrate-ai.js    ← One-time migration script (ai_content columns)
 │   ├── middleware/
 │   │   ├── auth.js         ← requireAuth, requireCsrf, requireApiKey
@@ -75,6 +91,11 @@ npm run dev               # nodemon server.js
 Server: `http://localhost:3001`
 Admin: `http://localhost:3001/admin` (password from `ADMIN_PASSWORD` env)
 
+For local review, start with `SESSION_SECRET` and `ADMIN_PASSWORD`, then add
+optional Google, Gmail, and AI provider credentials only for the integrations you are
+actively testing. The local SQLite database and local file storage are enough to
+exercise the core listing/admin flow.
+
 ### Local dev (with Docker)
 
 ```bash
@@ -94,7 +115,7 @@ Required to run:
 Optional integrations:
 - **Gmail notifications:** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN`, `GOOGLE_GMAIL_USER`, `NOTIFICATION_EMAIL`
 - **Drive photo backup:** `GOOGLE_DRIVE_FOLDER_ID`
-- **AI content generation:** `OPENAI_API_KEY` (optional `OPENAI_MODEL`)
+- **AI content generation:** one of (in precedence order) `AI_GATEWAY_API_KEY` → `ANTHROPIC_API_KEY` → `OPENAI_API_KEY`, each with an optional model override
 - **REST API auth:** `API_KEY`
 
 ---
@@ -141,9 +162,11 @@ All require session auth (`/admin/login`).
 
 ## AI Listing Machine
 
-With `OPENAI_API_KEY` set, every listing gets a full marketing package via OpenAI.
-Default model is `gpt-4o` (override with `OPENAI_MODEL`), with automatic fallback to `gpt-4o-mini` when account access is limited:
-MLS description, investor pitch, Facebook ad, Instagram caption, video script, email blast, SMS, landing page copy.
+With an AI provider key set, every listing gets a full marketing package. The generator
+resolves one provider in precedence order — **Vercel AI Gateway** (`AI_GATEWAY_API_KEY`),
+then **direct Anthropic** (`ANTHROPIC_API_KEY`), then **direct OpenAI** (`OPENAI_API_KEY`) —
+each with its own default model and an optional override (see [`api/.env.example`](api/.env.example)).
+Output: MLS description, investor pitch, Facebook ad, Instagram caption, video script, email blast, SMS, landing page copy.
 
 Cost: ~$0.01–0.03 per listing. Access via **Admin → AI** button on any listing.
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -599,3 +599,35 @@ button 404'd in production. Implemented option (A): a public, rate-limited, same
 
 ### Recommended Next Task
 - Phil: review/approve the PR; if approved and merged, set `AI_GATEWAY_API_KEY` in Railway and smoke `POST /api/chat` on production with a same-origin request.
+
+---
+
+## 2026-06-14 — Codex
+
+### Objective
+Finish the repo-side follow-up for the public assistant cost-control flag and direct Anthropic configuration guidance, without touching Railway secrets or production deployment.
+
+### Changes Made
+- `api/routes/admin.js` — updated admin AI disabled-state copy, button tooltip, and POST error message to mention `ANTHROPIC_API_KEY` alongside `AI_GATEWAY_API_KEY` and `OPENAI_API_KEY`.
+- `api/routes/chat.js` — updated the safe-by-default route comment to include the direct Anthropic provider path.
+- `scripts/preflight.sh` — added the `tests/public-assistant-flag.test.js` regression to the preflight gate so CI proves `PUBLIC_ASSISTANT_ENABLED=false` returns the canned reply without calling the AI provider.
+
+### Verification (Truthfulness Rule applies)
+- Command: `cd api && npm ci` -> PASSED (added 177 packages, audited 178, found 0 vulnerabilities).
+- Command: `node --check server.js && node --check middleware/auth.js && node --check routes/admin.js && node --check routes/api.js && node --check routes/public.js` -> PASSED.
+- Command: `node tests/ai-generator-routing.test.js` -> PASSED (18/18).
+- Command: `node tests/chat-assistant.test.js` -> PASSED (14/14).
+- Command: `node tests/public-assistant-flag.test.js` -> PASSED (3/3).
+- Command: `node tests/verify-security-fixes.test.js` -> PASSED (52/52).
+- Command: `bash scripts/preflight.sh` -> PASSED, including the new public assistant flag regression and `/api/chat` no-key fallback smoke.
+- Command: `git diff --check` -> PASSED.
+
+### Security Notes
+- No secrets read, printed, committed, or modified.
+- No Railway variables, production deployment, production data, or schema changed.
+- The Railway env swap remains a human/owner secret action: remove the broken `AI_GATEWAY_API_KEY` path and set `ANTHROPIC_API_KEY` directly in Railway.
+
+### Remaining Risks / Requires Human Decision
+1. **Railway env swap** — still required to unblock the live 502 if production is currently selecting the broken gateway provider. Codex did not alter production secrets.
+2. **Merge/deploy** — branch `feat/listings-feature-flag` remains unmerged; per AGENTS.md, Phil approves merge and Railway deployment.
+3. **Untracked root lockfile** — `package-lock.json` exists at repo root and was left untouched; the canonical lockfile is `api/package-lock.json`.

--- a/api/featureFlags.js
+++ b/api/featureFlags.js
@@ -18,4 +18,19 @@ function publicListingsEnabled() {
   return v !== 'false';
 }
 
-module.exports = { publicListingsEnabled };
+// ─────────────────────────────────────────────────────────────
+// Public homepage AI assistant ("MalickLand Assistant" chat widget).
+// Default ON to preserve current behavior. Turn OFF to stop the
+// public bot from making any paid AI calls — the widget then returns
+// its built-in canned reply (no LLM spend on anonymous visitors).
+// The admin AI listing generator is unaffected either way.
+//
+//   • set env  PUBLIC_ASSISTANT_ENABLED=false   to disable (no code change)
+// ─────────────────────────────────────────────────────────────
+function publicAssistantEnabled() {
+  const v = process.env.PUBLIC_ASSISTANT_ENABLED;
+  if (v === undefined || v === '') return true; // default: ON
+  return v !== 'false';
+}
+
+module.exports = { publicListingsEnabled, publicAssistantEnabled };

--- a/api/featureFlags.js
+++ b/api/featureFlags.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// ─────────────────────────────────────────────────────────────
+// TEMPORARY: public property listings are hidden from the site
+// until the inventory is cleaned up.
+//
+// To RESTORE listings later, either:
+//   • set env  PUBLIC_LISTINGS_ENABLED=true   (no code change), or
+//   • change the default below back to `return true`.
+//
+// When off: the homepage Featured/County sections + nav/footer
+// links are hidden, /listings + /wv/* + /listing/* redirect home,
+// and /api/listings returns empty. No listing data is deleted.
+// ─────────────────────────────────────────────────────────────
+function publicListingsEnabled() {
+  const v = process.env.PUBLIC_LISTINGS_ENABLED;
+  if (v === undefined || v === '') return false; // default: OFF for now
+  return v !== 'false';
+}
+
+module.exports = { publicListingsEnabled };

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -528,12 +528,12 @@ router.get('/ai/:id', requireAuth, adminActionRateLimit, (req, res) => {
       <a href="/admin" class="btn-outline">← Back</a>
     </div>
     ${!aiOk ? `<div style="background:#fff3cd;color:#856404;padding:1rem;border-radius:8px;margin-bottom:1.5rem">
-      ⚠️ <strong>AI is not configured.</strong> Set <code>AI_GATEWAY_API_KEY</code> (preferred) or <code>OPENAI_API_KEY</code> to enable AI generation.
+      ⚠️ <strong>AI is not configured.</strong> Set <code>ANTHROPIC_API_KEY</code> (recommended) — or <code>AI_GATEWAY_API_KEY</code> / <code>OPENAI_API_KEY</code> — to enable AI generation.
     </div>` : ''}
     <div style="display:flex;gap:1rem;align-items:center;margin-bottom:1.5rem;flex-wrap:wrap">
       <form method="POST" action="/admin/ai/${esc(p.id)}" style="margin:0">
         <input type="hidden" name="_csrf" value="${esc(csrfToken(req))}" />
-        <button type="submit" class="btn" ${!aiOk ? 'disabled title="Set AI_GATEWAY_API_KEY or OPENAI_API_KEY first"' : ''}>
+        <button type="submit" class="btn" ${!aiOk ? 'disabled title="Set ANTHROPIC_API_KEY, AI_GATEWAY_API_KEY, or OPENAI_API_KEY first"' : ''}>
           ${content ? '🔄 Regenerate' : '✨ Generate Now'}
         </button>
       </form>
@@ -571,7 +571,7 @@ router.post('/ai/:id', requireAuth, requireCsrf, adminActionRateLimit, async (re
   `).get(req.params.id);
   if (!p) return res.redirect('/admin');
   if (!aiConfigured())
-    return res.status(400).send('AI not configured (set AI_GATEWAY_API_KEY or OPENAI_API_KEY)');
+    return res.status(400).send('AI not configured (set ANTHROPIC_API_KEY, AI_GATEWAY_API_KEY, or OPENAI_API_KEY)');
 
   try {
     await generateListingContent(p, db);

--- a/api/routes/api.js
+++ b/api/routes/api.js
@@ -8,6 +8,7 @@ const { requireApiKey }   = require('../middleware/auth');
 const { contactsRateLimit, publicReadRateLimit, generateDescRateLimit, apiWriteRateLimit } = require('../middleware/rate-limits');
 const { sendContactEmail } = require('../google');
 const { isValidEmail, normalizeAcreage, slugify, VALID_PROP_TYPES, VALID_PROP_STATUSES } = require('../helpers');
+const { publicListingsEnabled } = require('../featureFlags');
 
 const router = express.Router();
 
@@ -19,6 +20,7 @@ router.get('/config', (_req, res) => {
   res.json({
     gaId:    process.env.GA_MEASUREMENT_ID  || null,
     pixelId: process.env.META_PIXEL_ID      || null,
+    listingsEnabled: publicListingsEnabled(),
   });
 });
 
@@ -29,6 +31,7 @@ router.get('/counties', publicReadRateLimit, (_req, res) => {
 
 // ── Properties ────────────────────────────────────────────
 function sendPropertyList(req, res) {
+  if (!publicListingsEnabled()) return res.json({ total: 0, page: 1, properties: [] });
   try {
     const { q='', county='', type='', minPrice='', maxPrice='', page=1, limit=12 } = req.query;
     const conditions = ["p.status = 'active'"];
@@ -54,6 +57,7 @@ function sendPropertyList(req, res) {
 }
 
 function sendPropertyDetail(req, res) {
+  if (!publicListingsEnabled()) return res.status(404).json({ error: 'Not found' });
   const row = db.prepare(`
     SELECT p.id, p.listing_slug, p.address, p.city, p.zip, p.price, p.property_type,
            p.bedrooms, p.bathrooms, p.sqft, p.acreage AS lot_acres,

--- a/api/routes/chat.js
+++ b/api/routes/chat.js
@@ -12,10 +12,10 @@
  *     turn count / length,
  *   - a server-injected brokerage-safe system prompt the client cannot override.
  *
- * Safe-by-default: if no AI provider is configured (no AI_GATEWAY_API_KEY /
- * OPENAI_API_KEY), or the upstream call fails, it returns a friendly canned
- * reply instead of crashing or 500-ing — main auto-deploys to Railway, so this
- * must never take the site down when the key is absent.
+ * Safe-by-default: if no AI provider is configured (AI_GATEWAY_API_KEY /
+ * ANTHROPIC_API_KEY / OPENAI_API_KEY), or the upstream call fails, it returns a
+ * friendly canned reply instead of crashing or 500-ing — main auto-deploys to
+ * Railway, so this must never take the site down when the key is absent.
  *
  * Contract (matches app/index.html sendChatMsg):
  *   Request:  { messages: [{ role: 'user'|'assistant', content: string }, ...] }
@@ -26,6 +26,7 @@ const express = require('express');
 
 const { chatRateLimit } = require('../middleware/rate-limits');
 const { generateChatReply, aiConfigured } = require('../ai-generator');
+const { publicAssistantEnabled } = require('../featureFlags');
 const {
   buildChatSystemPrompt,
   sanitizeChatMessages,
@@ -40,6 +41,13 @@ function createChatRouter() {
 
     if (!messages.length || !messages.some((m) => m.role === 'user')) {
       return res.status(400).json({ error: 'A user message is required.' });
+    }
+
+    // Public assistant disabled (PUBLIC_ASSISTANT_ENABLED=false) → return the
+    // canned reply without calling any AI provider. Zero LLM spend on anonymous
+    // visitors; the admin listing generator is unaffected.
+    if (!publicAssistantEnabled()) {
+      return res.json({ reply: FALLBACK_REPLY });
     }
 
     // No provider configured → degrade gracefully (steady state until the key

--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -7,6 +7,7 @@ const fs      = require('fs');
 const { db }           = require('../db');
 const { PROJECT_ROOT, esc } = require('../helpers');
 const { publicReadRateLimit } = require('../middleware/rate-limits');
+const { publicListingsEnabled } = require('../featureFlags');
 
 const router = express.Router();
 const HOMEPAGE_DISCLOSURE = 'WV Real Estate Agency, LLC | Sheila Judy, Broker | 501 East Main Street, Romney, WV 26757 | (540) 246-1421';
@@ -46,7 +47,7 @@ router.get('/sitemap.xml', publicReadRateLimit, (_req, res) => {
   ];
 
   let propertyPages = [];
-  try {
+  if (publicListingsEnabled()) try {
     const props = db.prepare(
       "SELECT listing_slug, id, updated_at FROM properties WHERE status = 'active'"
     ).all();
@@ -60,7 +61,7 @@ router.get('/sitemap.xml', publicReadRateLimit, (_req, res) => {
 
   // County landing pages — only counties with active listings (avoids thin-content pages).
   let countyPages = [];
-  try {
+  if (publicListingsEnabled()) try {
     const counties = db.prepare(
       "SELECT DISTINCT c.name FROM counties c JOIN properties p ON p.county_id = c.id WHERE p.status = 'active'"
     ).all();
@@ -93,6 +94,9 @@ router.get('/', publicReadRateLimit, (_req, res, next) => {
   try {
     const indexHtml = path.join(PROJECT_ROOT, 'app', 'index.html');
     let html = fs.readFileSync(indexHtml, 'utf8');
+    if (!publicListingsEnabled()) {
+      html = html.replace('<html lang="en">', '<html lang="en" class="listings-off">');
+    }
 
     html = replaceHomepageContent(
       html,
@@ -127,6 +131,7 @@ router.get('/', publicReadRateLimit, (_req, res, next) => {
 });
 
 router.get(['/listing/:id', '/properties/:id'], publicReadRateLimit, (_req, res) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
   const listingHtml = path.join(PROJECT_ROOT, 'app', 'listing.html');
   const indexHtml   = path.join(PROJECT_ROOT, 'app', 'index.html');
   res.sendFile(fs.existsSync(listingHtml) ? listingHtml : indexHtml);
@@ -139,6 +144,7 @@ router.get('/advent-drive-land-hampshire-county-wv', publicReadRateLimit, (_req,
 // County landing pages: /wv/<county>-county → server-rendered page listing that county's
 // active properties. Slug is validated against the counties table; unknown → 404 handler.
 router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
   const name = String(req.params.slug || '')
     .toLowerCase()
     .replace(/-county$/, '')
@@ -160,6 +166,13 @@ router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {
   } catch (err) {
     next(err);
   }
+});
+
+// Public listings search page (/listings → static app/listings.html when enabled).
+// Hidden while listings are disabled.
+router.get('/listings', publicReadRateLimit, (_req, res, next) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
+  next();
 });
 
 module.exports = router;

--- a/api/routes/public.js
+++ b/api/routes/public.js
@@ -141,6 +141,21 @@ router.get('/advent-drive-land-hampshire-county-wv', publicReadRateLimit, (_req,
   res.redirect(301, '/37-advent');
 });
 
+router.get('/contact', publicReadRateLimit, (_req, res) => {
+  res.redirect(302, '/#contact-form');
+});
+
+router.get('/about', publicReadRateLimit, (_req, res) => {
+  res.redirect(302, '/#about');
+});
+
+router.get('/search', publicReadRateLimit, (req, res) => {
+  if (!publicListingsEnabled()) return res.redirect(302, '/');
+  const queryStart = req.originalUrl.indexOf('?');
+  const query = queryStart === -1 ? '' : req.originalUrl.slice(queryStart);
+  return res.redirect(302, `/listings${query}`);
+});
+
 // County landing pages: /wv/<county>-county → server-rendered page listing that county's
 // active properties. Slug is validated against the counties table; unknown → 404 handler.
 router.get('/wv/:slug', publicReadRateLimit, (req, res, next) => {

--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <style>html.listings-off #listings,html.listings-off #countyBrowse,html.listings-off a[href="/listings"],html.listings-off a[href="#listings"],html.listings-off a[href^="/wv/"]{display:none!important}</style>
+  <style>html.listings-off #listings,html.listings-off #countyBrowse,html.listings-off a[href="/listings"],html.listings-off a[href="#listings"],html.listings-off a[href^="/wv/"],html.listings-off a[href="/37-advent"]{display:none!important}</style>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MalickLand | West Virginia Land, Homes & Property</title>
   <meta name="description" content="Find land, homes, farms, and rural property across all 55 West Virginia counties. AI-assisted property research, local expertise, responsive guidance." />

--- a/app/index.html
+++ b/app/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <style>html.listings-off #listings,html.listings-off #countyBrowse,html.listings-off a[href="/listings"],html.listings-off a[href="#listings"],html.listings-off a[href^="/wv/"]{display:none!important}</style>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MalickLand | West Virginia Land, Homes & Property</title>
   <meta name="description" content="Find land, homes, farms, and rural property across all 55 West Virginia counties. AI-assisted property research, local expertise, responsive guidance." />
@@ -15,6 +16,7 @@
   <!-- Analytics + Meta Pixel — loaded from /api/config (GA_MEASUREMENT_ID, META_PIXEL_ID) -->
   <script>
     fetch('/api/config').then(r=>r.json()).then(cfg=>{
+      if (cfg.listingsEnabled === false) document.documentElement.classList.add('listings-off');
       // Google Analytics 4
       if (cfg.gaId) {
         var s = document.createElement('script');
@@ -1290,7 +1292,7 @@
 </section>
 
 <!-- COUNTY LINKS -->
-<section style="background:#f9f6f0;padding:1.5rem 2rem;border-top:1px solid #e5e7eb">
+<section id="countyBrowse" style="background:#f9f6f0;padding:1.5rem 2rem;border-top:1px solid #e5e7eb">
   <div style="max-width:1200px;margin:0 auto">
     <p style="text-align:center;font-size:.8rem;color:#6b7280;margin-bottom:.85rem;text-transform:uppercase;letter-spacing:.5px;font-weight:600">Browse by County</p>
     <div style="display:flex;flex-wrap:wrap;gap:.5rem;justify-content:center">

--- a/app/index.html
+++ b/app/index.html
@@ -1529,6 +1529,21 @@ document.getElementById('leadModal').addEventListener('click', function(e) {
   if (e.target === this) closeModal();
 });
 
+// ---- HTML SAFETY ----
+function esc(str) {
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function jsArg(str) {
+  return esc(JSON.stringify(String(str == null ? '' : str)));
+}
+
 // ---- FORM SUBMISSION ----
 async function submitForm(form, successId) {
   const data = {};
@@ -1572,7 +1587,7 @@ function featureBadges(featStr) {
   if (!badges.length) return '';
   return `<div class="card-features">${badges.map(f => {
     const icon = Object.entries(FEATURE_ICONS).find(([k]) => f.toLowerCase().includes(k.toLowerCase()));
-    return `<span class="card-feat">${icon ? icon[1]+' ' : ''}${f}</span>`;
+    return `<span class="card-feat">${icon ? icon[1]+' ' : ''}${esc(f)}</span>`;
   }).join('')}</div>`;
 }
 
@@ -1597,35 +1612,41 @@ async function loadListings() {
     }
     grid.innerHTML = props.slice(0, 6).map(p => {
       const isLand = p.property_type === 'land';
+      const address = esc(p.address);
+      const city = esc(p.city);
+      const county = esc(p.county);
       const imgHtml = p.image_url
-        ? `<img src="${p.image_url}" alt="${p.address}" loading="lazy" />`
+        ? `<img src="${esc(p.image_url)}" alt="${address}" loading="lazy" />`
         : `<span style="font-size:3.5rem">${isLand ? '🌲' : '🏡'}</span>`;
       const price = p.price ? `$${Number(p.price).toLocaleString()}` : 'Contact for Price';
       // Land: acreage first; Home: beds/sqft first
       let primaryDetail = '';
       let secondaryLine = '';
       if (isLand) {
-        primaryDetail = p.lot_acres ? `<strong>${p.lot_acres} acres</strong>` : '';
+        primaryDetail = p.lot_acres ? `<strong>${esc(p.lot_acres)} acres</strong>` : '';
         if (p.price && p.lot_acres) secondaryLine = `<div class="card-ppa">$${Math.round(p.price/p.lot_acres).toLocaleString()}/acre</div>`;
       } else {
-        primaryDetail = [p.bedrooms ? `${p.bedrooms} bd` : '', p.bathrooms ? `${p.bathrooms} ba` : '', p.sqft ? `${Number(p.sqft).toLocaleString()} sqft` : ''].filter(Boolean).join(' · ');
+        primaryDetail = [
+          p.bedrooms ? `${esc(p.bedrooms)} bd` : '',
+          p.bathrooms ? `${esc(p.bathrooms)} ba` : '',
+          p.sqft ? `${Number(p.sqft).toLocaleString()} sqft` : ''
+        ].filter(Boolean).join(' · ');
       }
-      const detailSlug = p.listing_slug || p.id;
       return `
       <div class="card">
         <div class="card-img">
           ${imgHtml}
-          <span class="card-county">${p.county || ''} County</span>
+          <span class="card-county">${county} County</span>
         </div>
         <div class="card-body">
-          <div class="card-type">${isLand ? '🌲 Land' : '🏡 '+((p.property_type||'Home').replace(/-/g,' '))}</div>
-          <div class="card-address">${p.address}${p.city ? ', ' + p.city : ''}</div>
-          <div class="card-price">${price}</div>
+          <div class="card-type">${isLand ? '🌲 Land' : '🏡 '+esc((p.property_type||'Home').replace(/-/g,' '))}</div>
+          <div class="card-address">${address}${city ? ', ' + city : ''}</div>
+          <div class="card-price">${esc(price)}</div>
           ${primaryDetail ? `<div class="card-details">${primaryDetail}</div>` : ''}
           ${secondaryLine}
           ${featureBadges(p.features)}
-          ${p.driveTimes ? `<div style="font-size:.75rem;color:#6b7280;margin-bottom:.6rem">🚗 ${p.driveTimes.dc} to DC · ${p.driveTimes.balt} to Baltimore</div>` : ''}
-          <a href="#" class="card-btn" onclick="event.preventDefault();showPropertyModal('${p.id}')">View Details →</a>
+          ${p.driveTimes ? `<div style="font-size:.75rem;color:#6b7280;margin-bottom:.6rem">🚗 ${esc(p.driveTimes.dc)} to DC · ${esc(p.driveTimes.balt)} to Baltimore</div>` : ''}
+          <a href="#" class="card-btn" onclick="event.preventDefault();showPropertyModal(${jsArg(p.id)})">View Details →</a>
         </div>
       </div>`;
     }).join('');
@@ -1649,53 +1670,72 @@ async function showPropertyModal(id) {
   overlay.style.display = 'flex';
 
   try {
-    const p = await fetch(`/api/properties/${id}`).then(r => r.json());
+    const p = await fetch(`/api/properties/${encodeURIComponent(id)}`).then(r => r.json());
     pixelEvent('ViewContent', { content_type: 'property', content_ids: [id], value: p.price, currency: 'USD' });
     if (window.gtag) gtag('event', 'view_item', { item_id: id, price: p.price });
     const addr = encodeURIComponent(`${p.address}${p.city?', '+p.city:''}, WV${p.zip?' '+p.zip:''}`);
     const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${addr}`;
     const satUrl  = `https://www.google.com/maps/@?api=1&map_action=map&basemap=satellite&q=${addr}`;
+    const address = esc(p.address);
+    const city = esc(p.city);
+    const county = esc(p.county);
+    const zip = esc(p.zip);
+    const propertyType = esc(p.property_type);
+    const description = esc(p.description);
+    const lotAcres = esc(p.lot_acres);
+    const bedrooms = esc(p.bedrooms);
+    const bathrooms = esc(p.bathrooms);
+    const yearBuilt = esc(p.year_built);
+    const roadAccess = esc(p.road_access);
+    const broadbandType = esc(p.broadband_type);
+    const waterFeatures = esc(p.water_features);
+    const mineralRights = esc(p.mineral_rights);
+    const nearestTown = esc(p.nearest_town);
+    const milesToTown = esc(p.miles_to_town);
+    const parcelId = esc(p.parcel_id);
+    const listingSlug = esc(p.listing_slug);
+    const price = p.price ? `$${Number(p.price).toLocaleString()}` : 'Contact for Price';
     overlay.innerHTML = `
       <div style="background:#fff;border-radius:14px;max-width:680px;width:100%;max-height:90vh;overflow-y:auto;position:relative;">
         <button onclick="document.getElementById('propModal').style.display='none'"
           style="position:absolute;top:.75rem;right:.75rem;background:#1B4332;color:#fff;border:none;border-radius:50%;width:32px;height:32px;font-size:1rem;cursor:pointer;z-index:1">✕</button>
-        ${p.image_url ? `<img src="${p.image_url}" alt="${p.address}" style="width:100%;max-height:300px;object-fit:cover;border-radius:14px 14px 0 0">` : ''}
+        ${p.image_url ? `<img src="${esc(p.image_url)}" alt="${address}" style="width:100%;max-height:300px;object-fit:cover;border-radius:14px 14px 0 0">` : ''}
         <div style="padding:1.5rem">
-          <h2 style="font-size:1.9rem;font-weight:900;color:#0a0a0a;margin-bottom:.25rem">$${Number(p.price).toLocaleString()}</h2>
-          <p style="color:#555;margin-bottom:.75rem">${p.address}${p.city?', '+p.city:''}, ${p.county} County${p.zip?' '+p.zip:''}</p>
+          <h2 style="font-size:1.9rem;font-weight:900;color:#0a0a0a;margin-bottom:.25rem">${esc(price)}</h2>
+          <p style="color:#555;margin-bottom:.75rem">${address}${city?', '+city:''}, ${county} County${zip?' '+zip:''}</p>
           <div style="display:flex;flex-wrap:wrap;gap:.6rem;margin-bottom:.9rem">
-            <span style="background:#1B4332;color:#D4AF37;padding:.35rem .75rem;border-radius:6px;font-size:.82rem;font-weight:700">${p.property_type==='land'?'🌲 Land':'🏡 '+p.property_type}</span>
-            ${p.lot_acres ? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem;font-weight:700">🌿 ${p.lot_acres} acres</span>`:''}
+            <span style="background:#1B4332;color:#D4AF37;padding:.35rem .75rem;border-radius:6px;font-size:.82rem;font-weight:700">${p.property_type==='land'?'🌲 Land':'🏡 '+propertyType}</span>
+            ${p.lot_acres ? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem;font-weight:700">🌿 ${lotAcres} acres</span>`:''}
             ${p.price && p.lot_acres ? `<span style="background:#f9f6f0;padding:.35rem .75rem;border-radius:6px;font-size:.82rem;color:#666">$${Math.round(p.price/p.lot_acres).toLocaleString()}/acre</span>`:''}
-            ${p.bedrooms  ? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem">🛏 ${p.bedrooms} bd</span>`:''}
-            ${p.bathrooms ? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem">🚿 ${p.bathrooms} ba</span>`:''}
+            ${p.bedrooms  ? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem">🛏 ${bedrooms} bd</span>`:''}
+            ${p.bathrooms ? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem">🚿 ${bathrooms} ba</span>`:''}
             ${p.sqft      ? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem">📐 ${Number(p.sqft).toLocaleString()} sqft</span>`:''}
-            ${p.year_built? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem">🏗 ${p.year_built}</span>`:''}
+            ${p.year_built? `<span style="background:#f3f4f6;padding:.35rem .75rem;border-radius:6px;font-size:.85rem">🏗 ${yearBuilt}</span>`:''}
           </div>
-          ${p.features ? `<div style="display:flex;flex-wrap:wrap;gap:.4rem;margin-bottom:.9rem">${p.features.split(',').map(f=>f.trim()).filter(Boolean).map(f=>{const icon=Object.entries(FEATURE_ICONS).find(([k])=>f.toLowerCase().includes(k.toLowerCase()));return `<span style="background:#f0fdf4;border:1px solid #bbf7d0;padding:.25rem .6rem;border-radius:20px;font-size:.78rem;color:#166534">${icon?icon[1]+' ':''}${f}</span>`;}).join('')}</div>`:''}
-          ${p.description ? `<p style="color:#444;line-height:1.65;margin-bottom:1rem;font-size:.93rem">${p.description}</p>` : ''}
+          ${p.features ? `<div style="display:flex;flex-wrap:wrap;gap:.4rem;margin-bottom:.9rem">${p.features.split(',').map(f=>f.trim()).filter(Boolean).map(f=>{const icon=Object.entries(FEATURE_ICONS).find(([k])=>f.toLowerCase().includes(k.toLowerCase()));return `<span style="background:#f0fdf4;border:1px solid #bbf7d0;padding:.25rem .6rem;border-radius:20px;font-size:.78rem;color:#166534">${icon?icon[1]+' ':''}${esc(f)}</span>`;}).join('')}</div>`:''}
+          ${p.description ? `<p style="color:#444;line-height:1.65;margin-bottom:1rem;font-size:.93rem">${description}</p>` : ''}
           <!-- Land-specific detail grid -->
           ${p.property_type==='land' ? `
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:.5rem .75rem;margin-bottom:1rem;font-size:.83rem">
-            ${p.road_access ? `<div><span style="color:#888">🛣 Road:</span> ${p.road_access}</div>` : ''}
-            ${p.broadband_type ? `<div><span style="color:#888">📶 Broadband:</span> ${p.broadband_type}</div>` : (p.internet ? `<div><span style="color:#888">📶 Internet:</span> Available</div>` : '')}
-            ${p.water_features ? `<div style="grid-column:1/-1"><span style="color:#888">💧 Water:</span> ${p.water_features}</div>` : ''}
-            ${p.mineral_rights && p.mineral_rights!=='unknown' ? `<div><span style="color:#888">⛏ Mineral Rights:</span> ${p.mineral_rights}</div>` : ''}
-            ${(p.elevation_min||p.elevation_max) ? `<div><span style="color:#888">🏔 Elevation:</span> ${[p.elevation_min,p.elevation_max].filter(Boolean).join('–')} ft</div>` : ''}
-            ${p.nearest_town ? `<div><span style="color:#888">📍 Nearest Town:</span> ${p.nearest_town}${p.miles_to_town?' ('+p.miles_to_town+' mi)':''}</div>` : ''}
+            ${p.road_access ? `<div><span style="color:#888">🛣 Road:</span> ${roadAccess}</div>` : ''}
+            ${p.broadband_type ? `<div><span style="color:#888">📶 Broadband:</span> ${broadbandType}</div>` : (p.internet ? `<div><span style="color:#888">📶 Internet:</span> Available</div>` : '')}
+            ${p.water_features ? `<div style="grid-column:1/-1"><span style="color:#888">💧 Water:</span> ${waterFeatures}</div>` : ''}
+            ${p.mineral_rights && p.mineral_rights!=='unknown' ? `<div><span style="color:#888">⛏ Mineral Rights:</span> ${mineralRights}</div>` : ''}
+            ${(p.elevation_min||p.elevation_max) ? `<div><span style="color:#888">🏔 Elevation:</span> ${[p.elevation_min,p.elevation_max].filter(Boolean).map(esc).join('–')} ft</div>` : ''}
+            ${p.nearest_town ? `<div><span style="color:#888">📍 Nearest Town:</span> ${nearestTown}${p.miles_to_town?' ('+milesToTown+' mi)':''}</div>` : ''}
             ${p.annual_tax ? `<div><span style="color:#888">💰 Annual Tax:</span> $${Number(p.annual_tax).toLocaleString()}</div>` : ''}
-            ${p.parcel_id ? `<div><span style="color:#888">📋 Parcel ID:</span> ${p.parcel_id}</div>` : ''}
+            ${p.parcel_id ? `<div><span style="color:#888">📋 Parcel ID:</span> ${parcelId}</div>` : ''}
           </div>` : ''}
           ${p.driveTimes ? `
           <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:.65rem 1rem;margin-bottom:1rem;font-size:.83rem;display:flex;flex-wrap:wrap;gap:.75rem">
-            <span>🚗 <strong>${p.driveTimes.dc}</strong> to DC</span>
-            <span>🚗 <strong>${p.driveTimes.balt}</strong> to Baltimore</span>
-            <span>🚗 <strong>${p.driveTimes.pit}</strong> to Pittsburgh</span>
+            <span>🚗 <strong>${esc(p.driveTimes.dc)}</strong> to DC</span>
+            <span>🚗 <strong>${esc(p.driveTimes.balt)}</strong> to Baltimore</span>
+            <span>🚗 <strong>${esc(p.driveTimes.pit)}</strong> to Pittsburgh</span>
           </div>` : ''}
           <div style="display:flex;gap:.75rem;flex-wrap:wrap;margin-bottom:1.5rem">
             <a href="${mapsUrl}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:.4rem;padding:.55rem 1rem;border-radius:8px;font-size:.85rem;font-weight:600;background:#f3f4f6;color:#1a1a1a;border:1px solid #e0e0e0;text-decoration:none">🗺 View on Map</a>
             <a href="${satUrl}"  target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:.4rem;padding:.55rem 1rem;border-radius:8px;font-size:.85rem;font-weight:600;background:#f3f4f6;color:#1a1a1a;border:1px solid #e0e0e0;text-decoration:none">🛰 Satellite View</a>
-            ${p.listing_slug ? `<a href="/properties/${p.listing_slug}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:.4rem;padding:.55rem 1rem;border-radius:8px;font-size:.85rem;font-weight:600;background:#f3f4f6;color:#1a1a1a;border:1px solid #e0e0e0;text-decoration:none">🔗 Full Detail Page</a>` : ''}
+            ${p.listing_slug ? `<a href="/properties/${listingSlug}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:.4rem;padding:.55rem 1rem;border-radius:8px;font-size:.85rem;font-weight:600;background:#f3f4f6;color:#1a1a1a;border:1px solid #e0e0e0;text-decoration:none">🔗 Full Detail Page</a>` : ''}
           </div>
           <div style="border-top:1px solid #f0f0f0;padding-top:1.25rem">
             <h3 style="color:#1B4332;margin-bottom:.5rem;font-size:1rem">Contact Phil Malick</h3>
@@ -1709,8 +1749,8 @@ async function showPropertyModal(id) {
             <input id="pm_name"  type="text"  placeholder="Your Name"  style="width:100%;padding:.6rem .9rem;border:1px solid #e0e0e0;border-radius:8px;margin-bottom:.5rem;font-size:.9rem;font-family:inherit">
             <input id="pm_email" type="email" placeholder="Email"      style="width:100%;padding:.6rem .9rem;border:1px solid #e0e0e0;border-radius:8px;margin-bottom:.5rem;font-size:.9rem;font-family:inherit">
             <input id="pm_phone" type="tel"   placeholder="Phone (optional)" style="width:100%;padding:.6rem .9rem;border:1px solid #e0e0e0;border-radius:8px;margin-bottom:.5rem;font-size:.9rem;font-family:inherit">
-            <textarea id="pm_msg" placeholder="Message" style="width:100%;padding:.6rem .9rem;border:1px solid #e0e0e0;border-radius:8px;margin-bottom:.75rem;min-height:80px;font-size:.9rem;font-family:inherit;resize:vertical">I'd like more information about ${p.address}.</textarea>
-            <button onclick="pmSend('${p.id}',this)" style="width:100%;padding:.85rem;background:#D4AF37;color:#0a0a0a;border:none;border-radius:8px;font-size:1rem;font-weight:800;cursor:pointer">Send Inquiry</button>
+            <textarea id="pm_msg" placeholder="Message" style="width:100%;padding:.6rem .9rem;border:1px solid #e0e0e0;border-radius:8px;margin-bottom:.75rem;min-height:80px;font-size:.9rem;font-family:inherit;resize:vertical">I'd like more information about ${address}.</textarea>
+            <button onclick="pmSend(${jsArg(p.id)},this)" style="width:100%;padding:.85rem;background:#D4AF37;color:#0a0a0a;border:none;border-radius:8px;font-size:1rem;font-weight:800;cursor:pointer">Send Inquiry</button>
             <p style="font-size:.72rem;color:#999;margin-top:.5rem;line-height:1.5">By submitting, you consent to receive calls and texts from MalickLand at the number provided. Message &amp; data rates may apply. Reply STOP to opt out.</p>
           </div>
         </div>
@@ -1751,6 +1791,7 @@ window.addEventListener('scroll', () => {
 // (chat state now in aiMessages array)
 
 // ---- AI CHAT ----
+const MAX_CHAT_HISTORY = 10;
 const aiMessages = [];
 let chatReady = false;
 let chatConnectShown = false;
@@ -1807,7 +1848,7 @@ async function sendChatMsg() {
     const r = await fetch('/api/chat', {
       method: 'POST',
       headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({ messages: aiMessages })
+      body: JSON.stringify({ messages: aiMessages.slice(-MAX_CHAT_HISTORY) })
     });
     const data = await r.json();
     const reply = data.reply || "I couldn't connect right now. Call Phil at (540) 246-1421.";
@@ -1855,7 +1896,7 @@ async function submitChatLead(btn) {
   const phone = document.getElementById('chatLeadPhone')?.value.trim();
   if (!name || !email) { alert('Name and email are required.'); return; }
   btn.disabled = true; btn.textContent = 'Sending…';
-  const summary = aiMessages.filter(m=>m.role==='user').map(m=>m.content).join(' | ');
+  const summary = aiMessages.filter(m=>m.role==='user').map(m=>m.content).slice(-5).join(' | ');
   try {
     await fetch('/api/contacts', {
       method:'POST', headers:{'Content-Type':'application/json'},

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -45,7 +45,7 @@ echo "✓ Syntax OK"
 echo
 
 echo "== Startup smoke =="
-PORT="$PORT_TO_USE" DATABASE_PATH="$TMP_DIR/preflight.db" NODE_ENV=test API_KEY=preflight-api-key SESSION_SECRET=preflight-session-secret ADMIN_PASSWORD=preflight-admin-password node server.js > "$APP_LOG" 2>&1 &
+PORT="$PORT_TO_USE" DATABASE_PATH="$TMP_DIR/preflight.db" NODE_ENV=test PUBLIC_LISTINGS_ENABLED=true API_KEY=preflight-api-key SESSION_SECRET=preflight-session-secret ADMIN_PASSWORD=preflight-admin-password node server.js > "$APP_LOG" 2>&1 &
 PID=$!
 
 for _ in {1..30}; do

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -44,6 +44,11 @@ node --check routes/admin.js
 echo "✓ Syntax OK"
 echo
 
+echo "== Public assistant flag regression =="
+node "$ROOT/tests/public-assistant-flag.test.js"
+echo "✓ Public assistant flag OK"
+echo
+
 echo "== Startup smoke =="
 PORT="$PORT_TO_USE" DATABASE_PATH="$TMP_DIR/preflight.db" NODE_ENV=test PUBLIC_LISTINGS_ENABLED=true API_KEY=preflight-api-key SESSION_SECRET=preflight-session-secret ADMIN_PASSWORD=preflight-admin-password node server.js > "$APP_LOG" 2>&1 &
 PID=$!

--- a/tests/public-assistant-flag.test.js
+++ b/tests/public-assistant-flag.test.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Regression tests for the PUBLIC_ASSISTANT_ENABLED cost-control flag.
+ *
+ * Proves the trust/cost boundary the unit helpers don't: when the public
+ * assistant is disabled, POST /api/chat returns the canned reply WITHOUT
+ * ever calling the paid AI provider. Also proves the enabled (default) path
+ * still calls the provider, so the flag isn't silently dead.
+ *
+ * No network, no real AI: ai-generator is stubbed before chat.js binds it.
+ *
+ * Run: node tests/public-assistant-flag.test.js
+ */
+
+const assert = require('assert');
+const path = require('path');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function test(description, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passed++;
+      console.log(`✓ ${description}`);
+    })
+    .catch((error) => {
+      failed++;
+      failures.push({ description, error: error.message });
+      console.log(`✗ ${description}`);
+      console.log(`  Error: ${error.message}`);
+    });
+}
+
+const AIGEN_PATH = path.join(__dirname, '..', 'api', 'ai-generator.js');
+const CHAT_PATH = path.join(__dirname, '..', 'api', 'routes', 'chat.js');
+
+// Load a fresh copy of the chat router with generateChatReply / aiConfigured
+// stubbed. chat.js destructures these at require-time, so the stubs must be
+// installed on the cached ai-generator module BEFORE chat.js is required.
+function loadChatRouterWithSpy() {
+  delete require.cache[require.resolve(AIGEN_PATH)];
+  delete require.cache[require.resolve(CHAT_PATH)];
+
+  const aigen = require(AIGEN_PATH);
+  const spy = { calls: 0 };
+  aigen.generateChatReply = async () => {
+    spy.calls++;
+    return 'STUBBED_AI_REPLY';
+  };
+  aigen.aiConfigured = () => true; // isolate the flag from the no-provider branch
+
+  const createChatRouter = require(CHAT_PATH);
+  const router = createChatRouter();
+
+  // Pull the final POST '/' handler out of the express route stack (the layer
+  // after chatRateLimit). Call it directly with mock req/res.
+  const layer = router.stack.find((l) => l.route && l.route.path === '/');
+  const stack = layer.route.stack;
+  const handler = stack[stack.length - 1].handle;
+
+  return { handler, spy };
+}
+
+function mockRes() {
+  return {
+    _status: 200,
+    _json: null,
+    status(code) { this._status = code; return this; },
+    json(obj) { this._json = obj; return this; },
+  };
+}
+
+const userMessages = { body: { messages: [{ role: 'user', content: 'Got land in Hampshire County?' }] } };
+
+(async () => {
+  const { FALLBACK_REPLY } = require(path.join(__dirname, '..', 'api', 'utils', 'chatAssistant'));
+
+  await test('disabled (PUBLIC_ASSISTANT_ENABLED=false): canned reply, ZERO provider calls', async () => {
+    process.env.PUBLIC_ASSISTANT_ENABLED = 'false';
+    const { handler, spy } = loadChatRouterWithSpy();
+    const res = mockRes();
+    await handler(userMessages, res);
+
+    assert.strictEqual(spy.calls, 0, 'generateChatReply must NOT be called when disabled');
+    assert.strictEqual(res._status, 200, 'disabled bot should answer 200, not error');
+    assert.strictEqual(res._json && res._json.reply, FALLBACK_REPLY, 'should return the canned reply');
+  });
+
+  await test('enabled (default): provider IS called and its reply is returned', async () => {
+    delete process.env.PUBLIC_ASSISTANT_ENABLED; // default ON
+    const { handler, spy } = loadChatRouterWithSpy();
+    const res = mockRes();
+    await handler(userMessages, res);
+
+    assert.strictEqual(spy.calls, 1, 'generateChatReply must be called when enabled');
+    assert.strictEqual(res._json && res._json.reply, 'STUBBED_AI_REPLY', 'should return the provider reply');
+  });
+
+  await test('explicit enabled (PUBLIC_ASSISTANT_ENABLED=true): provider is called', async () => {
+    process.env.PUBLIC_ASSISTANT_ENABLED = 'true';
+    const { handler, spy } = loadChatRouterWithSpy();
+    const res = mockRes();
+    await handler(userMessages, res);
+
+    assert.strictEqual(spy.calls, 1, 'true should behave like enabled');
+  });
+
+  delete process.env.PUBLIC_ASSISTANT_ENABLED;
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failures.length) {
+    console.log('\nFailures:');
+    failures.forEach((f) => console.log(`  ✗ ${f.description}: ${f.error}`));
+  }
+  process.exit(failed ? 1 : 0);
+})();

--- a/tests/verify-security-fixes.test.js
+++ b/tests/verify-security-fixes.test.js
@@ -411,6 +411,21 @@ test('public property-page routes use publicReadRateLimit in routes/public.js', 
     "Public property-page routes (/listing/:id, /properties/:id) are missing publicReadRateLimit in routes/public.js");
 });
 
+test('public navigation aliases avoid dead /contact, /about, and /search routes', () => {
+  assert(publicRoutesCode.includes("router.get('/contact', publicReadRateLimit"),
+    'GET /contact should be an explicit public route');
+  assert(publicRoutesCode.includes("router.get('/about', publicReadRateLimit"),
+    'GET /about should be an explicit public route');
+  assert(publicRoutesCode.includes("router.get('/search', publicReadRateLimit"),
+    'GET /search should be an explicit public route');
+  assert(publicRoutesCode.includes("res.redirect(302, '/#contact-form')"),
+    'GET /contact should redirect to the homepage contact form anchor');
+  assert(publicRoutesCode.includes("res.redirect(302, '/#about')"),
+    'GET /about should redirect to the homepage about anchor');
+  assert(publicRoutesCode.includes("return res.redirect(302, `/listings${query}`)"),
+    'GET /search should preserve query params when listings are enabled');
+});
+
 // ============================================================
 // Test Suite 7: Gmail Helper Integrity (api/google.js)
 // ============================================================


### PR DESCRIPTION
## Summary

Finishes the listings feature-flag WIP by adding public-assistant cost control, homepage XSS hardening, nav-alias redirects, and documentation alignment.

## Key changes

- **Public-assistant cost flag** — `publicAssistantEnabled()`; with `PUBLIC_ASSISTANT_ENABLED=false`, `POST /api/chat` returns the canned reply with **zero provider spend**. The admin listing generator is unaffected.
- **Homepage XSS hardening** (`app/index.html`) — HTML-escape all interpolated property fields in the card + modal render, and safely embed the listing id into inline `onclick` handlers (HTML-escape + `JSON.stringify` layering for the JS-string context).
- **Safe ID encoding** — `encodeURIComponent` on the `/api/properties/:id` fetch; chat history sent to `/api/chat` is now bounded (`MAX_CHAT_HISTORY=10`).
- **Nav-alias redirects** (`api/routes/public.js`) — `/contact` → `/#contact-form`, `/about` → `/#about`, and `/search` → `/listings` (preserves the query string; redirects to `/` when `publicListingsEnabled()` is off). Both homepage anchors are verified to exist.
- **Docs alignment** — README AI section now reflects the real `AI_GATEWAY_API_KEY → ANTHROPIC_API_KEY → OPENAI_API_KEY` precedence (was OpenAI-only); Gmail notification framing left intact because it matches the wired code. `admin.js` AI-not-configured copy updated to the same precedence. AGENTS.md adopts the CLAUDE HANDOFF / Codex VERDICT protocol; WORK_LOG entry added.
- **Tests** — new `tests/public-assistant-flag.test.js` (network-free, proves zero provider calls when disabled) wired into `preflight.sh`; nav-route assertions added to `verify-security-fixes`.
- **Cleanup** — removed stray root `package-lock.json` (no root `package.json`; the real lockfile is `api/package-lock.json`); gitignored local-only `compose.override.yml` (machine-specific uid + localhost bind that would break the Traefik-fronted VPS if it ever reached prod).

## Verification

- `node --check` — passed on all changed API files
- `tests/public-assistant-flag.test.js` — **3/3**
- `tests/verify-security-fixes.test.js` — **53/53**
- `scripts/preflight.sh` — **PASSED** (server boot + health + property API + public page + assistant graceful fallback)

## Notes

- The `better-sqlite3` rebuild during local verification was a stale native-addon ABI mismatch (a local environment fix), **not** a code change.
- Intentionally **out of scope** (separate tasks): the unused Resend email service, and the README/comment "Railway" deploy wording vs the live VPS + Traefik reality.

---

**CLAUDE HANDOFF**
- PR: this
- Head SHA: `68b901404bd0f86afa1048e935e7c831e3e20441`
- What changed: public-assistant cost flag, homepage XSS hardening, `/contact` `/about` `/search` aliases, README/AGENTS doc alignment, test + cleanup
- What was tested: `node --check` clean; flag 3/3; security 53/53; `preflight.sh` PASSED
- Known unresolved: none known
- Opened as **draft** — do not mark ready/merge until Codex verifies `gh pr view` / `gh pr checks` / unresolved review threads = 0. Merge ≠ deploy (VPS deploy stays a separate manual step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add feature flags for public listings and the public AI assistant, harden the homepage against XSS, and align navigation, docs, and tests with the new behavior.

New Features:
- Introduce PUBLIC_LISTINGS_ENABLED and PUBLIC_ASSISTANT_ENABLED feature flags to control public listings visibility and AI assistant provider usage without code changes.
- Expose listingsEnabled in /api/config so the frontend can toggle listings-related UI dynamically.
- Add public navigation aliases for /contact, /about, and /search that redirect to appropriate homepage anchors or listings search while respecting listings visibility.

Bug Fixes:
- Harden the homepage property cards and modal against XSS by HTML-escaping interpolated fields, safely embedding IDs in inline handlers, and encoding property IDs in API calls.
- Bound chat history and lead-summary payload sizes sent from the homepage assistant to the /api/chat and /api/contacts endpoints.

Enhancements:
- Gate sitemap, county pages, listing detail routes, and listings/search APIs behind the public listings feature flag so the site can temporarily hide inventory without deleting data.
- Clarify AI provider precedence (AI Gateway, Anthropic, then OpenAI) in admin UI copy, API comments, and README/agent docs, and document the Codex handoff/verdict protocol.
- Add a homepage layout tweak to hide listings-related sections and links when listings are disabled, while ensuring anchor targets exist for the new nav redirects.

Tests:
- Add a public-assistant feature-flag regression test to prove the disabled path returns the canned reply with zero provider calls and integrate it into the preflight script.
- Extend the security verification tests to assert the presence and behavior of the new public navigation alias routes.

Chores:
- Add a LICENSE file and ignore/remove stray or local-only project files, and set test preflight defaults (including PUBLIC_LISTINGS_ENABLED) for consistent local and CI runs.