### PR TITLE
fix(admin): report Resend (not Gmail) on /integrations, reframe Google as Drive-only

### DIFF
--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -1013,11 +1013,15 @@ router.get('/integrations', requireAuth, adminActionRateLimit, (req, res) => {
         <h3>Setup Instructions</h3>
         <ol style="padding-left:1.5rem;line-height:2">
           <li><strong>Lead notifications (Resend):</strong> create an API key at <a href="https://resend.com/" target="_blank" rel="noopener noreferrer">resend.com</a>, then set <code>RESEND_API_KEY</code>, <code>NOTIFICATION_EMAIL</code> (address that receives alerts) and optionally <code>FROM_EMAIL</code> (a verified sender) in <code>api/.env</code>.</li>
-          <li><strong>Google Drive photo backup (optional):</strong> in the <a href="https://console.cloud.google.com/" target="_blank" rel="noopener noreferrer">Google Cloud Console</a>, create a project and enable the <strong>Google Drive API</strong>.</li>
-          <li>Create an <strong>OAuth 2.0 Client ID</strong> (Desktop application type).</li>
-          <li>Visit the <a href="https://developers.google.com/oauthplayground" target="_blank" rel="noopener noreferrer">OAuth Playground</a>, authorise scope
-            <code>https://www.googleapis.com/auth/drive.file</code>, and exchange the authorisation code for a <strong>refresh token</strong>.</li>
-          <li>Set <code>GOOGLE_CLIENT_ID</code>, <code>GOOGLE_CLIENT_SECRET</code>, <code>GOOGLE_REFRESH_TOKEN</code> and <code>GOOGLE_DRIVE_FOLDER_ID</code> in <code>api/.env</code> (see <code>api/.env.example</code> for all keys).</li>
+          <li><strong>Google Drive photo backup (optional):</strong>
+            <ol style="padding-left:1.5rem;list-style-type:lower-alpha;line-height:1.8">
+              <li>In the <a href="https://console.cloud.google.com/" target="_blank" rel="noopener noreferrer">Google Cloud Console</a>, create a project and enable the <strong>Google Drive API</strong>.</li>
+              <li>Create an <strong>OAuth 2.0 Client ID</strong> (Desktop application type).</li>
+              <li>Visit the <a href="https://developers.google.com/oauthplayground" target="_blank" rel="noopener noreferrer">OAuth Playground</a>, authorize scope
+                <code>https://www.googleapis.com/auth/drive.file</code>, and exchange the authorization code for a <strong>refresh token</strong>.</li>
+              <li>Set <code>GOOGLE_CLIENT_ID</code>, <code>GOOGLE_CLIENT_SECRET</code>, <code>GOOGLE_REFRESH_TOKEN</code> and <code>GOOGLE_DRIVE_FOLDER_ID</code> in <code>api/.env</code> (see <code>api/.env.example</code> for all keys).</li>
+            </ol>
+          </li>
           <li>Restart the server — the integrations activate automatically.</li>
         </ol>
       </div>

--- a/api/routes/admin.js
+++ b/api/routes/admin.js
@@ -984,9 +984,12 @@ router.post('/document-claims/:claimId/apply', requireAuth, requireCsrf, adminAc
 
 // ── Integrations ──────────────────────────────────────────
 router.get('/integrations', requireAuth, adminActionRateLimit, (req, res) => {
-  const gmailOk  = !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_REFRESH_TOKEN);
-  const driveOk  = !!(process.env.GOOGLE_DRIVE_FOLDER_ID);
+  // Lead notifications are sent via Resend (api/services/email.js). Google OAuth
+  // is now used only for optional Drive photo backup (uploadPhotoToDrive).
+  const resendOk = !!(process.env.RESEND_API_KEY && process.env.NOTIFICATION_EMAIL);
+  const googleAuthOk = !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET && process.env.GOOGLE_REFRESH_TOKEN);
   const driveFolderId = process.env.GOOGLE_DRIVE_FOLDER_ID || '';
+  const driveOk  = !!(googleAuthOk && driveFolderId);
 
   res.send(adminShell('Integrations', `
     <div class="dash-header">
@@ -995,28 +998,26 @@ router.get('/integrations', requireAuth, adminActionRateLimit, (req, res) => {
     </div>
     <div class="report-grid">
       <div class="report-card">
-        <h3>Gmail Notifications ${gmailOk ? '✅' : '⚠️'}</h3>
-        <p style="margin-bottom:1rem;color:${gmailOk?'#155724':'#856404'};font-size:.9rem">
-          ${gmailOk ? 'Connected — inquiry emails will be sent automatically.' : 'Not configured — set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN, GOOGLE_GMAIL_USER, NOTIFICATION_EMAIL in environment.'}
+        <h3>Lead Notifications (Resend) ${resendOk ? '✅' : '⚠️'}</h3>
+        <p style="margin-bottom:1rem;color:${resendOk?'#155724':'#856404'};font-size:.9rem">
+          ${resendOk ? 'Connected — new inquiry alerts are emailed automatically via Resend.' : 'Not configured — set RESEND_API_KEY and NOTIFICATION_EMAIL in environment to email inquiry alerts.'}
         </p>
       </div>
       <div class="report-card">
         <h3>Google Drive Backup ${driveOk ? '✅' : '⚠️'}</h3>
         <p style="margin-bottom:1rem;color:${driveOk?'#155724':'#856404'};font-size:.9rem">
-          ${driveOk ? `Connected — photos backup to folder ${esc(driveFolderId)}.` : 'Not configured — set GOOGLE_DRIVE_FOLDER_ID to enable photo backups.'}
+          ${driveOk ? `Connected — listing photos back up to Drive folder ${esc(driveFolderId)}.` : 'Not configured — set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN and GOOGLE_DRIVE_FOLDER_ID to back up listing photos to Google Drive.'}
         </p>
       </div>
       <div class="report-card full">
         <h3>Setup Instructions</h3>
         <ol style="padding-left:1.5rem;line-height:2">
-          <li>Go to <a href="https://console.cloud.google.com/" target="_blank" rel="noopener noreferrer">Google Cloud Console</a> and create a project.</li>
-          <li>Enable the <strong>Gmail API</strong> and <strong>Google Drive API</strong>.</li>
+          <li><strong>Lead notifications (Resend):</strong> create an API key at <a href="https://resend.com/" target="_blank" rel="noopener noreferrer">resend.com</a>, then set <code>RESEND_API_KEY</code>, <code>NOTIFICATION_EMAIL</code> (address that receives alerts) and optionally <code>FROM_EMAIL</code> (a verified sender) in <code>api/.env</code>.</li>
+          <li><strong>Google Drive photo backup (optional):</strong> in the <a href="https://console.cloud.google.com/" target="_blank" rel="noopener noreferrer">Google Cloud Console</a>, create a project and enable the <strong>Google Drive API</strong>.</li>
           <li>Create an <strong>OAuth 2.0 Client ID</strong> (Desktop application type).</li>
-          <li>Visit the <a href="https://developers.google.com/oauthplayground" target="_blank" rel="noopener noreferrer">OAuth Playground</a>, authorise with scopes<br>
-            <code>https://www.googleapis.com/auth/gmail.send</code> and
-            <code>https://www.googleapis.com/auth/drive.file</code>.<br>
-            Exchange the authorisation code for a <strong>refresh token</strong>.</li>
-          <li>Copy the values into <code>api/.env</code> (see <code>api/.env.example</code> for all keys).</li>
+          <li>Visit the <a href="https://developers.google.com/oauthplayground" target="_blank" rel="noopener noreferrer">OAuth Playground</a>, authorise scope
+            <code>https://www.googleapis.com/auth/drive.file</code>, and exchange the authorisation code for a <strong>refresh token</strong>.</li>
+          <li>Set <code>GOOGLE_CLIENT_ID</code>, <code>GOOGLE_CLIENT_SECRET</code>, <code>GOOGLE_REFRESH_TOKEN</code> and <code>GOOGLE_DRIVE_FOLDER_ID</code> in <code>api/.env</code> (see <code>api/.env.example</code> for all keys).</li>
           <li>Restart the server — the integrations activate automatically.</li>
         </ol>
       </div>


### PR DESCRIPTION
## What changed and why

The admin **/integrations** status page still described **Gmail** as the lead-notification transport. That copy is stale and misleading:

- Since **PR #97**, lead notifications are sent via **Resend** (`api/services/email.js` `sendLeadNotification`, used by `POST /api/contacts` and `POST /api/leads`).
- The Gmail send path (`api/google.js` `sendContactEmail`) is **dead code**.
- Google OAuth is now used **only** for optional **Drive photo backup** (`uploadPhotoToDrive`).

This PR makes the admin UI report what the runtime actually does:

- Renames the **"Gmail Notifications"** card to **"Lead Notifications (Resend)"** — shows *Connected* when `RESEND_API_KEY` **and** `NOTIFICATION_EMAIL` are set, otherwise the exact env vars to set.
- Reframes the Google row as **Drive-backup status** — marks *Connected* only when the OAuth creds (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN`) **and** `GOOGLE_DRIVE_FOLDER_ID` are all present (all four are required for `uploadPhotoToDrive`). Previously the card lit green on `GOOGLE_DRIVE_FOLDER_ID` alone, which was inaccurate.
- Updates **Setup Instructions**: adds Resend key setup, and drops the dead **Gmail API** / `gmail.send` scope guidance from the Google/Drive steps.

This is the admin-UI counterpart to the README + `.env.example` alignment already merged in #134/#135 (and further in #136). Copy/status accuracy only — no behavioral change to any send path.

## Closes

<!-- No tracked issue. -->
Closes #

## Scope

**Files changed:**
- `api/routes/admin.js` — `GET /admin/integrations` handler copy + status logic only.

**What is NOT changed:**
- No changes to any email/notification send path (`email.js`, `google.js`, `leadNotifications.js`).
- No changes to `POST /api/contacts` / `POST /api/leads`.
- No env vars, Railway config, DB, or docs touched (docs are handled separately by #136).

## How to validate

```bash
cd api && npm ci
node --check server.js
cd ..
bash scripts/preflight.sh
```

Rendered-output check (boots the real server + real admin auth, fetches `/admin/integrations` in both env states):

- **Unconfigured** → `Lead Notifications (Resend) ⚠️` + `Google Drive Backup ⚠️`, each listing the exact env vars to set. No "Gmail" / `gmail.send` anywhere on the page.
- **Configured** (`RESEND_API_KEY`+`NOTIFICATION_EMAIL`, plus the 3 OAuth creds + `GOOGLE_DRIVE_FOLDER_ID`) → both cards `✅`; Drive folder id rendered via `esc()`.

Local run: `scripts/preflight.sh` → **PRE-FLIGHT PASSED (exit 0)**; `node --check` on `admin.js`/`server.js` clean.

## QC Checklist (required before merge)

- [x] No direct push to `main` — this is a PR
- [x] Branch is up to date with `main` (branched from current `origin/main`)
- [ ] All required CI checks are green (CodeQL, preflight, verify, CodeScan)
- [x] `npm audit` — unchanged (no dependency changes)
- [x] No hardcoded secrets, passwords, or tokens introduced
- [x] No Railway environment variables modified
- [x] No production database mutations in tests
- [x] Scope is limited to what's described above
- [ ] `docs/agent-handoff.md` — n/a (no production-state/architecture change)

## Agent notes (if AI-implemented)

Implemented by Claude (Claude Code). Out of scope by design: the dead `sendContactEmail` Gmail path in `api/google.js` is left untouched (removing it is a separate cleanup, not required for this copy fix). Complementary docs PR: #136.

## Summary by Sourcery

Update the admin integrations page to accurately reflect Resend-based lead notifications and Google Drive–only OAuth usage, aligning status indicators and setup instructions with current runtime behavior.

New Features:
- Expose a dedicated "Lead Notifications (Resend)" status card that reports configuration based on RESEND_API_KEY and NOTIFICATION_EMAIL.
- Expose a more accurate "Google Drive Backup" status card that requires full Google OAuth credentials plus GOOGLE_DRIVE_FOLDER_ID before showing as connected.

Enhancements:
- Revise integration setup instructions to cover Resend configuration and remove outdated Gmail API guidance, clarifying Google is now used solely for Drive photo backups.